### PR TITLE
fix: Hangouts SDK update, announcement snaps, and modal layout

### DIFF
--- a/app/compose/Editor.tsx
+++ b/app/compose/Editor.tsx
@@ -204,11 +204,12 @@ interface EditorProps {
   setHashtags: (hashtags: string[]) => void;
   beneficiaries: Beneficiary[];
   setBeneficiaries: (beneficiaries: Beneficiary[]) => void;
+  lockedAccounts?: string[];
   onSubmit: () => void;
   isSubmitting?: boolean;
 }
 
-const Editor: FC<EditorProps> = ({ markdown, setMarkdown, title, setTitle, hashtagInput, setHashtagInput, hashtags, setHashtags, beneficiaries, setBeneficiaries, onSubmit, isSubmitting = false }) => {
+const Editor: FC<EditorProps> = ({ markdown, setMarkdown, title, setTitle, hashtagInput, setHashtagInput, hashtags, setHashtags, beneficiaries, setBeneficiaries, lockedAccounts, onSubmit, isSubmitting = false }) => {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const toast = useToast();
     const isMobile = useBreakpointValue({ base: true, sm: false }, { ssr: false });
@@ -793,6 +794,7 @@ const Editor: FC<EditorProps> = ({ markdown, setMarkdown, title, setTitle, hasht
                         <BeneficiariesInput
                             beneficiaries={beneficiaries}
                             setBeneficiaries={setBeneficiaries}
+                            lockedAccounts={lockedAccounts}
                         />
                         
                         {/* Submit Button */}

--- a/app/compose/page.tsx
+++ b/app/compose/page.tsx
@@ -237,6 +237,7 @@ export default function Home() {
           setHashtags={setHashtags}
           beneficiaries={beneficiaries}
           setBeneficiaries={setBeneficiaries}
+          lockedAccounts={isHangout ? ['snapie', 'threespeakfund'] : undefined}
           onSubmit={handleSubmit}
           isSubmitting={isSubmitting}
         />

--- a/app/compose/page.tsx
+++ b/app/compose/page.tsx
@@ -4,7 +4,7 @@ import { signAndBroadcastWithKeychain } from '@/lib/hive/client-functions'
 import { Flex, Input, Tag, TagCloseButton, TagLabel, Wrap, WrapItem, Button, useToast } from '@chakra-ui/react'
 import dynamic from 'next/dynamic'
 import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { prepareImageArray, validateTitle, validateContent } from '@/lib/utils/composeUtils'
 import { createComposer, type Beneficiary } from '@snapie/operations'
 import type { Beneficiary as BeneficiaryInputType } from '@/components/compose/BeneficiariesInput'
@@ -18,12 +18,30 @@ const blogComposer = createComposer({
   beneficiaries: [] // Will be set per-post
 })
 
+const HANGOUT_THUMBNAIL = 'https://files.peakd.com/file/peakd-hive/meno/AKDgvpgFrvsp3fEazRgb971Pm8N7NqV3TUt1dF4TUY9798tUJHfZvwHE2BZB56Y.png';
+
+function buildHangoutBody(audioUrl: string, thumbnail: string): string {
+  return `![Hangout Recording](${thumbnail})\n\n<center>\n\n### Listen to this hangout\n\n[Play on 3Speak](${audioUrl})\n\n</center>\n\n---\n\n*Write a description of your hangout here...*`;
+}
+
 export default function Home() {
-  const [markdown, setMarkdown] = useState("")
-  const [title, setTitle] = useState("")
+  const searchParams = useSearchParams()
+  const isHangout = searchParams.get('hangout') === 'true'
+  const hangoutTitle = searchParams.get('title') || ''
+  const hangoutAudioUrl = searchParams.get('audioUrl') || ''
+  const hangoutThumbnail = searchParams.get('thumbnail') || HANGOUT_THUMBNAIL
+
+  const [markdown, setMarkdown] = useState(
+    isHangout && hangoutAudioUrl ? buildHangoutBody(hangoutAudioUrl, hangoutThumbnail) : ""
+  )
+  const [title, setTitle] = useState(isHangout ? hangoutTitle : "")
   const [hashtagInput, setHashtagInput] = useState("")
-  const [hashtags, setHashtags] = useState<string[]>([])
-  const [beneficiaries, setBeneficiaries] = useState<BeneficiaryInputType[]>([{ account: 'snapie', weight: 300 }]) // Default 3% to snapie
+  const [hashtags, setHashtags] = useState<string[]>(isHangout ? ['hangout', 'podcast'] : [])
+  const [beneficiaries, setBeneficiaries] = useState<BeneficiaryInputType[]>(
+    isHangout
+      ? [{ account: 'snapie', weight: 300 }, { account: 'threespeakfund', weight: 700 }]
+      : [{ account: 'snapie', weight: 300 }]
+  )
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const { user } = useKeychain()

--- a/app/compose/page.tsx
+++ b/app/compose/page.tsx
@@ -3,7 +3,7 @@ import { useKeychain } from '@/contexts/KeychainContext'
 import { signAndBroadcastWithKeychain } from '@/lib/hive/client-functions'
 import { Flex, Input, Tag, TagCloseButton, TagLabel, Wrap, WrapItem, Button, useToast } from '@chakra-ui/react'
 import dynamic from 'next/dynamic'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { prepareImageArray, validateTitle, validateContent } from '@/lib/utils/composeUtils'
 import { createComposer, type Beneficiary } from '@snapie/operations'
@@ -43,6 +43,22 @@ export default function Home() {
       : [{ account: 'snapie', weight: 300 }]
   )
   const [isSubmitting, setIsSubmitting] = useState(false)
+
+  // Sync state when search params change (e.g., same-route navigation from recording upload)
+  useEffect(() => {
+    if (!isHangout) return
+
+    setTitle(hangoutTitle)
+    setHashtags(['hangout', 'podcast'])
+    setBeneficiaries([
+      { account: 'snapie', weight: 300 },
+      { account: 'threespeakfund', weight: 700 },
+    ])
+
+    if (hangoutAudioUrl) {
+      setMarkdown(buildHangoutBody(hangoutAudioUrl, hangoutThumbnail))
+    }
+  }, [isHangout, hangoutTitle, hangoutAudioUrl, hangoutThumbnail])
 
   const { user } = useKeychain()
   const toast = useToast()

--- a/components/compose/BeneficiariesInput.tsx
+++ b/components/compose/BeneficiariesInput.tsx
@@ -25,20 +25,23 @@ export interface Beneficiary {
 interface BeneficiariesInputProps {
   beneficiaries: Beneficiary[];
   setBeneficiaries: (beneficiaries: Beneficiary[]) => void;
+  lockedAccounts?: string[];
 }
 
-const BeneficiariesInput: FC<BeneficiariesInputProps> = ({ beneficiaries, setBeneficiaries }) => {
+const BeneficiariesInput: FC<BeneficiariesInputProps> = ({ beneficiaries, setBeneficiaries, lockedAccounts = ['snapie'] }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [newAccount, setNewAccount] = useState('');
   const [newPercentage, setNewPercentage] = useState('');
   const toast = useToast();
 
-  // Calculate total percentage (excluding snapie's 3%)
+  // Calculate total percentage (excluding locked accounts)
   const totalPercentage = beneficiaries
-    .filter(b => b.account !== 'snapie')
+    .filter(b => !lockedAccounts.includes(b.account))
     .reduce((sum, b) => sum + (b.weight / 100), 0);
 
-  const snapiePercentage = 3; // Fixed 3% for snapie
+  const lockedPercentage = beneficiaries
+    .filter(b => lockedAccounts.includes(b.account))
+    .reduce((sum, b) => sum + (b.weight / 100), 0);
 
   const handleAddBeneficiary = () => {
     // Validation
@@ -66,10 +69,10 @@ const BeneficiariesInput: FC<BeneficiariesInputProps> = ({ beneficiaries, setBen
     }
 
     // Check if total would exceed 100%
-    if (totalPercentage + percentage + snapiePercentage > 100) {
+    if (totalPercentage + percentage + lockedPercentage > 100) {
       toast({
         title: 'Exceeds 100%',
-        description: `Total beneficiaries would be ${(totalPercentage + percentage + snapiePercentage).toFixed(1)}%. Maximum is 100%.`,
+        description: `Total beneficiaries would be ${(totalPercentage + percentage + lockedPercentage).toFixed(1)}%. Maximum is 100%.`,
         status: 'error',
         duration: 3000,
         isClosable: true,
@@ -107,11 +110,10 @@ const BeneficiariesInput: FC<BeneficiariesInputProps> = ({ beneficiaries, setBen
   };
 
   const handleRemoveBeneficiary = (account: string) => {
-    // Can't remove snapie
-    if (account === 'snapie') {
+    if (lockedAccounts.includes(account)) {
       toast({
         title: 'Cannot Remove',
-        description: 'Snapie is a required beneficiary (3%)',
+        description: `@${account} is a required beneficiary`,
         status: 'warning',
         duration: 2000,
         isClosable: true,
@@ -145,7 +147,7 @@ const BeneficiariesInput: FC<BeneficiariesInputProps> = ({ beneficiaries, setBen
             Reward Beneficiaries
           </Text>
           <Tag size="sm" colorScheme="blue">
-            {(totalPercentage + snapiePercentage).toFixed(1)}% allocated
+            {(totalPercentage + lockedPercentage).toFixed(1)}% allocated
           </Tag>
         </HStack>
         <IconButton
@@ -174,12 +176,12 @@ const BeneficiariesInput: FC<BeneficiariesInputProps> = ({ beneficiaries, setBen
                       size="md"
                       borderRadius="base"
                       variant="solid"
-                      colorScheme={b.account === 'snapie' ? 'green' : 'blue'}
+                      colorScheme={lockedAccounts.includes(b.account) ? 'green' : 'blue'}
                     >
                       <TagLabel>
                         @{b.account} ({(b.weight / 100).toFixed(1)}%)
                       </TagLabel>
-                      {b.account !== 'snapie' && (
+                      {!lockedAccounts.includes(b.account) && (
                         <TagCloseButton onClick={() => handleRemoveBeneficiary(b.account)} />
                       )}
                     </Tag>
@@ -227,11 +229,11 @@ const BeneficiariesInput: FC<BeneficiariesInputProps> = ({ beneficiaries, setBen
                   size="sm"
                   colorScheme="blue"
                   onClick={handleAddBeneficiary}
-                  isDisabled={totalPercentage + snapiePercentage >= 100}
+                  isDisabled={totalPercentage + lockedPercentage >= 100}
                 />
               </HStack>
               <Text fontSize="xs" color="gray.500" mt={1}>
-                Remaining: {(100 - totalPercentage - snapiePercentage).toFixed(1)}% • Note: 3% to @snapie is required
+                Remaining: {(100 - totalPercentage - lockedPercentage).toFixed(1)}% • Required: {lockedAccounts.map(a => `@${a}`).join(', ')}
               </Text>
             </Box>
           </VStack>

--- a/components/hangouts/HangoutModal.tsx
+++ b/components/hangouts/HangoutModal.tsx
@@ -1,12 +1,16 @@
 'use client';
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
 import { Modal, ModalOverlay, ModalContent, ModalCloseButton, Center, Spinner, Text, VStack, Button } from '@chakra-ui/react';
-import { HangoutsProvider, HangoutsRoom, useHangoutsAuth } from '@snapie/hangouts-react';
+import { HangoutsProvider, HangoutsRoom, useHangoutsAuth, useRecording } from '@snapie/hangouts-react';
 import { useKeychain } from '@/contexts/KeychainContext';
 import { useAutoHangoutLogin } from '@/hooks/useAutoHangoutLogin';
 import '@snapie/hangouts-react/src/styles/hangouts.css';
 
 const API_URL = process.env.NEXT_PUBLIC_HANGOUTS_API_URL!;
 const LK_URL = process.env.NEXT_PUBLIC_LIVEKIT_URL || 'wss://livekit.3speak.tv';
+
+const HANGOUT_THUMBNAIL = 'https://files.peakd.com/file/peakd-hive/meno/AKDgvpgFrvsp3fEazRgb971Pm8N7NqV3TUt1dF4TUY9798tUJHfZvwHE2BZB56Y.png';
 
 interface HangoutModalProps {
   isOpen: boolean;
@@ -18,6 +22,24 @@ function HangoutRoomWithAuth({ roomName, onClose }: { roomName: string; onClose:
   const { user } = useKeychain();
   const auth = useHangoutsAuth();
   const { retryLogin } = useAutoHangoutLogin(user, auth);
+  const recording = useRecording(roomName);
+  const router = useRouter();
+  const hasRedirected = useRef(false);
+
+  // When recording upload completes, redirect to compose page with pre-filled data
+  useEffect(() => {
+    if (recording.uploadResult && !hasRedirected.current) {
+      hasRedirected.current = true;
+      const params = new URLSearchParams({
+        hangout: 'true',
+        title: roomName.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase()),
+        audioUrl: recording.uploadResult.playUrl,
+        thumbnail: HANGOUT_THUMBNAIL,
+      });
+      router.push(`/compose?${params.toString()}`);
+      onClose();
+    }
+  }, [recording.uploadResult]);
 
   if (!user) {
     return (

--- a/components/hangouts/HangoutModal.tsx
+++ b/components/hangouts/HangoutModal.tsx
@@ -53,8 +53,8 @@ function HangoutRoomWithAuth({ roomName, onClose }: { roomName: string; onClose:
   }
 
   return (
-    <div data-hh-theme="dark">
-      <HangoutsRoom roomName={roomName} onLeave={onClose} embedded />
+    <div data-hh-theme="dark" style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <HangoutsRoom roomName={roomName} onLeave={onClose} embedded maxHeight="78vh" />
     </div>
   );
 }
@@ -62,9 +62,9 @@ function HangoutRoomWithAuth({ roomName, onClose }: { roomName: string; onClose:
 export default function HangoutModal({ isOpen, onClose, roomName }: HangoutModalProps) {
   return (
     <HangoutsProvider apiBaseUrl={API_URL} livekitServerUrl={LK_URL}>
-      <Modal isOpen={isOpen} onClose={onClose} size="2xl" scrollBehavior="inside">
+      <Modal isOpen={isOpen} onClose={onClose} size="2xl">
         <ModalOverlay bg="rgba(0, 0, 0, 0.6)" backdropFilter="blur(10px)" />
-        <ModalContent bg="background" color="text" borderColor="border" borderWidth="2px" maxH="85vh">
+        <ModalContent bg="background" color="text" borderColor="border" borderWidth="2px" maxH="85vh" overflow="hidden">
           <ModalCloseButton zIndex={10} />
           <HangoutRoomWithAuth roomName={roomName} onClose={onClose} />
         </ModalContent>

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@hiveio/dhive": "1.3.1-beta",
     "@livekit/components-react": "^2.9.20",
     "@snapie/composer": "workspace:*",
-    "@snapie/hangouts-react": "^0.1.1",
+    "@snapie/hangouts-react": "^0.1.2",
     "@snapie/operations": "workspace:*",
     "@snapie/renderer": "workspace:*",
     "@supabase/supabase-js": "^2.45.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@hiveio/dhive": "1.3.1-beta",
     "@livekit/components-react": "^2.9.20",
     "@snapie/composer": "workspace:*",
-    "@snapie/hangouts-react": "^0.1.2",
+    "@snapie/hangouts-react": "^0.2.3",
     "@snapie/operations": "workspace:*",
     "@snapie/renderer": "workspace:*",
     "@supabase/supabase-js": "^2.45.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: workspace:*
         version: link:packages/composer
       '@snapie/hangouts-react':
-        specifier: ^0.1.2
-        version: 0.1.2(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
+        specifier: ^0.2.3
+        version: 0.2.3(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
       '@snapie/operations':
         specifier: workspace:*
         version: link:packages/operations
@@ -874,11 +874,11 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@snapie/hangouts-core@0.1.1':
-    resolution: {integrity: sha512-mHEgXGvhJUgO+DIexfSOHeSm14zvcd4+6AHSbEMv+EDbclBviM0C+bL4RbbT9lt3x6Gg9hhWpqQZi+wMfex7Yw==}
+  '@snapie/hangouts-core@0.2.1':
+    resolution: {integrity: sha512-vWFTXLj711yMJJvLB4IubLn8eDb9J8VV+BPnKOGuNSzgBGSY4sAGyByREmC321X4iSh77D4YTpFmcSsEBMxJyg==}
 
-  '@snapie/hangouts-react@0.1.2':
-    resolution: {integrity: sha512-u97O64JG6++26P0zlvnqdeFIG8z26Uq4V7DbAdTaq6XGL5u7LLzWz8KTx5HdjtMY4NN0rrLABEQZppkepexnrQ==}
+  '@snapie/hangouts-react@0.2.3':
+    resolution: {integrity: sha512-6OVKYYyIO2hXZZiR6gIgsNpXC9kwAlmPqXc6aVrfwvGrxYdKl/FhBojTU3yZDcl/fKcf7RmthN/FdCiCIangsg==}
     peerDependencies:
       '@livekit/components-react': ^2.0.0
       livekit-client: ^2.0.0
@@ -4224,12 +4224,12 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@snapie/hangouts-core@0.1.1': {}
+  '@snapie/hangouts-core@0.2.1': {}
 
-  '@snapie/hangouts-react@0.1.2(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
+  '@snapie/hangouts-react@0.2.3(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
     dependencies:
       '@livekit/components-react': 2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
-      '@snapie/hangouts-core': 0.1.1
+      '@snapie/hangouts-core': 0.2.1
       livekit-client: 2.18.0(@types/dom-mediacapture-record@1.0.22)
       react: 18.3.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: workspace:*
         version: link:packages/composer
       '@snapie/hangouts-react':
-        specifier: ^0.1.1
-        version: 0.1.1(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
+        specifier: ^0.1.2
+        version: 0.1.2(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
       '@snapie/operations':
         specifier: workspace:*
         version: link:packages/operations
@@ -877,8 +877,8 @@ packages:
   '@snapie/hangouts-core@0.1.1':
     resolution: {integrity: sha512-mHEgXGvhJUgO+DIexfSOHeSm14zvcd4+6AHSbEMv+EDbclBviM0C+bL4RbbT9lt3x6Gg9hhWpqQZi+wMfex7Yw==}
 
-  '@snapie/hangouts-react@0.1.1':
-    resolution: {integrity: sha512-4tX/i3p743m/MHAan3VRkZ9kVV9XqzZbt//beQwnQ76M3sTMDvgGSqYhIymoO1IQfFwFvyTndxXSm8/dBZxjKg==}
+  '@snapie/hangouts-react@0.1.2':
+    resolution: {integrity: sha512-u97O64JG6++26P0zlvnqdeFIG8z26Uq4V7DbAdTaq6XGL5u7LLzWz8KTx5HdjtMY4NN0rrLABEQZppkepexnrQ==}
     peerDependencies:
       '@livekit/components-react': ^2.0.0
       livekit-client: ^2.0.0
@@ -4226,7 +4226,7 @@ snapshots:
 
   '@snapie/hangouts-core@0.1.1': {}
 
-  '@snapie/hangouts-react@0.1.1(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
+  '@snapie/hangouts-react@0.1.2(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
     dependencies:
       '@livekit/components-react': 2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@snapie/hangouts-core': 0.1.1


### PR DESCRIPTION
## Summary
- Update `@snapie/hangouts-react` to 0.1.2 (fixes host controls panel overflow, adds slim scrollbar in embedded mode)
- Fix modal height chain: propagate height through `data-hh-theme` wrapper, pass `maxHeight="78vh"` to `HangoutsRoom`
- Auto-post announcement snap with 10% beneficiary when creating a hangout room
- Fix snap posting to use `parentAuthor: 'peak.snaps'` so announcements appear in the feed (not as top-level posts)
- Address CodeRabbit review feedback: shared `useAutoHangoutLogin` hook, error handling in preview card, accessibility, `isCreating` ref guard

## Changes since PR #21 was merged
- `components/hangouts/HangoutModal.tsx` — modal height fix, SDK 0.1.2 embedded improvements
- `app/hangouts/page.tsx` — announcement snap on room creation with beneficiaries
- `lib/utils/composerSdk.ts` — `snapieHangoutComposer` alias for 10% beneficiary
- `hooks/useAutoHangoutLogin.ts` — shared auto-auth hook (no infinite retry)
- `components/hangouts/HangoutPreviewCard.tsx` — error state, accessibility
- `app/LayoutContent.tsx` — simplified `isOpen` prop
- `components/homepage/Snap.tsx` — composite key for hangout cards
- `package.json` / `pnpm-lock.yaml` — SDK version bump

## Test plan
- [ ] Create a room from `/hangouts` — announcement snap posts to feed with 10% beneficiary
- [ ] Announcement snap renders as HangoutPreviewCard in feed
- [ ] Modal layout: controls visible at bottom, content scrolls, host panel doesn't overflow
- [ ] Test on mobile (375px) — embedded layout works
- [ ] Join existing room from preview card — modal opens, auth works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * After a hangout recording completes, users are redirected to Compose with title, audio URL, thumbnail, prefilled post content, default tags, and suggested beneficiaries; Compose now initializes title/markdown/hashtags/beneficiaries from URL.
  * Beneficiaries can be locked (defaults applied) and Editor forwards locked accounts to the beneficiaries input.

* **Bug Fixes**
  * Improved hangout modal/layout behavior, modal content overflow handling, and container sizing for more consistent display.

* **Chores**
  * Bumped hangouts-related dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->