### PR TITLE
feat: Recording upload → compose page + locked beneficiaries

### DIFF
--- a/components/hangouts/HangoutModal.tsx
+++ b/components/hangouts/HangoutModal.tsx
@@ -1,8 +1,8 @@
 'use client';
-import { useEffect, useRef } from 'react';
+import { useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Modal, ModalOverlay, ModalContent, ModalCloseButton, Center, Spinner, Text, VStack, Button } from '@chakra-ui/react';
-import { HangoutsProvider, HangoutsRoom, useHangoutsAuth, useRecording } from '@snapie/hangouts-react';
+import { HangoutsProvider, HangoutsRoom, useHangoutsAuth } from '@snapie/hangouts-react';
 import { useKeychain } from '@/contexts/KeychainContext';
 import { useAutoHangoutLogin } from '@/hooks/useAutoHangoutLogin';
 import '@snapie/hangouts-react/src/styles/hangouts.css';
@@ -22,24 +22,18 @@ function HangoutRoomWithAuth({ roomName, onClose }: { roomName: string; onClose:
   const { user } = useKeychain();
   const auth = useHangoutsAuth();
   const { retryLogin } = useAutoHangoutLogin(user, auth);
-  const recording = useRecording(roomName);
   const router = useRouter();
-  const hasRedirected = useRef(false);
 
-  // When recording upload completes, redirect to compose page with pre-filled data
-  useEffect(() => {
-    if (recording.uploadResult && !hasRedirected.current) {
-      hasRedirected.current = true;
-      const params = new URLSearchParams({
-        hangout: 'true',
-        title: roomName.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase()),
-        audioUrl: recording.uploadResult.playUrl,
-        thumbnail: HANGOUT_THUMBNAIL,
-      });
-      router.push(`/compose?${params.toString()}`);
-      onClose();
-    }
-  }, [recording.uploadResult]);
+  const handleRecordingUploaded = useCallback((result: { permlink: string; cid: string; playUrl: string }) => {
+    const params = new URLSearchParams({
+      hangout: 'true',
+      title: roomName.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase()),
+      audioUrl: result.playUrl,
+      thumbnail: HANGOUT_THUMBNAIL,
+    });
+    router.push(`/compose?${params.toString()}`);
+    onClose();
+  }, [roomName, router, onClose]);
 
   if (!user) {
     return (
@@ -76,7 +70,13 @@ function HangoutRoomWithAuth({ roomName, onClose }: { roomName: string; onClose:
 
   return (
     <div data-hh-theme="dark" style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      <HangoutsRoom roomName={roomName} onLeave={onClose} embedded maxHeight="78vh" />
+      <HangoutsRoom
+        roomName={roomName}
+        onLeave={onClose}
+        onRecordingUploaded={handleRecordingUploaded}
+        embedded
+        maxHeight="78vh"
+      />
     </div>
   );
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@hiveio/dhive": "1.3.1-beta",
     "@livekit/components-react": "^2.9.20",
     "@snapie/composer": "workspace:*",
-    "@snapie/hangouts-react": "^0.2.3",
+    "@snapie/hangouts-react": "^0.2.4",
     "@snapie/operations": "workspace:*",
     "@snapie/renderer": "workspace:*",
     "@supabase/supabase-js": "^2.45.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: workspace:*
         version: link:packages/composer
       '@snapie/hangouts-react':
-        specifier: ^0.2.3
-        version: 0.2.3(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
+        specifier: ^0.2.4
+        version: 0.2.4(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
       '@snapie/operations':
         specifier: workspace:*
         version: link:packages/operations
@@ -877,8 +877,8 @@ packages:
   '@snapie/hangouts-core@0.2.1':
     resolution: {integrity: sha512-vWFTXLj711yMJJvLB4IubLn8eDb9J8VV+BPnKOGuNSzgBGSY4sAGyByREmC321X4iSh77D4YTpFmcSsEBMxJyg==}
 
-  '@snapie/hangouts-react@0.2.3':
-    resolution: {integrity: sha512-6OVKYYyIO2hXZZiR6gIgsNpXC9kwAlmPqXc6aVrfwvGrxYdKl/FhBojTU3yZDcl/fKcf7RmthN/FdCiCIangsg==}
+  '@snapie/hangouts-react@0.2.4':
+    resolution: {integrity: sha512-LvTeMk/ktcaqxjsGSjzB3QAvCi/Xv3ggv/BFxewNfLfiIc7CVSKOkS0UFzr2yWU8Il2LYwd//S7IETCVrgRPIw==}
     peerDependencies:
       '@livekit/components-react': ^2.0.0
       livekit-client: ^2.0.0
@@ -4226,7 +4226,7 @@ snapshots:
 
   '@snapie/hangouts-core@0.2.1': {}
 
-  '@snapie/hangouts-react@0.2.3(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
+  '@snapie/hangouts-react@0.2.4(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
     dependencies:
       '@livekit/components-react': 2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@snapie/hangouts-core': 0.2.1


### PR DESCRIPTION
## Summary
- After recording upload, redirect host to `/compose` with pre-filled title, audio embed, thumbnail, tags, and beneficiaries
- Uses SDK v0.2.4's `onRecordingUploaded` callback (replaces broken `useRecording` hook approach)
- Lock `@snapie` (3%) and `@threespeakfund` (7%) beneficiaries on hangout recording posts — can't be removed
- Generalized `BeneficiariesInput` with `lockedAccounts` prop
- Sync compose state via `useEffect` for same-route navigation edge case
- Fix modal height chain for embedded room layout
- Default podcast thumbnail image for lazy posters

## Files changed
- `components/hangouts/HangoutModal.tsx` — `onRecordingUploaded` callback, modal height fix
- `app/compose/page.tsx` — hangout query param pre-fill + useEffect sync
- `app/compose/Editor.tsx` — pass `lockedAccounts` to BeneficiariesInput
- `components/compose/BeneficiariesInput.tsx` — generalized `lockedAccounts` prop
- `lib/utils/composerSdk.ts` — `snapieHangoutComposer` alias
- `package.json` — SDK bump to v0.2.4

## Test plan
- [ ] Record a hangout, upload → redirects to `/compose` with pre-filled content
- [ ] Verify `@snapie` (3%) and `@threespeakfund` (7%) are locked (green tags, no close button)
- [ ] Verify regular (non-hangout) posts only lock `@snapie`
- [ ] Test same-route navigation: be on `/compose`, then navigate to `/compose?hangout=true&...` — fields update
- [ ] Modal layout: controls visible, content scrolls, host panel doesn't overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated hangout library dependency

* **Refactor**
  * Improved recording upload handling implementation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->