### PR TITLE
fix: Raw audio URL for frontend auto-embed + SDK v0.2.4 recording callback

### DIFF
--- a/app/compose/page.tsx
+++ b/app/compose/page.tsx
@@ -21,7 +21,7 @@ const blogComposer = createComposer({
 const HANGOUT_THUMBNAIL = 'https://files.peakd.com/file/peakd-hive/meno/AKDgvpgFrvsp3fEazRgb971Pm8N7NqV3TUt1dF4TUY9798tUJHfZvwHE2BZB56Y.png';
 
 function buildHangoutBody(audioUrl: string, thumbnail: string): string {
-  return `![Hangout Recording](${thumbnail})\n\n<center>\n\n### Listen to this hangout\n\n[Play on 3Speak](${audioUrl})\n\n</center>\n\n---\n\n*Write a description of your hangout here...*`;
+  return `![Hangout Recording](${thumbnail})\n\n<center>\n\n### Listen to this hangout\n\n${audioUrl}\n\n[Play on 3Speak](${audioUrl})\n\n</center>\n\n---\n\n*Write a description of your hangout here...*`;
 }
 
 export default function Home() {


### PR DESCRIPTION
## Summary
- Include raw `audio.3speak.tv` URL in hangout recording posts so frontends (PeakD, Ecency) auto-detect and render the player
- Keep markdown link as fallback for frontends that don't auto-embed
- Use SDK v0.2.4's `onRecordingUploaded` callback (fixes recording upload not redirecting to compose)
- Sync compose prefill state on same-route navigation
- Lock `@snapie` + `@threespeakfund` beneficiaries on recording posts

## Test plan
- [ ] Record hangout, upload → redirects to `/compose` with pre-filled content
- [ ] Published post body contains both raw URL and markdown link
- [ ] Verify PeakD renders the audio player from the raw URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Audio URLs in hangout posts are now displayed as plain text within the post content, in addition to the existing play link, providing improved visibility and direct access to audio files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->