### PR TITLE
fix: coerce aioha user undefined to null for useVoteCalculator

### DIFF
--- a/components/homepage/Snap.tsx
+++ b/components/homepage/Snap.tsx
@@ -31,7 +31,7 @@ const Snap = memo(({ comment, onOpen, setReply, setConversation, level = 0 }: Sn
     const [editedBody, setEditedBody] = useState(comment.body);
     const [isEditing, setIsEditing] = useState(false);
     const [optimisticDeltaHBD, setOptimisticDeltaHBD] = useState(0);
-    const { calculateDelta } = useVoteCalculator(user);
+    const { calculateDelta } = useVoteCalculator(user ?? null);
     const payoutDisplay = useCurrencyDisplay(comment, optimisticDeltaHBD);
     const toast = useToast();
     

--- a/components/shared/InteractionBar.tsx
+++ b/components/shared/InteractionBar.tsx
@@ -26,7 +26,7 @@ export default function InteractionBar({
     const [voted, setVoted] = useState(false);
     const [voteCount, setVoteCount] = useState(post.active_votes?.length || 0);
     const [optimisticDeltaHBD, setOptimisticDeltaHBD] = useState(0);
-    const { calculateDelta } = useVoteCalculator(user);
+    const { calculateDelta } = useVoteCalculator(user ?? null);
     const payoutDisplay = useCurrencyDisplay(post, optimisticDeltaHBD);
     const toast = useToast();
 


### PR DESCRIPTION
## Summary

- `useAioha()` types `user` as `string | undefined`, but `useVoteCalculator` expects `string | null`
- This mismatch was causing the Vercel build to fail with a TypeScript compile error
- Fixed by passing `user ?? null` at both call sites (`Snap.tsx` and `InteractionBar.tsx`)

## Test plan

- [ ] Vercel preview build passes TypeScript compile step
- [ ] Voting on snaps and posts still works (no behavioural change — `undefined` and `null` are both falsy and handled identically in the hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)