### PR TITLE
fix: Update hangouts SDK to v0.2.6 — speaker promotion UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@hiveio/dhive": "1.3.1-beta",
     "@livekit/components-react": "^2.9.20",
     "@snapie/composer": "workspace:*",
-    "@snapie/hangouts-react": "^0.2.4",
+    "@snapie/hangouts-react": "^0.2.6",
     "@snapie/operations": "workspace:*",
     "@snapie/renderer": "workspace:*",
     "@supabase/supabase-js": "^2.45.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: workspace:*
         version: link:packages/composer
       '@snapie/hangouts-react':
-        specifier: ^0.2.4
-        version: 0.2.4(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
+        specifier: ^0.2.6
+        version: 0.2.6(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
       '@snapie/operations':
         specifier: workspace:*
         version: link:packages/operations
@@ -877,8 +877,8 @@ packages:
   '@snapie/hangouts-core@0.2.1':
     resolution: {integrity: sha512-vWFTXLj711yMJJvLB4IubLn8eDb9J8VV+BPnKOGuNSzgBGSY4sAGyByREmC321X4iSh77D4YTpFmcSsEBMxJyg==}
 
-  '@snapie/hangouts-react@0.2.4':
-    resolution: {integrity: sha512-LvTeMk/ktcaqxjsGSjzB3QAvCi/Xv3ggv/BFxewNfLfiIc7CVSKOkS0UFzr2yWU8Il2LYwd//S7IETCVrgRPIw==}
+  '@snapie/hangouts-react@0.2.6':
+    resolution: {integrity: sha512-UrCIe4sWu3PAG4OA0O0xs77iJPq+cS5QNil44mrXTZTkZD0K7VcKfZsAFEtb/SvXqaMhxv2GgU6mKQShvIoRPA==}
     peerDependencies:
       '@livekit/components-react': ^2.0.0
       livekit-client: ^2.0.0
@@ -4226,7 +4226,7 @@ snapshots:
 
   '@snapie/hangouts-core@0.2.1': {}
 
-  '@snapie/hangouts-react@0.2.4(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
+  '@snapie/hangouts-react@0.2.6(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
     dependencies:
       '@livekit/components-react': 2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@snapie/hangouts-core': 0.2.1


### PR DESCRIPTION
## Summary
- Update `@snapie/hangouts-react` to v0.2.6
- Promoted listeners now get their hand auto-lowered via data channel broadcast
- Mic mute and hand raise buttons shown independently (no more either/or)
- After hand auto-lowers, only the mic button remains

## Test plan
- [ ] As host, promote a listener → their hand auto-lowers, mic button appears
- [ ] Promoted speaker can unmute immediately
- [ ] Listeners still only see the hand raise button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated third-party dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->