### PR TITLE
feat: Enable video & screen share for premium hangout users

### DIFF
--- a/components/hangouts/HangoutModal.tsx
+++ b/components/hangouts/HangoutModal.tsx
@@ -74,6 +74,7 @@ function HangoutRoomWithAuth({ roomName, onClose }: { roomName: string; onClose:
         roomName={roomName}
         onLeave={onClose}
         onRecordingUploaded={handleRecordingUploaded}
+        video
         embedded
         maxHeight="78vh"
       />

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@hiveio/dhive": "1.3.1-beta",
     "@livekit/components-react": "^2.9.20",
     "@snapie/composer": "workspace:*",
-    "@snapie/hangouts-react": "^0.2.7",
+    "@snapie/hangouts-react": "^0.3.4",
     "@snapie/operations": "workspace:*",
     "@snapie/renderer": "workspace:*",
     "@supabase/supabase-js": "^2.45.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: workspace:*
         version: link:packages/composer
       '@snapie/hangouts-react':
-        specifier: ^0.2.7
-        version: 0.2.7(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
+        specifier: ^0.3.4
+        version: 0.3.4(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
       '@snapie/operations':
         specifier: workspace:*
         version: link:packages/operations
@@ -874,11 +874,11 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@snapie/hangouts-core@0.2.1':
-    resolution: {integrity: sha512-vWFTXLj711yMJJvLB4IubLn8eDb9J8VV+BPnKOGuNSzgBGSY4sAGyByREmC321X4iSh77D4YTpFmcSsEBMxJyg==}
+  '@snapie/hangouts-core@0.3.0':
+    resolution: {integrity: sha512-3GQfHptlUWK7quBi4ZQwA5eEtMT+t5ROloyI7Rh0VwsoF8mQorRdJo0UcOtBFvRNHfevdbW/mAbxiLr6HNPqow==}
 
-  '@snapie/hangouts-react@0.2.7':
-    resolution: {integrity: sha512-SqNynB+zOufYcC/MlhBVqRR7+cqrTE4to071n+v93rQC1FEeQXJblxUJo1qBfnQK/y2XCjGca1W0Y7q6t5obUQ==}
+  '@snapie/hangouts-react@0.3.4':
+    resolution: {integrity: sha512-ERwofYxOXXRGqjWJ4RZDPfM89aPaiHHRuszyMlUtSYa7E7YqAQjngMxs0ydFq3HhCJsBOvA5M3rb7zk6WAP6/A==}
     peerDependencies:
       '@livekit/components-react': ^2.0.0
       livekit-client: ^2.0.0
@@ -4224,12 +4224,12 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@snapie/hangouts-core@0.2.1': {}
+  '@snapie/hangouts-core@0.3.0': {}
 
-  '@snapie/hangouts-react@0.2.7(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
+  '@snapie/hangouts-react@0.3.4(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
     dependencies:
       '@livekit/components-react': 2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
-      '@snapie/hangouts-core': 0.2.1
+      '@snapie/hangouts-core': 0.3.0
       livekit-client: 2.18.0(@types/dom-mediacapture-record@1.0.22)
       react: 18.3.1
 


### PR DESCRIPTION
## Summary
- Update `@snapie/hangouts-react` to v0.3.4 (video, screen share, premium gating)
- Add `video` prop to `HangoutsRoom` in the modal
- Premium users see camera toggle + screen share buttons
- Non-premium users see audio-only (server-enforced via LiveKit token restrictions)
- Banned users get 403 on all hangout routes

## How it works
- Server checks 3speak's `embed-users` MongoDB on room create/join
- Premium users get full publish token (audio + video + screen share)
- Non-premium users get `canPublishSources: [MICROPHONE]` only
- SDK internally does `const videoEnabled = video && room.isPremium`
- No frontend premium check needed — one prop, server handles the rest

## Test plan
- [ ] Premium user: camera + screen share buttons visible in room controls
- [ ] Non-premium user: only mic toggle, no camera/screen share buttons
- [ ] Screen share renders as focused view with fullscreen toggle
- [ ] Video tiles render at 3x size above audio-only avatars
- [ ] Recording still works for all hosts regardless of premium

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video capability is now enabled for hangout sessions, allowing participants to communicate via video alongside existing features.

* **Chores**
  * Updated dependencies to support new functionality in hangout sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->