### PR TITLE
feat: Prevent screen sleep during hangouts (Wake Lock API)

### DIFF
--- a/components/hangouts/HangoutModal.tsx
+++ b/components/hangouts/HangoutModal.tsx
@@ -5,6 +5,7 @@ import { Modal, ModalOverlay, ModalContent, ModalCloseButton, Center, Spinner, T
 import { HangoutsProvider, HangoutsRoom, useHangoutsAuth } from '@snapie/hangouts-react';
 import { useKeychain } from '@/contexts/KeychainContext';
 import { useAutoHangoutLogin } from '@/hooks/useAutoHangoutLogin';
+import { useWakeLock } from '@/hooks/useWakeLock';
 import '@snapie/hangouts-react/src/styles/hangouts.css';
 
 const API_URL = process.env.NEXT_PUBLIC_HANGOUTS_API_URL!;
@@ -22,6 +23,7 @@ function HangoutRoomWithAuth({ roomName, onClose }: { roomName: string; onClose:
   const { user } = useKeychain();
   const auth = useHangoutsAuth();
   const { retryLogin } = useAutoHangoutLogin(user, auth);
+  useWakeLock(auth.isAuthenticated);
   const router = useRouter();
 
   const handleRecordingUploaded = useCallback((result: { permlink: string; cid: string; playUrl: string }) => {

--- a/hooks/useWakeLock.ts
+++ b/hooks/useWakeLock.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+
+export function useWakeLock(active: boolean) {
+  const lockRef = useRef<WakeLockSentinel | null>(null);
+
+  useEffect(() => {
+    if (!active || typeof navigator === 'undefined' || !('wakeLock' in navigator)) return;
+
+    let cancelled = false;
+
+    async function acquire() {
+      try {
+        lockRef.current = await navigator.wakeLock.request('screen');
+      } catch {
+        // Permission denied or not supported — fail silently
+      }
+    }
+
+    function onVisibilityChange() {
+      if (document.visibilityState === 'visible' && !lockRef.current?.released && !cancelled) {
+        acquire();
+      }
+    }
+
+    acquire();
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      lockRef.current?.release().catch(() => {});
+      lockRef.current = null;
+    };
+  }, [active]);
+}

--- a/hooks/useWakeLock.ts
+++ b/hooks/useWakeLock.ts
@@ -10,7 +10,12 @@ export function useWakeLock(active: boolean) {
 
     async function acquire() {
       try {
-        lockRef.current = await navigator.wakeLock.request('screen');
+        const sentinel = await navigator.wakeLock.request('screen');
+        if (cancelled) {
+          sentinel.release().catch(() => {});
+          return;
+        }
+        lockRef.current = sentinel;
       } catch {
         // Permission denied or not supported — fail silently
       }

--- a/hooks/useWakeLock.ts
+++ b/hooks/useWakeLock.ts
@@ -17,7 +17,7 @@ export function useWakeLock(active: boolean) {
     }
 
     function onVisibilityChange() {
-      if (document.visibilityState === 'visible' && !lockRef.current?.released && !cancelled) {
+      if (document.visibilityState === 'visible' && !cancelled && (!lockRef.current || lockRef.current.released)) {
         acquire();
       }
     }


### PR DESCRIPTION
## Summary

- Adds `useWakeLock` hook that acquires `navigator.wakeLock.request('screen')` while the user is in a hangout room
- Re-acquires the lock on `visibilitychange` since the OS silently releases it when the tab is backgrounded
- Releases cleanly on unmount (user leaves room or closes modal)
- Activated only when `auth.isAuthenticated` — not during loading/auth screens
- Fails silently on unsupported browsers (no regression risk)

**Browser support:** Chrome/Edge 84+, Firefox 126+, Safari 16.4+

## Test plan

- [ ] Join a hangout on mobile, leave the phone idle — screen should stay on
- [ ] Switch tabs mid-call, return — wake lock should re-acquire (check DevTools > Application > Wake Locks)
- [ ] Leave the room — wake lock should release
- [ ] Test on an older/unsupported browser — should join and behave normally

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device screen stays active during authenticated hangout sessions to prevent auto-sleep during video calls or active engagement. The app will automatically re-establish the screen lock when returning to a visible session and release it when the session ends or the user is no longer authenticated. This improves continuity for longer meetings and reduces interruptions from device sleep.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->