### PR TITLE
fix: Dynamic Hive RPC node selection via PeakD beacon

### DIFF
--- a/lib/hive/hiveclient.tsx
+++ b/lib/hive/hiveclient.tsx
@@ -16,7 +16,11 @@ const EXCLUDED_NODES = [
 const BEACON_API = "https://beacon.peakd.com/api/nodes"
 const MIN_SCORE = 80
 
-let HiveClient = new Client(FALLBACK_NODES)
+// Proxy object so reassigning .client propagates to all importers
+// (export default captures a value, not a binding)
+const hive = {
+  client: new Client(FALLBACK_NODES),
+}
 
 async function fetchHealthyNodes(): Promise<string[]> {
   try {
@@ -40,11 +44,24 @@ async function fetchHealthyNodes(): Promise<string[]> {
 // Initialize with healthy nodes on first load (client-side only)
 if (typeof window !== "undefined") {
   fetchHealthyNodes().then(nodes => {
-    HiveClient = new Client(nodes)
+    hive.client = new Client(nodes)
     if (process.env.NODE_ENV === "development") {
       console.log("🔗 HiveClient initialized with beacon nodes:", nodes)
     }
+  }).catch(err => {
+    if (process.env.NODE_ENV === "development") {
+      console.error("Failed to initialize HiveClient with beacon nodes:", err)
+    }
   })
 }
+
+// Proxy that delegates all property access to the current hive.client.
+// This lets consumers keep `import HiveClient from './hiveclient'`
+// and automatically use the updated client after beacon nodes load.
+const HiveClient: Client = new Proxy({} as Client, {
+  get(_target, prop, receiver) {
+    return Reflect.get(hive.client, prop, receiver)
+  },
+})
 
 export default HiveClient

--- a/lib/hive/hiveclient.tsx
+++ b/lib/hive/hiveclient.tsx
@@ -1,12 +1,50 @@
 import { Client } from "@hiveio/dhive"
 
-const HiveClient = new Client([
-  "https://api.deathwing.me",
-  "https://techcoderx.com",
+const FALLBACK_NODES = [
   "https://api.hive.blog",
-  "https://anyx.io",
-  "https://hive-api.arcange.eu",
-  "https://hive-api.3speak.tv",
-])
+  "https://api.openhive.network",
+  "https://techcoderx.com",
+  "https://rpc.mahdiyari.info",
+  "https://api.c0ff33a.uk",
+]
+
+// Nodes to exclude (CORS issues with snapie.io)
+const EXCLUDED_NODES = [
+  "api.deathwing.me",
+]
+
+const BEACON_API = "https://beacon.peakd.com/api/nodes"
+const MIN_SCORE = 80
+
+let HiveClient = new Client(FALLBACK_NODES)
+
+async function fetchHealthyNodes(): Promise<string[]> {
+  try {
+    const res = await fetch(BEACON_API)
+    if (!res.ok) return FALLBACK_NODES
+
+    const nodes: Array<{ endpoint: string; score: number; name: string }> = await res.json()
+
+    const healthy = nodes
+      .filter(n => n.score >= MIN_SCORE)
+      .filter(n => !EXCLUDED_NODES.some(ex => n.name.includes(ex)))
+      .sort((a, b) => b.score - a.score)
+      .map(n => n.endpoint)
+
+    return healthy.length >= 2 ? healthy : FALLBACK_NODES
+  } catch {
+    return FALLBACK_NODES
+  }
+}
+
+// Initialize with healthy nodes on first load (client-side only)
+if (typeof window !== "undefined") {
+  fetchHealthyNodes().then(nodes => {
+    HiveClient = new Client(nodes)
+    if (process.env.NODE_ENV === "development") {
+      console.log("🔗 HiveClient initialized with beacon nodes:", nodes)
+    }
+  })
+}
 
 export default HiveClient


### PR DESCRIPTION
## Summary
- Fetch healthy Hive RPC nodes from PeakD beacon API (`https://beacon.peakd.com/api/nodes`) on client-side page load
- Filter nodes by health score >= 80, exclude `api.deathwing.me` (CORS issues with `snapie.io`)
- Sort by score descending so healthiest node is used first
- Fall back to hardcoded node list if beacon API is down or returns insufficient nodes

## Problem
`api.deathwing.me` blocks CORS from `snapie.io`, and dhive's Client doesn't fail over on browser-level CORS blocks. This caused an infinite retry loop on the same broken node, making the app unusable when deathwing was first in the list.

## Test plan
- [ ] Open `snapie.io` in browser — verify no CORS errors from `api.deathwing.me`
- [ ] Check dev console for `HiveClient initialized with beacon nodes:` log
- [ ] Verify feed loads, voting works, and posting works
- [ ] Test with beacon API blocked (e.g., DevTools network block) — verify fallback nodes work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic node selection: app now queries a beacon API to discover healthy endpoints, filters and ranks them by score, and automatically falls back to default nodes if too few healthy nodes are found.
  * Runtime connection update: the active connection is refreshed on first load so the app switches to discovered healthy nodes when available; optional dev logging reports success/failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->