### PR TITLE
fix: Remove encodeURIComponent from OG image proxy URL

### DIFF
--- a/lib/utils/buildMetadata.ts
+++ b/lib/utils/buildMetadata.ts
@@ -52,7 +52,7 @@ export function buildPostMetadata(post: {
 
   // Proxy through Hive images for consistent sizing (URL-encode for proxy path)
   if (ogImage) {
-    ogImage = `https://images.hive.blog/1200x630/${encodeURIComponent(ogImage)}`;
+    ogImage = `https://images.hive.blog/1200x630/${ogImage}`;
   } else {
     // Fallback to author avatar
     ogImage = getHiveAvatarUrl(post.author, 'large');


### PR DESCRIPTION
## Summary
- Removes `encodeURIComponent` from the Hive image proxy URL in OG meta tags
- The proxy expects raw URLs, not encoded ones — this was preventing social share images from loading

## Test plan
- [ ] Share a Snapie post link on Twitter/Discord/Telegram and verify the image preview appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect handling of post preview images in metadata generation, ensuring images display properly when posts are shared or previewed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->