### PR TITLE
fix: sync aioha modal dark theme with Chakra and fix TS error

### DIFF
--- a/components/auth/LoginModal.tsx
+++ b/components/auth/LoginModal.tsx
@@ -18,7 +18,6 @@ export default function LoginModal({
   onClose,
   loginTitle = 'Login',
   loginOptions,
-  forceShowProviders,
 }: LoginModalProps) {
   return (
     <AiohaModal
@@ -27,7 +26,6 @@ export default function LoginModal({
       onClose={onClose}
       loginTitle={loginTitle}
       loginOptions={loginOptions}
-      forceShowProviders={forceShowProviders}
     />
   );
 }

--- a/components/auth/login-modal.css
+++ b/components/auth/login-modal.css
@@ -100,11 +100,43 @@
   }
 }
 
-/* Always show the light-mode icon variant, regardless of OS dark-mode setting.
-   AiohaModal renders two <svg>s per provider with iconDark (HiveAuth / Ledger)
-   — one `class="... block dark:hidden"` (for light bg), one `class="... hidden
-   dark:block"` (for dark bg). Our modal always has a light background, so we
-   always want the light-bg icon. Matching by attribute substring hits both
-   with-escape (light-mode CSS) and without-escape (HTML class attribute). */
-#aioha-modal svg[class*="dark:block"] { display: none !important; }
-#aioha-modal svg[class*="dark:hidden"] { display: block !important; }
+/* Show the correct icon variant based on the app's actual theme.
+   AiohaModal renders two <svg>s per provider: one with `dark:hidden` (light-bg
+   icon) and one with `dark:block` (dark-bg icon). Chakra's dark mode uses
+   data-theme="dark" on <html>, so we scope the icon swap to that attribute. */
+html:not([data-theme="dark"]) #aioha-modal svg[class*="dark:block"] { display: none !important; }
+html:not([data-theme="dark"]) #aioha-modal svg[class*="dark:hidden"] { display: block !important; }
+
+/* Sync aioha modal dark theme with Chakra's [data-theme="dark"] attribute.
+   public/aioha-modal.css uses @media (prefers-color-scheme:dark) which only
+   responds to OS preference, not the app's Chakra-controlled dark mode.
+   These rules ensure the modal matches the app theme regardless of OS setting. */
+[data-theme="dark"] .dark\:block { display: block !important; }
+[data-theme="dark"] .dark\:hidden { display: none !important; }
+[data-theme="dark"] .dark\:bg-gray-600 { background-color: var(--color-gray-600) !important; }
+[data-theme="dark"] .dark\:bg-gray-700 { background-color: var(--color-gray-700) !important; }
+[data-theme="dark"] .dark\:bg-gray-800 { background-color: var(--color-gray-800) !important; }
+[data-theme="dark"] .dark\:bg-green-900 { background-color: var(--color-green-900) !important; }
+[data-theme="dark"] .dark\:fill-gray-100 { fill: var(--color-gray-100) !important; }
+[data-theme="dark"] .dark\:text-gray-100 { color: var(--color-gray-100) !important; }
+[data-theme="dark"] .dark\:text-gray-300 { color: var(--color-gray-300) !important; }
+[data-theme="dark"] .dark\:text-gray-400 { color: var(--color-gray-400) !important; }
+[data-theme="dark"] .dark\:text-gray-500 { color: var(--color-gray-500) !important; }
+[data-theme="dark"] .dark\:text-green-200 { color: var(--color-green-200) !important; }
+[data-theme="dark"] .dark\:text-red-400 { color: var(--color-red-400) !important; }
+[data-theme="dark"] .dark\:text-white { color: var(--color-white) !important; }
+[data-theme="dark"] .dark\:border-gray-600,
+[data-theme="dark"] :where(.dark\:divide-gray-600 > :not(:last-child)) { border-color: var(--color-gray-600) !important; }
+[data-theme="dark"] .dark\:border-gray-700 { border-color: var(--color-gray-700) !important; }
+[data-theme="dark"] .dark\:border-red-800 { border-color: var(--color-red-800) !important; }
+[data-theme="dark"] .dark\:placeholder-gray-400::placeholder { color: var(--color-gray-400) !important; }
+[data-theme="dark"] .dark\:hover\:border-gray-500:hover { border-color: var(--color-gray-500) !important; }
+[data-theme="dark"] .dark\:hover\:border-gray-600:hover { border-color: var(--color-gray-600) !important; }
+[data-theme="dark"] .dark\:hover\:bg-gray-500:hover { background-color: var(--color-gray-500) !important; }
+[data-theme="dark"] .dark\:hover\:bg-gray-600:hover { background-color: var(--color-gray-600) !important; }
+[data-theme="dark"] .dark\:hover\:bg-gray-700:hover { background-color: var(--color-gray-700) !important; }
+[data-theme="dark"] .dark\:hover\:bg-gray-800:hover { background-color: var(--color-gray-800) !important; }
+[data-theme="dark"] .dark\:hover\:text-white:hover { color: var(--color-white) !important; }
+[data-theme="dark"] .dark\:focus\:border-white:focus { border-color: var(--color-white) !important; }
+[data-theme="dark"] .dark\:focus\:ring-gray-600:focus { --tw-ring-color: var(--color-gray-600) !important; }
+[data-theme="dark"] .dark\:focus\:ring-gray-700:focus { --tw-ring-color: var(--color-gray-700) !important; }


### PR DESCRIPTION
## Summary

- **Dark theme mismatch**: `public/aioha-modal.css` uses `@media (prefers-color-scheme: dark)` (OS-level) while Chakra UI controls dark mode via `data-theme="dark"` on `<html>`. When the OS is light but the app is forced dark (`initialColorMode: "dark"`), the modal rendered white inside a dark UI. Fixed by adding `[data-theme="dark"]` scoped overrides for every `dark:*` class the aioha modal uses in `login-modal.css`.
- **Icon variant fix**: Icon overrides that forced light-mode icons were updated to only apply when `html:not([data-theme="dark"])`, so the correct icon variant shows in both modes.
- **TypeScript fix**: `forceShowProviders` was being forwarded to `AiohaModal` but is not in its `ModalProps` type, causing a `TS2322` build error on Vercel. Removed the unsupported prop from the JSX call (it was not used by the component).

## Test plan

- [ ] Open the login modal in the app (dark mode) — modal should have a dark background matching the rest of the UI
- [ ] Verify wallet provider icons are visible and use the correct variant in dark mode
- [ ] Verify Vercel build passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dark mode support in the login modal to correctly respect the app's selected theme instead of relying on system preference
  * Enhanced login modal styling to properly adapt icons and visual appearance based on the active theme setting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->