### PR TITLE
fix: add type guard for conversation prop in PostPage

### DIFF
--- a/components/blog/PostPage.tsx
+++ b/components/blog/PostPage.tsx
@@ -89,7 +89,7 @@ export default function PostPage({ author, permlink }: PostPageProps) {
                   data={commentsData}
                 />
               </>
-            ) : !isEmbedMode ? (
+            ) : !isEmbedMode && conversation ? (
               <Conversation comment={conversation} setConversation={setConversation} onOpen={onOpen} setReply={setReply} />
             ) : null}
           </Container>


### PR DESCRIPTION
- Add null check before rendering Conversation component
- Fixes TypeScript error where Comment | undefined was not assignable to Comment
- Resolves Vercel build failure