### PR TITLE
fix: Gate hangouts on Snapie login and handle account switches

### DIFF
--- a/app/hangouts/page.tsx
+++ b/app/hangouts/page.tsx
@@ -7,7 +7,7 @@ import { useKeychain } from '@/contexts/KeychainContext';
 import { useAutoHangoutLogin } from '@/hooks/useAutoHangoutLogin';
 import { snapieHangoutComposer } from '@/lib/utils/composerSdk';
 import { getLastSnapsContainer, signAndBroadcastWithKeychain } from '@/lib/hive/client-functions';
-import { useToast } from '@chakra-ui/react';
+import { useToast, Center, VStack, Text, Spinner } from '@chakra-ui/react';
 
 const API_URL = process.env.NEXT_PUBLIC_HANGOUTS_API_URL!;
 const LK_URL = process.env.NEXT_PUBLIC_LIVEKIT_URL || 'wss://livekit.3speak.tv';
@@ -20,17 +20,34 @@ function LobbyWithAutoAuth() {
   const isCreating = useRef(false);
   useAutoHangoutLogin(user, auth);
 
-  const handleRoomCreated = useCallback(async (room: Room) => {
+  // Not logged into Snapie — prompt to login
+  if (!user) {
+    return (
+      <Center p={12}>
+        <VStack spacing={3}>
+          <Text fontSize="xl" fontWeight="bold" color="text">Hive Hangouts</Text>
+          <Text color="primary">Log in with Hive Keychain to browse and create hangout rooms.</Text>
+        </VStack>
+      </Center>
+    );
+  }
+
+  // Logged into Snapie but still authenticating with Hangouts API
+  if (auth.isLoading || !auth.isAuthenticated) {
+    return (
+      <Center p={12}>
+        <VStack spacing={3}>
+          <Spinner size="lg" color="primary" />
+          <Text fontSize="sm" color="primary">Connecting to Hangouts...</Text>
+        </VStack>
+      </Center>
+    );
+  }
+
+  const handleRoomCreated = async (room: Room) => {
     isCreating.current = true;
-    if (!user) {
-      openRoom(room.name);
-      isCreating.current = false;
-      return;
-    }
 
     // Post the announcement snap BEFORE opening the room.
-    // Opening the room triggers a Keychain auth popup for hangouts,
-    // which would race with the snap broadcast Keychain request.
     try {
       const { author: parentAuthor, permlink: parentPermlink } = await getLastSnapsContainer();
 
@@ -70,16 +87,14 @@ function LobbyWithAutoAuth() {
       });
     }
 
-    // Now open the room after snap is posted (or failed)
     openRoom(room.name);
     isCreating.current = false;
-  }, [user, openRoom, toast]);
+  };
 
-  const handleJoinRoom = useCallback((name: string) => {
-    // Skip if we're in the create flow — handleRoomCreated handles opening
+  const handleJoinRoom = (name: string) => {
     if (isCreating.current) return;
     openRoom(name);
-  }, [openRoom]);
+  };
 
   return (
     <RoomLobby

--- a/app/hangouts/page.tsx
+++ b/app/hangouts/page.tsx
@@ -7,7 +7,7 @@ import { useKeychain } from '@/contexts/KeychainContext';
 import { useAutoHangoutLogin } from '@/hooks/useAutoHangoutLogin';
 import { snapieHangoutComposer } from '@/lib/utils/composerSdk';
 import { getLastSnapsContainer, signAndBroadcastWithKeychain } from '@/lib/hive/client-functions';
-import { useToast, Center, VStack, Text, Spinner } from '@chakra-ui/react';
+import { useToast, Center, VStack, Text, Spinner, Button } from '@chakra-ui/react';
 
 const API_URL = process.env.NEXT_PUBLIC_HANGOUTS_API_URL!;
 const LK_URL = process.env.NEXT_PUBLIC_LIVEKIT_URL || 'wss://livekit.3speak.tv';
@@ -18,7 +18,7 @@ function LobbyWithAutoAuth() {
   const { openRoom } = useHangout();
   const toast = useToast();
   const isCreating = useRef(false);
-  useAutoHangoutLogin(user, auth);
+  const { retryLogin } = useAutoHangoutLogin(user, auth);
 
   // Not logged into Snapie — prompt to login
   if (!user) {
@@ -32,13 +32,26 @@ function LobbyWithAutoAuth() {
     );
   }
 
-  // Logged into Snapie but still authenticating with Hangouts API
-  if (auth.isLoading || !auth.isAuthenticated) {
+  // Still authenticating with Hangouts API
+  if (auth.isLoading) {
     return (
       <Center p={12}>
         <VStack spacing={3}>
           <Spinner size="lg" color="primary" />
           <Text fontSize="sm" color="primary">Connecting to Hangouts...</Text>
+        </VStack>
+      </Center>
+    );
+  }
+
+  // Auth failed — show error with retry
+  if (!auth.isAuthenticated) {
+    return (
+      <Center p={12}>
+        <VStack spacing={3}>
+          <Text fontSize="xl" fontWeight="bold" color="text">Connection Failed</Text>
+          <Text color="primary">{auth.error || 'Could not connect to Hangouts'}</Text>
+          <Button colorScheme="blue" onClick={() => retryLogin().catch(() => {})}>Retry</Button>
         </VStack>
       </Center>
     );

--- a/hooks/useAutoHangoutLogin.ts
+++ b/hooks/useAutoHangoutLogin.ts
@@ -39,6 +39,8 @@ export function useAutoHangoutLogin(user: string | null, auth: HangoutsAuth) {
         // Don't reset loginAttempted — no automatic retries.
       });
     }
+  // auth.login and auth.logout are stable refs from HangoutsProvider
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user, auth.isAuthenticated, auth.isLoading, auth.username]);
 
   const retryLogin = () => {

--- a/hooks/useAutoHangoutLogin.ts
+++ b/hooks/useAutoHangoutLogin.ts
@@ -1,32 +1,49 @@
 import { useEffect, useRef } from 'react';
 
 interface HangoutsAuth {
+  username: string | null;
   isAuthenticated: boolean;
   isLoading: boolean;
   login: (username: string) => Promise<void>;
+  logout: () => void;
   error: string | null;
 }
 
 /**
  * Auto-authenticates with the Hangouts API using the current Hive user.
- * Only attempts login once per mount. Retry is manual via the returned retryLogin.
+ * Handles account switches by logging out and re-authenticating.
+ * Only attempts login once per user. Retry is manual via retryLogin.
  */
 export function useAutoHangoutLogin(user: string | null, auth: HangoutsAuth) {
-  const loginAttempted = useRef(false);
+  const loginAttempted = useRef<string | null>(null);
 
   useEffect(() => {
-    if (user && !auth.isAuthenticated && !auth.isLoading && !loginAttempted.current) {
-      loginAttempted.current = true;
+    // User logged out of Snapie — logout from hangouts too
+    if (!user && auth.isAuthenticated) {
+      auth.logout();
+      loginAttempted.current = null;
+      return;
+    }
+
+    // User switched accounts — logout old session and re-authenticate
+    if (user && auth.isAuthenticated && auth.username && auth.username !== user) {
+      auth.logout();
+      loginAttempted.current = null;
+      return; // Will re-trigger on next render after logout
+    }
+
+    // Auto-login if user is set but not authenticated
+    if (user && !auth.isAuthenticated && !auth.isLoading && loginAttempted.current !== user) {
+      loginAttempted.current = user;
       auth.login(user).catch(() => {
         // Don't reset loginAttempted — no automatic retries.
-        // User can retry manually via retryLogin().
       });
     }
-  }, [user, auth.isAuthenticated, auth.isLoading]);
+  }, [user, auth.isAuthenticated, auth.isLoading, auth.username]);
 
   const retryLogin = () => {
     if (user) {
-      loginAttempted.current = true;
+      loginAttempted.current = user;
       return auth.login(user);
     }
     return Promise.reject(new Error('No user'));


### PR DESCRIPTION
## Summary
- If not logged into Snapie, show "Log in with Hive Keychain" message instead of SDK's login form
- Detect account switches and re-authenticate hangouts session with the new user
- `useAutoHangoutLogin` now tracks username and handles logout/re-login on user change

## Problem
1. Unauthenticated users saw the SDK's own login form on `/hangouts`, which let them auth with hangouts without being logged into Snapie — confusing
2. Switching Snapie accounts (meno → cguitars) kept the old hangouts session token, causing permission errors

## Test plan
- [ ] Visit `/hangouts` logged out → see "Log in with Hive Keychain" message
- [ ] Log in → auto-authenticates with hangouts, lobby loads
- [ ] Switch accounts → hangouts session refreshes with new user
- [ ] Log out → hangouts session cleared, back to login message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show explicit login prompt, “Connecting to Hangouts…” spinner, and a Retry button when needed, preventing room creation until connected.
* **Bug Fixes**
  * Prevents redundant automatic logins for the same user and strengthens account-switch handling by auto-logging out when accounts change.
  * Ensures room creation/join flows only run after successful authentication, reducing mis‑directed room opens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->