### PR TITLE
fix: Update hangouts SDK to v0.2.7 — single host controls panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@hiveio/dhive": "1.3.1-beta",
     "@livekit/components-react": "^2.9.20",
     "@snapie/composer": "workspace:*",
-    "@snapie/hangouts-react": "^0.2.6",
+    "@snapie/hangouts-react": "^0.2.7",
     "@snapie/operations": "workspace:*",
     "@snapie/renderer": "workspace:*",
     "@supabase/supabase-js": "^2.45.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: workspace:*
         version: link:packages/composer
       '@snapie/hangouts-react':
-        specifier: ^0.2.6
-        version: 0.2.6(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
+        specifier: ^0.2.7
+        version: 0.2.7(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
       '@snapie/operations':
         specifier: workspace:*
         version: link:packages/operations
@@ -877,8 +877,8 @@ packages:
   '@snapie/hangouts-core@0.2.1':
     resolution: {integrity: sha512-vWFTXLj711yMJJvLB4IubLn8eDb9J8VV+BPnKOGuNSzgBGSY4sAGyByREmC321X4iSh77D4YTpFmcSsEBMxJyg==}
 
-  '@snapie/hangouts-react@0.2.6':
-    resolution: {integrity: sha512-UrCIe4sWu3PAG4OA0O0xs77iJPq+cS5QNil44mrXTZTkZD0K7VcKfZsAFEtb/SvXqaMhxv2GgU6mKQShvIoRPA==}
+  '@snapie/hangouts-react@0.2.7':
+    resolution: {integrity: sha512-SqNynB+zOufYcC/MlhBVqRR7+cqrTE4to071n+v93rQC1FEeQXJblxUJo1qBfnQK/y2XCjGca1W0Y7q6t5obUQ==}
     peerDependencies:
       '@livekit/components-react': ^2.0.0
       livekit-client: ^2.0.0
@@ -4226,7 +4226,7 @@ snapshots:
 
   '@snapie/hangouts-core@0.2.1': {}
 
-  '@snapie/hangouts-react@0.2.6(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
+  '@snapie/hangouts-react@0.2.7(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
     dependencies:
       '@livekit/components-react': 2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@snapie/hangouts-core': 0.2.1


### PR DESCRIPTION
## Summary
- Update `@snapie/hangouts-react` to v0.2.7
- Only one host controls panel open at a time (clicking a new speaker tile closes the previous panel)

## Test plan
- [ ] As host, click a speaker tile → panel opens
- [ ] Click a different speaker tile → first panel closes, new one opens
- [ ] Click same tile again → panel closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->