### PR TITLE
feat: optimistic payout updates on vote

### DIFF
--- a/components/homepage/Snap.tsx
+++ b/components/homepage/Snap.tsx
@@ -11,6 +11,7 @@ import HivePostPreview from '@/components/shared/HivePostPreview';
 import HangoutPreviewCard from '@/components/hangouts/HangoutPreviewCard';
 import markdownRenderer from '@/lib/utils/MarkdownRenderer';
 import { useCurrencyDisplay } from '@/hooks/useCurrencyDisplay';
+import { useVoteCalculator } from '@/hooks/useVoteCalculator';
 import { vote, commentWithKeychain } from '@/lib/hive/client-functions';
 import NextLink from 'next/link';
 import VoteControls from './VoteSlider';
@@ -29,7 +30,9 @@ const Snap = memo(({ comment, onOpen, setReply, setConversation, level = 0 }: Sn
     const [isEditModalOpen, setIsEditModalOpen] = useState(false);
     const [editedBody, setEditedBody] = useState(comment.body);
     const [isEditing, setIsEditing] = useState(false);
-    const payoutDisplay = useCurrencyDisplay(comment);
+    const [optimisticDeltaHBD, setOptimisticDeltaHBD] = useState(0);
+    const { calculateDelta } = useVoteCalculator(user);
+    const payoutDisplay = useCurrencyDisplay(comment, optimisticDeltaHBD);
     const toast = useToast();
     
     // Check if user can edit (is author and post is less than 7 days old)
@@ -243,6 +246,8 @@ const Snap = memo(({ comment, onOpen, setReply, setConversation, level = 0 }: Sn
                         initialVoted={comment.active_votes?.some(item => item.voter === user) ?? false}
                         initialVoteCount={comment.active_votes?.length || 0}
                         onVote={handleVote}
+                        onVoteOptimistic={(weight) => setOptimisticDeltaHBD(calculateDelta(weight))}
+                        onVoteRollback={() => setOptimisticDeltaHBD(0)}
                     />
                     <HStack spacing={4}>
                         {/* Reply button - opens reply modal */}

--- a/components/homepage/VoteSlider.tsx
+++ b/components/homepage/VoteSlider.tsx
@@ -24,9 +24,11 @@ const VoteControls = memo(({ initialVoted, initialVoteCount, onVote, onVoteOptim
         const previousCount = voteCount;
         
         setVoted(true);
-        setVoteCount(prev => prev + 1);
+        if (!wasVoted) {
+            setVoteCount(prev => prev + 1);
+            onVoteOptimistic?.(sliderValue);
+        }
         setIsVoting(true);
-        onVoteOptimistic?.(sliderValue);
 
         try {
             const result = await onVote(sliderValue);

--- a/components/homepage/VoteSlider.tsx
+++ b/components/homepage/VoteSlider.tsx
@@ -6,9 +6,11 @@ interface VoteControlsProps {
     initialVoted: boolean;
     initialVoteCount: number;
     onVote: (weight: number) => Promise<any>;
+    onVoteOptimistic?: (weight: number) => void;
+    onVoteRollback?: () => void;
 }
 
-const VoteControls = memo(({ initialVoted, initialVoteCount, onVote }: VoteControlsProps) => {
+const VoteControls = memo(({ initialVoted, initialVoteCount, onVote, onVoteOptimistic, onVoteRollback }: VoteControlsProps) => {
     const [voted, setVoted] = useState(initialVoted);
     const [voteCount, setVoteCount] = useState(initialVoteCount);
     const [showSlider, setShowSlider] = useState(false);
@@ -24,14 +26,15 @@ const VoteControls = memo(({ initialVoted, initialVoteCount, onVote }: VoteContr
         setVoted(true);
         setVoteCount(prev => prev + 1);
         setIsVoting(true);
-        
+        onVoteOptimistic?.(sliderValue);
+
         try {
             const result = await onVote(sliderValue);
-            
+
             if (!result.success) {
-                // Rollback on failure
                 setVoted(wasVoted);
                 setVoteCount(previousCount);
+                onVoteRollback?.();
                 toast({
                     title: 'Vote Failed',
                     description: 'Failed to vote. Please try again.',
@@ -42,9 +45,9 @@ const VoteControls = memo(({ initialVoted, initialVoteCount, onVote }: VoteContr
                 setShowSlider(false);
             }
         } catch (error) {
-            // Rollback on error
             setVoted(wasVoted);
             setVoteCount(previousCount);
+            onVoteRollback?.();
             toast({
                 title: 'Vote Failed',
                 description: 'An error occurred. Please try again.',

--- a/components/shared/InteractionBar.tsx
+++ b/components/shared/InteractionBar.tsx
@@ -5,6 +5,7 @@ import { FaHeart, FaComment, FaRegHeart, FaShare } from 'react-icons/fa';
 import { useAioha } from '@aioha/react-ui';
 import { vote } from '@/lib/hive/client-functions';
 import { useCurrencyDisplay } from '@/hooks/useCurrencyDisplay';
+import { useVoteCalculator } from '@/hooks/useVoteCalculator';
 
 interface InteractionBarProps {
     post: Discussion;
@@ -24,7 +25,9 @@ export default function InteractionBar({
     const [showSlider, setShowSlider] = useState(false);
     const [voted, setVoted] = useState(false);
     const [voteCount, setVoteCount] = useState(post.active_votes?.length || 0);
-    const payoutDisplay = useCurrencyDisplay(post);
+    const [optimisticDeltaHBD, setOptimisticDeltaHBD] = useState(0);
+    const { calculateDelta } = useVoteCalculator(user);
+    const payoutDisplay = useCurrencyDisplay(post, optimisticDeltaHBD);
     const toast = useToast();
 
     // Update voted state when user changes
@@ -64,13 +67,15 @@ export default function InteractionBar({
         // Optimistic update
         const wasVoted = voted;
         const previousCount = voteCount;
-        
+        const previousDelta = optimisticDeltaHBD;
+
         setVoted(true);
         if (!wasVoted) {
             setVoteCount(prev => prev + 1);
+            setOptimisticDeltaHBD(calculateDelta(sliderValue));
         }
         setShowSlider(false);
-        
+
         // Send to blockchain
         try {
             const voteResult = await vote({
@@ -79,11 +84,12 @@ export default function InteractionBar({
                 permlink: post.permlink,
                 weight: sliderValue * 100
             });
-            
+
             if (!voteResult.success) {
                 // Rollback on failure
                 setVoted(wasVoted);
                 setVoteCount(previousCount);
+                setOptimisticDeltaHBD(previousDelta);
                 toast({
                     title: 'Vote Failed',
                     description: 'Failed to vote. Please try again.',
@@ -95,6 +101,7 @@ export default function InteractionBar({
             // Rollback on error
             setVoted(wasVoted);
             setVoteCount(previousCount);
+            setOptimisticDeltaHBD(previousDelta);
             toast({
                 title: 'Vote Failed',
                 description: 'An error occurred. Please try again.',

--- a/hooks/useCurrencyDisplay.ts
+++ b/hooks/useCurrencyDisplay.ts
@@ -14,35 +14,32 @@ import { convertHBDToDisplayCurrency } from '@/lib/utils/currencyConverter';
  * @param post - The post or comment object with payout information
  * @returns Formatted currency string (e.g., "R$25.50", "$5.123")
  */
-export function useCurrencyDisplay(post: any): string {
+export function useCurrencyDisplay(post: any, optimisticDeltaHBD: number = 0): string {
   const [displayValue, setDisplayValue] = useState<string>('');
   const targetCurrency = process.env.NEXT_PUBLIC_DISPLAY_CURRENCY;
 
   useEffect(() => {
     async function convertValue() {
-      // Get the HBD payout value
       const hbdValue = getPayoutValue(post);
-      const hbdAmount = parseFloat(hbdValue);
+      const baseAmount = parseFloat(hbdValue);
+      const hbdAmount = (isNaN(baseAmount) ? 0 : baseAmount) + optimisticDeltaHBD;
 
-      // If no valid amount, display zero
-      if (isNaN(hbdAmount)) {
+      if (hbdAmount === 0 && isNaN(baseAmount)) {
         setDisplayValue('$0.000');
         return;
       }
 
-      // If no target currency or empty string, return HBD value as-is
       if (!targetCurrency || targetCurrency.trim() === '') {
-        setDisplayValue(`$${hbdValue}`);
+        setDisplayValue(`$${hbdAmount.toFixed(3)}`);
         return;
       }
 
-      // Convert to target currency
       const converted = await convertHBDToDisplayCurrency(hbdAmount, targetCurrency);
       setDisplayValue(converted);
     }
 
     convertValue();
-  }, [post, targetCurrency]);
+  }, [post, targetCurrency, optimisticDeltaHBD]);
 
   return displayValue || '$0.000';
 }

--- a/hooks/useVoteCalculator.ts
+++ b/hooks/useVoteCalculator.ts
@@ -7,7 +7,9 @@ interface HiveGlobals {
   medianPrice: number;
 }
 
-// Module-level caches so every component shares one fetch per session
+// Module-level caches so every component shares one fetch per session.
+// accountCache is intentionally not invalidated after votes — the estimate
+// drifts slightly as mana regenerates, which is acceptable for a UI hint.
 let globalsCache: HiveGlobals | null = null;
 let globalsFetchPromise: Promise<HiveGlobals> | null = null;
 const accountCache = new Map<string, any>();
@@ -16,15 +18,19 @@ async function fetchGlobals(): Promise<HiveGlobals> {
   if (globalsCache) return globalsCache;
   if (!globalsFetchPromise) {
     globalsFetchPromise = (async () => {
-      const [rewardFund, priceData] = await Promise.all([
-        HiveClient.database.call('get_reward_fund', ['post']),
-        HiveClient.database.call('get_current_median_history_price', []),
-      ]);
-      const base = parseFloat(priceData.base);
-      const quote = parseFloat(priceData.quote);
-      globalsCache = { rewardFund, medianPrice: base / quote };
-      globalsFetchPromise = null;
-      return globalsCache;
+      try {
+        const [rewardFund, priceData] = await Promise.all([
+          HiveClient.database.call('get_reward_fund', ['post']),
+          HiveClient.database.call('get_current_median_history_price', []),
+        ]);
+        const base = parseFloat(priceData.base);
+        const quote = parseFloat(priceData.quote);
+        globalsCache = { rewardFund, medianPrice: base / quote };
+        return globalsCache;
+      } finally {
+        // Always clear so a failed fetch can be retried on next call
+        globalsFetchPromise = null;
+      }
     })();
   }
   return globalsFetchPromise;

--- a/hooks/useVoteCalculator.ts
+++ b/hooks/useVoteCalculator.ts
@@ -1,0 +1,68 @@
+import { useState, useEffect } from 'react';
+import HiveClient from '@/lib/hive/hiveclient';
+import { calculateVoteValue } from '@/lib/hive/voteValueCalculator';
+
+interface HiveGlobals {
+  rewardFund: { recent_claims: string; reward_balance: string };
+  medianPrice: number;
+}
+
+// Module-level caches so every component shares one fetch per session
+let globalsCache: HiveGlobals | null = null;
+let globalsFetchPromise: Promise<HiveGlobals> | null = null;
+const accountCache = new Map<string, any>();
+
+async function fetchGlobals(): Promise<HiveGlobals> {
+  if (globalsCache) return globalsCache;
+  if (!globalsFetchPromise) {
+    globalsFetchPromise = (async () => {
+      const [rewardFund, priceData] = await Promise.all([
+        HiveClient.database.call('get_reward_fund', ['post']),
+        HiveClient.database.call('get_current_median_history_price', []),
+      ]);
+      const base = parseFloat(priceData.base);
+      const quote = parseFloat(priceData.quote);
+      globalsCache = { rewardFund, medianPrice: base / quote };
+      globalsFetchPromise = null;
+      return globalsCache;
+    })();
+  }
+  return globalsFetchPromise;
+}
+
+async function fetchAccount(username: string): Promise<any | null> {
+  if (accountCache.has(username)) return accountCache.get(username);
+  const accounts = await HiveClient.database.getAccounts([username]);
+  if (accounts?.[0]) accountCache.set(username, accounts[0]);
+  return accounts?.[0] || null;
+}
+
+/**
+ * Returns a `calculateDelta(weight)` function that estimates the HBD value
+ * a vote of the given weight (0–100) would add to a post's payout.
+ *
+ * Data is fetched once per session and shared across all callers via
+ * module-level caches, so mounting many vote-capable components is cheap.
+ */
+export function useVoteCalculator(username: string | null) {
+  const [globals, setGlobals] = useState<HiveGlobals | null>(globalsCache);
+  const [account, setAccount] = useState<any>(
+    username ? (accountCache.get(username) ?? null) : null
+  );
+
+  useEffect(() => {
+    fetchGlobals().then(setGlobals).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!username) return;
+    fetchAccount(username).then(setAccount).catch(() => {});
+  }, [username]);
+
+  function calculateDelta(weight: number): number {
+    if (!globals || !account) return 0;
+    return calculateVoteValue(account, globals.rewardFund, weight, globals.medianPrice);
+  }
+
+  return { calculateDelta };
+}

--- a/lib/hive/voteValueCalculator.ts
+++ b/lib/hive/voteValueCalculator.ts
@@ -19,10 +19,12 @@ export function calculateVoteValue(
     return parseFloat(typeof v === 'string' ? v : String(v));
   };
 
-  const effectiveVests =
+  const effectiveVests = Math.max(
     parseVests(account.vesting_shares) +
     parseVests(account.received_vesting_shares) -
-    parseVests(account.delegated_vesting_shares);
+    parseVests(account.delegated_vesting_shares),
+    0
+  );
 
   const weightFraction = Math.min(Math.max(voteWeight / 100, 0), 1);
   const rshares = (effectiveVests * 1e6 * weightFraction) / 50;

--- a/lib/hive/voteValueCalculator.ts
+++ b/lib/hive/voteValueCalculator.ts
@@ -1,0 +1,37 @@
+/**
+ * Calculates the estimated HBD value of a vote.
+ *
+ * Formula (post-HF20): voting power does NOT affect dollar value — only
+ * effective VESTS and the weight slider do.
+ *
+ *   rshares        = effectiveVests * 1e6 * (weight / 100) / 50
+ *   voteValueHIVE  = (rshares / recentClaims) * rewardBalance
+ *   voteValueHBD   = voteValueHIVE * medianPrice
+ */
+export function calculateVoteValue(
+  account: any,
+  rewardFund: { recent_claims: string; reward_balance: string },
+  voteWeight: number, // 0–100 (slider percentage)
+  medianPrice: number // HBD per HIVE
+): number {
+  const parseVests = (v: any): number => {
+    if (!v) return 0;
+    return parseFloat(typeof v === 'string' ? v : String(v));
+  };
+
+  const effectiveVests =
+    parseVests(account.vesting_shares) +
+    parseVests(account.received_vesting_shares) -
+    parseVests(account.delegated_vesting_shares);
+
+  const weightFraction = Math.min(Math.max(voteWeight / 100, 0), 1);
+  const rshares = (effectiveVests * 1e6 * weightFraction) / 50;
+
+  const recentClaims = parseFloat(rewardFund.recent_claims);
+  const rewardBalance = parseFloat(rewardFund.reward_balance);
+
+  if (!recentClaims || !rewardBalance) return 0;
+
+  const voteValueHIVE = (rshares / recentClaims) * rewardBalance;
+  return voteValueHIVE * medianPrice;
+}


### PR DESCRIPTION
## Summary

- Adds a client-side vote value estimator (`lib/hive/voteValueCalculator.ts`) using the standard Hive rshares formula, ported from hivesnaps
- Introduces `hooks/useVoteCalculator.ts` — fetches `rewardFund` + `medianPrice` + voter account once per session via module-level caching; returns a `calculateDelta(weight)` function
- `useCurrencyDisplay` now accepts an optional `optimisticDeltaHBD` param and adds it to the base payout before currency conversion
- `VoteSlider` (snaps) gains `onVoteOptimistic` / `onVoteRollback` callbacks, fired at the same moment as the icon fill
- `InteractionBar` (posts) and `Snap.tsx` (comments) both wire up the delta state with full rollback on vote failure

## Behaviour

When a user votes, the payout display updates immediately — same frame as the heart icon filling — without waiting for blockchain confirmation. If the vote fails, both the icon and the payout roll back.

## Test plan

- [ ] Vote on a snap — heart fills and payout increments instantly
- [ ] Vote on a blog post (feed card and detail page) — same behaviour
- [ ] Simulate a failed vote — icon and payout both revert
- [ ] Re-vote on an already-voted post — no duplicate delta applied
- [ ] Vote with a non-100% slider weight — delta scales proportionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added instant payout feedback when voting—the displayed payout now updates immediately as you adjust your vote weight, providing real-time feedback before blockchain confirmation completes
  * Vote display automatically reverts to the previous value if the transaction fails, ensuring accuracy with the confirmed blockchain state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->