### PR TITLE
feat: Add Open Graph and Twitter Card meta tags for social sharing

### DIFF
--- a/app/LayoutContent.tsx
+++ b/app/LayoutContent.tsx
@@ -28,9 +28,9 @@ export default function LayoutContent({ children }: { children: React.ReactNode 
     };
   }, [isEmbedMode]);
 
-  // Poll for unread messages
+  // Poll for unread messages (skip when embed mode or chat is open)
   useEffect(() => {
-    if (isEmbedMode) return; // Skip chat polling in embed mode
+    if (isEmbedMode || isChatOpen) return;
 
     const fetchUnread = async () => {
       try {
@@ -47,12 +47,8 @@ export default function LayoutContent({ children }: { children: React.ReactNode 
     // Fetch immediately
     fetchUnread();
 
-    // Poll every 30 seconds when chat is closed
-    const interval = setInterval(() => {
-      if (!isChatOpen) {
-        fetchUnread();
-      }
-    }, 30000);
+    // Poll every 30 seconds while chat stays closed
+    const interval = setInterval(fetchUnread, 30000);
 
     return () => clearInterval(interval);
   }, [isChatOpen, isEmbedMode]);

--- a/app/LayoutContent.tsx
+++ b/app/LayoutContent.tsx
@@ -17,16 +17,15 @@ export default function LayoutContent({ children }: { children: React.ReactNode 
   const [chatUnreadCount, setChatUnreadCount] = useState(0);
 
   useEffect(() => {
-    console.log('🟢 Layout: isChatOpen changed to:', isChatOpen);
-  }, [isChatOpen]);
-
-  useEffect(() => {
     // Add embed-mode class to body when embed mode is active
     if (isEmbedMode) {
       document.body.classList.add('embed-mode');
     } else {
       document.body.classList.remove('embed-mode');
     }
+    return () => {
+      document.body.classList.remove('embed-mode');
+    };
   }, [isEmbedMode]);
 
   // Poll for unread messages

--- a/app/LayoutContent.tsx
+++ b/app/LayoutContent.tsx
@@ -1,0 +1,99 @@
+'use client'
+import { Box, Flex } from '@chakra-ui/react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { useState, useEffect } from 'react';
+import Header from '@/components/layout/Header';
+import Sidebar from '@/components/layout/Sidebar';
+import FooterNavigation from '@/components/layout/FooterNavigation';
+import ChatPanel from '@/components/chat/ChatPanel';
+
+export default function LayoutContent({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const isComposePage = pathname === '/compose';
+  const isEmbedMode = searchParams.get('embed') === 'true';
+  const [isChatOpen, setIsChatOpen] = useState(false);
+  const [isChatMinimized, setIsChatMinimized] = useState(false);
+  const [chatUnreadCount, setChatUnreadCount] = useState(0);
+
+  useEffect(() => {
+    console.log('🟢 Layout: isChatOpen changed to:', isChatOpen);
+  }, [isChatOpen]);
+
+  useEffect(() => {
+    // Add embed-mode class to body when embed mode is active
+    if (isEmbedMode) {
+      document.body.classList.add('embed-mode');
+    } else {
+      document.body.classList.remove('embed-mode');
+    }
+  }, [isEmbedMode]);
+
+  // Poll for unread messages
+  useEffect(() => {
+    if (isEmbedMode) return; // Skip chat polling in embed mode
+
+    const fetchUnread = async () => {
+      try {
+        const res = await fetch('/api/chat/unread', { credentials: 'include' });
+        if (res.ok) {
+          const data = await res.json();
+          setChatUnreadCount(data.unread || 0);
+        }
+      } catch (err) {
+        // Silently fail - don't spam console
+      }
+    };
+
+    // Fetch immediately
+    fetchUnread();
+
+    // Poll every 30 seconds when chat is closed
+    const interval = setInterval(() => {
+      if (!isChatOpen) {
+        fetchUnread();
+      }
+    }, 30000);
+
+    return () => clearInterval(interval);
+  }, [isChatOpen, isEmbedMode]);
+
+  // Clear unread count when chat is opened
+  useEffect(() => {
+    if (isChatOpen) {
+      setChatUnreadCount(0);
+    }
+  }, [isChatOpen]);
+
+  return (
+    <Box bg="background" color="text" minH="100vh">
+      <Flex direction={{ base: 'column', sm: 'row' }} h="100vh">
+        {!isEmbedMode && (
+          <Sidebar isChatOpen={isChatOpen} setIsChatOpen={setIsChatOpen} chatUnreadCount={chatUnreadCount} />
+        )}
+        <Box
+          flex="1"
+          ml={isEmbedMode ? '0' : (isComposePage ? { base: '0', sm: '60px' } : { base: '0', sm: '60px', md: '20%' })}
+          h="100vh"
+          overflowY="auto"
+          transition="margin-left 0.3s ease"
+        >
+          {children}
+        </Box>
+      </Flex>
+      {!isEmbedMode && (
+        <>
+          <FooterNavigation isChatOpen={isChatOpen} setIsChatOpen={setIsChatOpen} chatUnreadCount={chatUnreadCount} />
+          <ChatPanel
+            isOpen={isChatOpen}
+            onClose={() => setIsChatOpen(false)}
+            isMinimized={isChatMinimized}
+            onMinimize={() => setIsChatMinimized(true)}
+            onRestore={() => setIsChatMinimized(false)}
+            unreadCount={chatUnreadCount}
+          />
+        </>
+      )}
+    </Box>
+  );
+}

--- a/app/[...slug]/SlugPageClient.tsx
+++ b/app/[...slug]/SlugPageClient.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import PostPage from "@/components/blog/PostPage";
+import NotificationsComp from "@/components/notifications/NotificationsComp";
+import ProfilePage from "@/components/profile/ProfilePage";
+import WalletPage from "@/components/wallet/WalletPage";
+
+interface SlugPageClientProps {
+  slug: string[];
+}
+
+export default function SlugPageClient({ slug }: SlugPageClientProps) {
+    if (slug.length === 1 && decodeURIComponent(slug[0]).startsWith('@')) {
+      return (
+        <ProfilePage username={decodeURIComponent(slug[0]).substring(1)} />
+      )
+    } else if ((slug.length === 2 && decodeURIComponent(slug[0]).startsWith('@')) && slug[1] === 'wallet') {
+      return (
+        <WalletPage username={decodeURIComponent(slug[0]).slice(1)} />
+      )
+    } else if ((slug.length === 2 && decodeURIComponent(slug[0]).startsWith('@')) && slug[1] === 'notifications') {
+      return (
+        <NotificationsComp username={decodeURIComponent(slug[0]).slice(1)} />
+      )
+    } else if ((slug.length === 2 && decodeURIComponent(slug[0]).startsWith('@')) || (slug.length === 3 && decodeURIComponent(slug[1]).startsWith('@'))) {
+      return (
+        <PostPage author={decodeURIComponent(slug[0]).substring(1)} permlink={slug[1]} />
+      )
+    }
+
+  return (
+    <></>
+  );
+}

--- a/app/[...slug]/SlugPageClient.tsx
+++ b/app/[...slug]/SlugPageClient.tsx
@@ -10,25 +10,21 @@ interface SlugPageClientProps {
 }
 
 export default function SlugPageClient({ slug }: SlugPageClientProps) {
-    if (slug.length === 1 && decodeURIComponent(slug[0]).startsWith('@')) {
-      return (
-        <ProfilePage username={decodeURIComponent(slug[0]).substring(1)} />
-      )
-    } else if ((slug.length === 2 && decodeURIComponent(slug[0]).startsWith('@')) && slug[1] === 'wallet') {
-      return (
-        <WalletPage username={decodeURIComponent(slug[0]).slice(1)} />
-      )
-    } else if ((slug.length === 2 && decodeURIComponent(slug[0]).startsWith('@')) && slug[1] === 'notifications') {
-      return (
-        <NotificationsComp username={decodeURIComponent(slug[0]).slice(1)} />
-      )
-    } else if ((slug.length === 2 && decodeURIComponent(slug[0]).startsWith('@')) || (slug.length === 3 && decodeURIComponent(slug[1]).startsWith('@'))) {
-      return (
-        <PostPage author={decodeURIComponent(slug[0]).substring(1)} permlink={slug[1]} />
-      )
-    }
+  const decoded0 = slug[0] ? decodeURIComponent(slug[0]) : '';
+  const decoded1 = slug[1] ? decodeURIComponent(slug[1]) : '';
+  const decoded2 = slug[2] ? decodeURIComponent(slug[2]) : '';
 
-  return (
-    <></>
-  );
+  if (slug.length === 1 && decoded0.startsWith('@')) {
+    return <ProfilePage username={decoded0.substring(1)} />;
+  } else if (slug.length === 2 && decoded0.startsWith('@') && slug[1] === 'wallet') {
+    return <WalletPage username={decoded0.substring(1)} />;
+  } else if (slug.length === 2 && decoded0.startsWith('@') && slug[1] === 'notifications') {
+    return <NotificationsComp username={decoded0.substring(1)} />;
+  } else if (slug.length === 2 && decoded0.startsWith('@')) {
+    return <PostPage author={decoded0.substring(1)} permlink={decoded1} />;
+  } else if (slug.length === 3 && decoded1.startsWith('@')) {
+    return <PostPage author={decoded1.substring(1)} permlink={decoded2} />;
+  }
+
+  return null;
 }

--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -20,7 +20,18 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   // Post page: /@author/permlink
   if (slug.length === 2 && slug[1] !== 'wallet' && slug[1] !== 'notifications') {
-    const post = await getPostForMetadata(username, slug[1]);
+    const permlink = decodeURIComponent(slug[1]);
+    const post = await getPostForMetadata(username, permlink);
+    if (post) {
+      return buildPostMetadata(post);
+    }
+  }
+
+  // 3-segment post page: /@community/@author/permlink
+  if (slug.length === 3 && decodeURIComponent(slug[1]).startsWith('@')) {
+    const author = decodeURIComponent(slug[1]).substring(1);
+    const permlink = decodeURIComponent(slug[2]);
+    const post = await getPostForMetadata(author, permlink);
     if (post) {
       return buildPostMetadata(post);
     }

--- a/app/[...slug]/page.tsx
+++ b/app/[...slug]/page.tsx
@@ -1,39 +1,42 @@
-// app/page.tsx
-'use client';
+import type { Metadata } from 'next';
+import { getPostForMetadata, getProfileForMetadata } from '@/lib/hive/metadata-functions';
+import { buildPostMetadata, buildProfileMetadata } from '@/lib/utils/buildMetadata';
+import SlugPageClient from './SlugPageClient';
 
-import PostPage from "@/components/blog/PostPage";
-import NotificationsComp from "@/components/notifications/NotificationsComp";
-import ProfilePage from "@/components/profile/ProfilePage";
-import WalletPage from "@/components/wallet/WalletPage";
-
-interface HomePageProps {
-  params: {
-    slug: string[];
-  };
+interface PageProps {
+  params: { slug: string[] };
 }
 
-export default function HomePage({ params }: HomePageProps) {
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = params;
 
-    if (params.slug.length === 1 && decodeURIComponent(params.slug[0]).startsWith('@')) {
-      return (
-        <ProfilePage username={decodeURIComponent(params.slug[0]).substring(1)} />
-      )
-    } else if ((params.slug.length === 2 && decodeURIComponent(params.slug[0]).startsWith('@')) && params.slug[1] === 'wallet') {
-      return (
-        <WalletPage username={decodeURIComponent(params.slug[0]).slice(1)} />
-      )
-    } else if ((params.slug.length === 2 && decodeURIComponent(params.slug[0]).startsWith('@')) && params.slug[1] === 'notifications') {
-      return (
-        <NotificationsComp username={decodeURIComponent(params.slug[0]).slice(1)} />
-      )
-    } else if ((params.slug.length === 2 && decodeURIComponent(params.slug[0]).startsWith('@')) || (params.slug.length === 3 && decodeURIComponent(params.slug[1]).startsWith('@'))) {
-      return (
-        <PostPage author={decodeURIComponent(params.slug[0]).substring(1)} permlink={params.slug[1]} />
-      )
+  if (!slug || slug.length === 0) return {};
+
+  const firstSegment = decodeURIComponent(slug[0]);
+
+  if (!firstSegment.startsWith('@')) return {};
+
+  const username = firstSegment.substring(1);
+
+  // Post page: /@author/permlink
+  if (slug.length === 2 && slug[1] !== 'wallet' && slug[1] !== 'notifications') {
+    const post = await getPostForMetadata(username, slug[1]);
+    if (post) {
+      return buildPostMetadata(post);
     }
+  }
 
-  return (
-    <></>
+  // Profile page: /@username
+  if (slug.length === 1) {
+    const profile = await getProfileForMetadata(username);
+    if (profile) {
+      return buildProfileMetadata(profile);
+    }
+  }
 
-  );
+  return {};
+}
+
+export default function SlugPage({ params }: PageProps) {
+  return <SlugPageClient slug={params.slug} />;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,110 +1,34 @@
-'use client'
-import { Box, Flex } from '@chakra-ui/react';
-import { usePathname, useSearchParams } from 'next/navigation';
-import { useState, useEffect, Suspense } from 'react';
-import Header from '@/components/layout/Header';
-import Sidebar from '@/components/layout/Sidebar';
-import FooterNavigation from '@/components/layout/FooterNavigation';
-import ChatPanel from '@/components/chat/ChatPanel';
+import { Suspense } from 'react';
 import { Providers } from './providers';
+import LayoutContent from './LayoutContent';
+import type { Metadata } from 'next';
 
-function LayoutContent({ children }: { children: React.ReactNode }) {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const isComposePage = pathname === '/compose';
-  const isEmbedMode = searchParams.get('embed') === 'true';
-  const [isChatOpen, setIsChatOpen] = useState(false);
-  const [isChatMinimized, setIsChatMinimized] = useState(false);
-  const [chatUnreadCount, setChatUnreadCount] = useState(0);
-
-  useEffect(() => {
-    console.log('🟢 Layout: isChatOpen changed to:', isChatOpen);
-  }, [isChatOpen]);
-
-  useEffect(() => {
-    // Add embed-mode class to body when embed mode is active
-    if (isEmbedMode) {
-      document.body.classList.add('embed-mode');
-    } else {
-      document.body.classList.remove('embed-mode');
-    }
-  }, [isEmbedMode]);
-
-  // Poll for unread messages
-  useEffect(() => {
-    if (isEmbedMode) return; // Skip chat polling in embed mode
-
-    const fetchUnread = async () => {
-      try {
-        const res = await fetch('/api/chat/unread', { credentials: 'include' });
-        if (res.ok) {
-          const data = await res.json();
-          setChatUnreadCount(data.unread || 0);
-        }
-      } catch (err) {
-        // Silently fail - don't spam console
-      }
-    };
-
-    // Fetch immediately
-    fetchUnread();
-    
-    // Poll every 30 seconds when chat is closed
-    const interval = setInterval(() => {
-      if (!isChatOpen) {
-        fetchUnread();
-      }
-    }, 30000);
-
-    return () => clearInterval(interval);
-  }, [isChatOpen, isEmbedMode]);
-
-  // Clear unread count when chat is opened
-  useEffect(() => {
-    if (isChatOpen) {
-      setChatUnreadCount(0);
-    }
-  }, [isChatOpen]);
-
-  return (
-    <Box bg="background" color="text" minH="100vh">
-      <Flex direction={{ base: 'column', sm: 'row' }} h="100vh">
-        {!isEmbedMode && (
-          <Sidebar isChatOpen={isChatOpen} setIsChatOpen={setIsChatOpen} chatUnreadCount={chatUnreadCount} />
-        )}
-        <Box 
-          flex="1" 
-          ml={isEmbedMode ? '0' : (isComposePage ? { base: '0', sm: '60px' } : { base: '0', sm: '60px', md: '20%' })}
-          h="100vh"
-          overflowY="auto"
-          transition="margin-left 0.3s ease"
-        >
-          {children}
-        </Box>
-      </Flex>
-      {!isEmbedMode && (
-        <>
-          <FooterNavigation isChatOpen={isChatOpen} setIsChatOpen={setIsChatOpen} chatUnreadCount={chatUnreadCount} />
-          <ChatPanel 
-            isOpen={isChatOpen} 
-            onClose={() => setIsChatOpen(false)}
-            isMinimized={isChatMinimized}
-            onMinimize={() => setIsChatMinimized(true)}
-            onRestore={() => setIsChatMinimized(false)}
-            unreadCount={chatUnreadCount}
-          />
-        </>
-      )}
-    </Box>
-  );
-}
+export const metadata: Metadata = {
+  metadataBase: new URL('https://snapie.io'),
+  title: {
+    default: 'Snapie',
+    template: '%s | Snapie',
+  },
+  description: 'Decentralized social on Hive',
+  openGraph: {
+    title: 'Snapie',
+    description: 'Decentralized social on Hive',
+    siteName: 'Snapie',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Snapie',
+    description: 'Decentralized social on Hive',
+  },
+};
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <body>
         <Providers>
-          <Suspense fallback={<Box bg="background" color="text" minH="100vh">{children}</Box>}>
+          <Suspense fallback={null}>
             <LayoutContent>{children}</LayoutContent>
           </Suspense>
         </Providers>

--- a/lib/hive/metadata-functions.ts
+++ b/lib/hive/metadata-functions.ts
@@ -12,7 +12,9 @@ export async function getPostForMetadata(author: string, permlink: string) {
 
 export async function getProfileForMetadata(username: string) {
   try {
-    return await HiveClient.call('bridge', 'get_profile', { account: username });
+    const profile = await HiveClient.call('bridge', 'get_profile', { account: username });
+    if (!profile || !profile.name) return null;
+    return profile;
   } catch {
     return null;
   }

--- a/lib/hive/metadata-functions.ts
+++ b/lib/hive/metadata-functions.ts
@@ -1,0 +1,19 @@
+import HiveClient from "./hiveclient";
+
+export async function getPostForMetadata(author: string, permlink: string) {
+  try {
+    const post = await HiveClient.database.call('get_content', [author, permlink]);
+    if (!post || !post.author) return null;
+    return post;
+  } catch {
+    return null;
+  }
+}
+
+export async function getProfileForMetadata(username: string) {
+  try {
+    return await HiveClient.call('bridge', 'get_profile', { account: username });
+  } catch {
+    return null;
+  }
+}

--- a/lib/utils/buildMetadata.ts
+++ b/lib/utils/buildMetadata.ts
@@ -1,0 +1,113 @@
+import type { Metadata } from "next";
+import { extractImageUrls } from "./extractImageUrls";
+import { getHiveAvatarUrl } from "./avatarUtils";
+
+const SITE_NAME = "Snapie";
+const MAX_DESCRIPTION_LENGTH = 200;
+
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/!\[.*?\]\(.*?\)/g, '')        // remove images
+    .replace(/\[([^\]]*)\]\(.*?\)/g, '$1')   // links → text only
+    .replace(/[#*>`~_\-]/g, '')              // strip markdown chars
+    .replace(/\n+/g, ' ')                    // collapse newlines
+    .trim();
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max) + '...';
+}
+
+function extractOgImage(body: string, jsonMetadata?: string): string | undefined {
+  // 1. Try json_metadata.image first
+  try {
+    const meta = JSON.parse(jsonMetadata || '{}');
+    if (meta.image && meta.image.length > 0) {
+      return meta.image[0];
+    }
+  } catch {}
+
+  // 2. Fall back to first image in markdown body
+  const bodyImages = extractImageUrls(body);
+  if (bodyImages.length > 0) {
+    return bodyImages[0];
+  }
+
+  return undefined;
+}
+
+export function buildPostMetadata(post: {
+  title: string;
+  body: string;
+  author: string;
+  permlink: string;
+  json_metadata?: string;
+}): Metadata {
+  const title = post.title || `Post by @${post.author}`;
+  const plainText = stripMarkdown(post.body);
+  const description = truncate(plainText || `Post by @${post.author}`, MAX_DESCRIPTION_LENGTH);
+
+  let ogImage = extractOgImage(post.body, post.json_metadata);
+
+  // Proxy through Hive images for consistent sizing
+  if (ogImage) {
+    ogImage = `https://images.hive.blog/1200x630/${ogImage}`;
+  } else {
+    // Fallback to author avatar
+    ogImage = getHiveAvatarUrl(post.author, 'large');
+  }
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: 'article',
+      url: `/@${post.author}/${post.permlink}`,
+      siteName: SITE_NAME,
+      images: ogImage ? [{ url: ogImage, width: 1200, height: 630 }] : [],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: ogImage ? [ogImage] : [],
+    },
+  };
+}
+
+export function buildProfileMetadata(profile: {
+  name: string;
+  about?: string;
+  metadata?: { profile?: { cover_image?: string; profile_image?: string; about?: string } };
+}): Metadata {
+  const about = profile.metadata?.profile?.about || profile.about || `@${profile.name} on Snapie`;
+  const description = truncate(about, MAX_DESCRIPTION_LENGTH);
+
+  const profileImage = profile.metadata?.profile?.profile_image || getHiveAvatarUrl(profile.name, 'large');
+  const coverImage = profile.metadata?.profile?.cover_image;
+  const ogImage = coverImage || profileImage;
+
+  const title = `@${profile.name}`;
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: 'profile',
+      url: `/@${profile.name}`,
+      siteName: SITE_NAME,
+      images: ogImage ? [{ url: ogImage }] : [],
+    },
+    twitter: {
+      card: coverImage ? 'summary_large_image' : 'summary',
+      title,
+      description,
+      images: ogImage ? [ogImage] : [],
+    },
+  };
+}

--- a/lib/utils/buildMetadata.ts
+++ b/lib/utils/buildMetadata.ts
@@ -23,7 +23,7 @@ function extractOgImage(body: string, jsonMetadata?: string): string | undefined
   // 1. Try json_metadata.image first
   try {
     const meta = JSON.parse(jsonMetadata || '{}');
-    if (meta.image && meta.image.length > 0) {
+    if (Array.isArray(meta.image) && meta.image.length > 0) {
       return meta.image[0];
     }
   } catch {}
@@ -50,9 +50,9 @@ export function buildPostMetadata(post: {
 
   let ogImage = extractOgImage(post.body, post.json_metadata);
 
-  // Proxy through Hive images for consistent sizing
+  // Proxy through Hive images for consistent sizing (URL-encode for proxy path)
   if (ogImage) {
-    ogImage = `https://images.hive.blog/1200x630/${ogImage}`;
+    ogImage = `https://images.hive.blog/1200x630/${encodeURIComponent(ogImage)}`;
   } else {
     // Fallback to author avatar
     ogImage = getHiveAvatarUrl(post.author, 'large');
@@ -67,13 +67,13 @@ export function buildPostMetadata(post: {
       type: 'article',
       url: `/@${post.author}/${post.permlink}`,
       siteName: SITE_NAME,
-      images: ogImage ? [{ url: ogImage, width: 1200, height: 630 }] : [],
+      images: [{ url: ogImage, width: 1200, height: 630 }],
     },
     twitter: {
       card: 'summary_large_image',
       title,
       description,
-      images: ogImage ? [ogImage] : [],
+      images: [ogImage],
     },
   };
 }


### PR DESCRIPTION
## Summary
- Convert `app/layout.tsx` and `app/[...slug]/page.tsx` from client to server components to enable Next.js `generateMetadata()`
- Post links (`/@author/permlink`) now return OG/Twitter meta tags with title, description, and image extracted from Hive post data
- Profile links (`/@username`) return meta tags with display name, bio, and profile/cover image
- Crawlers (Twitter, Discord, Facebook, Telegram) will render rich preview cards when links are shared

## Changes
| File | Action |
|------|--------|
| `lib/hive/metadata-functions.ts` | New — server-safe Hive fetch for posts & profiles |
| `lib/utils/buildMetadata.ts` | New — builds OG + Twitter Card metadata objects |
| `app/LayoutContent.tsx` | New — extracted client layout logic (unchanged behavior) |
| `app/[...slug]/SlugPageClient.tsx` | New — extracted client routing logic (unchanged behavior) |
| `app/layout.tsx` | Modified — now server component with default site metadata |
| `app/[...slug]/page.tsx` | Modified — now server component with `generateMetadata` |

## Test plan
- [ ] `npm run dev` — verify app loads and all pages work (home, profile, post, wallet, notifications, compose)
- [ ] `curl -s http://localhost:3000/@meno/53375298 | grep -E 'og:\|twitter:'` — verify meta tags in raw HTML
- [ ] Test embed mode still works (`?embed=true`)
- [ ] Test post with no images (should fallback to author avatar)
- [ ] Test non-existent post/profile (should not crash, returns default metadata)
- [ ] Paste a link in Discord/Twitter to verify rich preview card renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic metadata for posts and profiles to improve sharing and search previews.
  * Embed mode that streamlines the UI for embedded views (hides sidebar/footer/chat and adjusts page styling).
  * Chat unread indicator that updates via periodic background checks when chat is closed.
  * Improved routing and client-side slug handling for profiles, posts, wallets, and notifications, plus a refactored layout for cleaner rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->