### PR TITLE
fix: Improve layout width utilization and video rendering

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Container } from '@chakra-ui/react';
+import { Box } from '@chakra-ui/react';
 import { useState, useRef, useEffect } from 'react';
 import { Discussion } from '@hiveio/dhive';
 import { findPosts, getCommunityMutedAccounts } from '@/lib/hive/client-functions';
@@ -82,10 +82,10 @@ export default function Blog() {
     }, [query, mutedLoaded, tag]); // fetchPosts excluded - callback identity changes each render
 
     return (
-        <Container
+        <Box
             id="scrollableDiv"
-            maxW="container.lg"
             mt="3"
+            px={4}
             h="100vh"
             overflowY="auto"
             sx={{
@@ -97,6 +97,6 @@ export default function Blog() {
         >
             <TopBar viewMode={viewMode} setViewMode={setViewMode} setQuery={setQuery} />
             <PostInfiniteScroll allPosts={allPosts} fetchPosts={fetchPosts} viewMode={viewMode} />
-        </Container>
+        </Box>
     );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Container, Flex } from '@chakra-ui/react';
+import { Box, Flex } from '@chakra-ui/react';
 import SnapList from '@/components/homepage/SnapList';
 import RightSidebar from '@/components/layout/RightSideBar';
 import { useState, useEffect } from 'react';
@@ -75,14 +75,10 @@ export default function Home() {
 
   return (
     <Flex direction={{ base: 'column', md: 'row' }}>
-      <Container
-        maxW={{ base: '100%', md: '720px' }}
+      <Box
         h="100vh"
         overflowY="auto"
-        px={0}
-        position={"sticky"}
-        top={0}
-        justifyContent="center"
+        px={2}
         flex="1"
         sx={
           {
@@ -114,7 +110,7 @@ export default function Home() {
         ) : (
           <Conversation comment={conversation} setConversation={setConversation} onOpen={onOpen} setReply={setReply} />
         )}
-      </Container>
+      </Box>
       <RightSidebar />
       {isOpen && <SnapReplyModal isOpen={isOpen} onClose={onClose} comment={reply} onNewReply={handleNewComment} />}
     </Flex>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -65,19 +65,17 @@ function styleIframe(iframe: HTMLIFrameElement, data: any) {
     parent.style.width = '100%';
     parent.style.overflow = 'hidden';
   } else {
-    // Horizontal videos: use padding trick
-    iframe.style.position = 'absolute';
-    iframe.style.top = '0';
-    iframe.style.left = '0';
+    // Horizontal videos: use aspect-ratio
+    iframe.style.position = 'static';
     iframe.style.width = '100%';
-    iframe.style.height = '100%';
+    iframe.style.height = 'auto';
+    iframe.style.aspectRatio = '16 / 9';
+    iframe.style.display = 'block';
     iframe.style.overflow = 'hidden';
-    
-    parent.style.position = 'relative';
+
     parent.style.width = '100%';
     parent.style.maxWidth = '800px';
     parent.style.margin = '0 auto';
-    parent.style.paddingBottom = '56.25%'; // 16:9 ratio
     parent.style.overflow = 'hidden';
   }
   

--- a/components/blog/PostDetails.tsx
+++ b/components/blog/PostDetails.tsx
@@ -107,16 +107,21 @@ export default function PostDetails({ post, isEmbedMode = false }: PostDetailsPr
                         marginRight: 'auto'
                     },
                     '& .video-container': {
+                        position: 'relative',
                         width: '100%',
+                        maxWidth: '800px',
                         marginTop: '1em',
                         marginBottom: '1em',
-                        textAlign: 'left'
+                        textAlign: 'left',
+                        overflow: 'hidden',
                     },
                     '& .video-container iframe': {
                         width: '100%',
                         aspectRatio: '16/9',
+                        maxHeight: '450px',
                         borderRadius: 'md',
-                        border: 'none'
+                        border: 'none',
+                        display: 'block',
                     },
                     '& iframe': {
                         maxWidth: '100%',

--- a/components/blog/PostPage.tsx
+++ b/components/blog/PostPage.tsx
@@ -1,7 +1,7 @@
 // app/page.tsx
 'use client';
 
-import { Box, Container, Flex, Spinner } from '@chakra-ui/react';
+import { Box, Spinner } from '@chakra-ui/react';
 import SnapList from '../homepage/SnapList';
 import SnapComposer from '../homepage/SnapComposer';
 import { useEffect, useState } from 'react';
@@ -70,31 +70,25 @@ export default function PostPage({ author, permlink }: PostPageProps) {
   }
 
   return (
-    <Box bg="background" color="text" minH="100vh">
-      <Flex direction={{ base: 'column', md: 'row' }}>
-        <Box flex="1" p={isEmbedMode ? 2 : 4}>
-          <Container maxW={isEmbedMode ? '100%' : 'container.sm'} p={isEmbedMode ? 0 : undefined}>
-            <PostDetails post={post} isEmbedMode={isEmbedMode} />
-            {!isEmbedMode && !conversation ? (
-              <>
-                <SnapComposer pa={author} pp={permlink} onNewComment={handleNewComment} post={true} onClose={() => {}} />
-                <SnapList
-                  author={author}
-                  permlink={permlink}
-                  setConversation={setConversation}
-                  onOpen={onOpen}
-                  setReply={setReply}
-                  newComment={newComment} // Pass the newComment to SnapList
-                  post={true}
-                  data={commentsData}
-                />
-              </>
-            ) : !isEmbedMode && conversation ? (
-              <Conversation comment={conversation} setConversation={setConversation} onOpen={onOpen} setReply={setReply} />
-            ) : null}
-          </Container>
-        </Box>
-      </Flex>
+    <Box bg="background" color="text" minH="100vh" p={isEmbedMode ? 2 : 4}>
+      <PostDetails post={post} isEmbedMode={isEmbedMode} />
+      {!isEmbedMode && !conversation ? (
+        <>
+          <SnapComposer pa={author} pp={permlink} onNewComment={handleNewComment} post={true} onClose={() => {}} />
+          <SnapList
+            author={author}
+            permlink={permlink}
+            setConversation={setConversation}
+            onOpen={onOpen}
+            setReply={setReply}
+            newComment={newComment}
+            post={true}
+            data={commentsData}
+          />
+        </>
+      ) : !isEmbedMode && conversation ? (
+        <Conversation comment={conversation} setConversation={setConversation} onOpen={onOpen} setReply={setReply} />
+      ) : null}
       {!isEmbedMode && isOpen && <SnapReplyModal isOpen={isOpen} onClose={onClose} comment={reply} onNewReply={handleNewComment} />}
     </Box>
   );

--- a/components/homepage/Snap.tsx
+++ b/components/homepage/Snap.tsx
@@ -216,8 +216,8 @@ const Snap = memo(({ comment, onOpen, setReply, setConversation, level = 0 }: Sn
                     </VStack>
                 )}
                 
-                <HStack justify="space-between" mt={3} width="100%">
-                    <VoteControls 
+                <Flex wrap="wrap" justify="space-between" align="center" mt={3} width="100%" gap={2}>
+                    <VoteControls
                         initialVoted={comment.active_votes?.some(item => item.voter === user) ?? false}
                         initialVoteCount={comment.active_votes?.length || 0}
                         onVote={handleVote}
@@ -247,7 +247,7 @@ const Snap = memo(({ comment, onOpen, setReply, setConversation, level = 0 }: Sn
                     <Text fontWeight="bold" fontSize="sm">
                         {payoutDisplay}
                     </Text>
-                </HStack>
+                </Flex>
             </Box>
             
             {/* Edit Modal */}

--- a/components/homepage/VoteSlider.tsx
+++ b/components/homepage/VoteSlider.tsx
@@ -62,7 +62,7 @@ const VoteControls = memo(({ initialVoted, initialVoteCount, onVote }: VoteContr
 
     if (showSlider) {
         return (
-            <Flex mt={4} alignItems="center" width="100%">
+            <Flex alignItems="center" width="100%" flexBasis="100%">
                 <Box width="100%" mr={2}>
                     <Slider
                         aria-label="slider-ex-1"


### PR DESCRIPTION
## Summary
- Replaced narrow `Container` components with full-width `Box` on home, blog, and post detail pages — eliminates dead space and makes scrolling work across the entire content area
- Fixed mobile vote slider: action bar now wraps to two lines when the slider is open so it's actually usable on small screens
- Fixed 3speak video rendering gap: replaced `paddingBottom: 56.25%` hack with modern `aspectRatio: 16/9` approach, eliminating the large black gap below videos

## Test plan
- [ ] Verify snaps fill available width on home page (no dead space between sidebar and right panel)
- [ ] Verify blog posts fill available width
- [ ] Verify post detail pages use full width
- [ ] Verify scrolling works when mouse is anywhere in the content area (not just over the narrow column)
- [ ] Verify vote slider wraps to its own row on mobile when expanded
- [ ] Verify 3speak horizontal videos render without black gap below
- [ ] Verify 3speak vertical videos still render correctly
- [ ] Test on mobile viewport sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for nested reply indentation to improve conversation organization

* **Refactor**
  * Improved video rendering across the platform with modern aspect ratio handling
  * Optimized layout and spacing for better visual consistency
  * Streamlined page structures for improved performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->