### PR TITLE
feat: Hangouts image integration

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,7 @@
 
 :root {
   --foreground-rgb: 0, 0, 0;
+  --hh-room-card-bg-height: 140px;
   --background-start-rgb: 214, 219, 220;
   --background-end-rgb: 255, 255, 255;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,7 +4,6 @@
 
 :root {
   --foreground-rgb: 0, 0, 0;
-  --hh-room-card-bg-height: 140px;
   --background-start-rgb: 214, 219, 220;
   --background-end-rgb: 255, 255, 255;
 }
@@ -221,3 +220,4 @@ body.embed-mode * {
 body.embed-mode {
   -webkit-overflow-scrolling: touch !important;
 }
+

--- a/app/hangouts/overrides.css
+++ b/app/hangouts/overrides.css
@@ -1,0 +1,7 @@
+.hh-room-card__bg {
+  height: 200px;
+}
+
+.hh-bg-picker__preview {
+  height: 200px;
+}

--- a/app/hangouts/page.tsx
+++ b/app/hangouts/page.tsx
@@ -11,7 +11,7 @@ import { useToast, Center, VStack, Text, Spinner, Button } from '@chakra-ui/reac
 
 const API_URL = process.env.NEXT_PUBLIC_HANGOUTS_API_URL!;
 const LK_URL = process.env.NEXT_PUBLIC_LIVEKIT_URL || 'wss://livekit.3speak.tv';
-const IMAGE_KEY = process.env.NEXT_PUBLIC_IMAGE_SERVER_API_KEY;
+const IMAGE_KEY = process.env.NEXT_PUBLIC_IMAGE_SERVER_API_KEY || process.env.NEXT_PUBLIC_3SPEAK_API_KEY;
 
 interface LobbyProps {
   user: string;

--- a/app/hangouts/page.tsx
+++ b/app/hangouts/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { useRef } from 'react';
 import { HangoutsProvider, RoomLobby, type Room } from '@snapie/hangouts-react';
+
+type RoomWithBackground = Room & { backgroundImage?: string };
 import '@snapie/hangouts-react/src/styles/hangouts.css';
 import { useHangout } from '@/contexts/HangoutContext';
 import { useAioha } from '@aioha/react-ui';
@@ -53,7 +55,7 @@ function LobbyWithAutoAuth({ user, sessionToken, isLoading, error, retryLogin }:
     );
   }
 
-  const handleRoomCreated = async (room: Room) => {
+  const handleRoomCreated = async (room: RoomWithBackground) => {
     isCreating.current = true;
 
     // Post the announcement snap BEFORE opening the room.
@@ -67,6 +69,7 @@ function LobbyWithAutoAuth({ user, sessionToken, isLoading, error, retryLogin }:
         body,
         parentAuthor,
         parentPermlink,
+        images: room.backgroundImage ? [room.backgroundImage] : undefined,
       });
 
       const response = await signAndBroadcastWithKeychain(user, result.operations, 'posting');
@@ -108,7 +111,7 @@ function LobbyWithAutoAuth({ user, sessionToken, isLoading, error, retryLogin }:
   return (
     <RoomLobby
       onJoinRoom={handleJoinRoom}
-      onRoomCreated={handleRoomCreated}
+      onRoomCreated={handleRoomCreated as (room: Room) => void}
     />
   );
 }

--- a/app/hangouts/page.tsx
+++ b/app/hangouts/page.tsx
@@ -2,6 +2,7 @@
 import { useRef } from 'react';
 import { HangoutsProvider, RoomLobby, type Room } from '@snapie/hangouts-react';
 import '@snapie/hangouts-react/src/styles/hangouts.css';
+import './overrides.css';
 import { useHangout } from '@/contexts/HangoutContext';
 import { useAioha } from '@aioha/react-ui';
 import { useHangoutsSession } from '@/hooks/useHangoutsSession';

--- a/app/hangouts/page.tsx
+++ b/app/hangouts/page.tsx
@@ -11,6 +11,7 @@ import { useToast, Center, VStack, Text, Spinner, Button } from '@chakra-ui/reac
 
 const API_URL = process.env.NEXT_PUBLIC_HANGOUTS_API_URL!;
 const LK_URL = process.env.NEXT_PUBLIC_LIVEKIT_URL || 'wss://livekit.3speak.tv';
+const IMAGE_KEY = process.env.NEXT_PUBLIC_IMAGE_SERVER_API_KEY;
 
 interface LobbyProps {
   user: string;
@@ -137,6 +138,7 @@ export default function HangoutsPage() {
         livekitServerUrl={LK_URL}
         sessionToken={sessionToken}
         username={user}
+        imageServerApiKey={IMAGE_KEY}
       >
         <LobbyWithAutoAuth
           user={user}

--- a/app/hangouts/page.tsx
+++ b/app/hangouts/page.tsx
@@ -10,9 +10,10 @@ import { snapieHangoutComposer } from '@/lib/utils/composerSdk';
 import { getLastSnapsContainer, signAndBroadcastWithKeychain } from '@/lib/hive/client-functions';
 import { useToast, Center, VStack, Text, Spinner, Button } from '@chakra-ui/react';
 
+import { IMAGE_SERVER_API_KEY } from '@/lib/env';
+
 const API_URL = process.env.NEXT_PUBLIC_HANGOUTS_API_URL!;
 const LK_URL = process.env.NEXT_PUBLIC_LIVEKIT_URL || 'wss://livekit.3speak.tv';
-const IMAGE_KEY = process.env.NEXT_PUBLIC_IMAGE_SERVER_API_KEY || process.env.NEXT_PUBLIC_3SPEAK_API_KEY;
 
 interface LobbyProps {
   user: string;
@@ -140,7 +141,7 @@ export default function HangoutsPage() {
         livekitServerUrl={LK_URL}
         sessionToken={sessionToken}
         username={user}
-        imageServerApiKey={IMAGE_KEY}
+        imageServerApiKey={IMAGE_SERVER_API_KEY}
       >
         <LobbyWithAutoAuth
           user={user}

--- a/app/hangouts/page.tsx
+++ b/app/hangouts/page.tsx
@@ -1,8 +1,6 @@
 'use client';
 import { useRef } from 'react';
 import { HangoutsProvider, RoomLobby, type Room } from '@snapie/hangouts-react';
-
-type RoomWithBackground = Room & { backgroundImage?: string };
 import '@snapie/hangouts-react/src/styles/hangouts.css';
 import { useHangout } from '@/contexts/HangoutContext';
 import { useAioha } from '@aioha/react-ui';
@@ -55,7 +53,7 @@ function LobbyWithAutoAuth({ user, sessionToken, isLoading, error, retryLogin }:
     );
   }
 
-  const handleRoomCreated = async (room: RoomWithBackground) => {
+  const handleRoomCreated = async (room: Room) => {
     isCreating.current = true;
 
     // Post the announcement snap BEFORE opening the room.
@@ -111,7 +109,7 @@ function LobbyWithAutoAuth({ user, sessionToken, isLoading, error, retryLogin }:
   return (
     <RoomLobby
       onJoinRoom={handleJoinRoom}
-      onRoomCreated={handleRoomCreated as (room: Room) => void}
+      onRoomCreated={handleRoomCreated}
     />
   );
 }

--- a/components/hangouts/HangoutModal.tsx
+++ b/components/hangouts/HangoutModal.tsx
@@ -10,6 +10,7 @@ import '@snapie/hangouts-react/src/styles/hangouts.css';
 
 const API_URL = process.env.NEXT_PUBLIC_HANGOUTS_API_URL!;
 const LK_URL = process.env.NEXT_PUBLIC_LIVEKIT_URL || 'wss://livekit.3speak.tv';
+const IMAGE_KEY = process.env.NEXT_PUBLIC_IMAGE_SERVER_API_KEY;
 
 const HANGOUT_THUMBNAIL = 'https://files.peakd.com/file/peakd-hive/meno/AKDgvpgFrvsp3fEazRgb971Pm8N7NqV3TUt1dF4TUY9798tUJHfZvwHE2BZB56Y.png';
 
@@ -100,6 +101,7 @@ export default function HangoutModal({ isOpen, onClose, roomName }: HangoutModal
       livekitServerUrl={LK_URL}
       sessionToken={sessionToken}
       username={user}
+      imageServerApiKey={IMAGE_KEY}
     >
       <Modal isOpen={isOpen} onClose={onClose} size="2xl">
         <ModalOverlay bg="rgba(0, 0, 0, 0.6)" backdropFilter="blur(10px)" />

--- a/components/hangouts/HangoutModal.tsx
+++ b/components/hangouts/HangoutModal.tsx
@@ -8,9 +8,10 @@ import { useHangoutsSession } from '@/hooks/useHangoutsSession';
 import { useWakeLock } from '@/hooks/useWakeLock';
 import '@snapie/hangouts-react/src/styles/hangouts.css';
 
+import { IMAGE_SERVER_API_KEY } from '@/lib/env';
+
 const API_URL = process.env.NEXT_PUBLIC_HANGOUTS_API_URL!;
 const LK_URL = process.env.NEXT_PUBLIC_LIVEKIT_URL || 'wss://livekit.3speak.tv';
-const IMAGE_KEY = process.env.NEXT_PUBLIC_IMAGE_SERVER_API_KEY || process.env.NEXT_PUBLIC_3SPEAK_API_KEY;
 
 const HANGOUT_THUMBNAIL = 'https://files.peakd.com/file/peakd-hive/meno/AKDgvpgFrvsp3fEazRgb971Pm8N7NqV3TUt1dF4TUY9798tUJHfZvwHE2BZB56Y.png';
 
@@ -101,7 +102,7 @@ export default function HangoutModal({ isOpen, onClose, roomName }: HangoutModal
       livekitServerUrl={LK_URL}
       sessionToken={sessionToken}
       username={user}
-      imageServerApiKey={IMAGE_KEY}
+      imageServerApiKey={IMAGE_SERVER_API_KEY}
     >
       <Modal isOpen={isOpen} onClose={onClose} size="2xl">
         <ModalOverlay bg="rgba(0, 0, 0, 0.6)" backdropFilter="blur(10px)" />

--- a/components/hangouts/HangoutModal.tsx
+++ b/components/hangouts/HangoutModal.tsx
@@ -10,7 +10,7 @@ import '@snapie/hangouts-react/src/styles/hangouts.css';
 
 const API_URL = process.env.NEXT_PUBLIC_HANGOUTS_API_URL!;
 const LK_URL = process.env.NEXT_PUBLIC_LIVEKIT_URL || 'wss://livekit.3speak.tv';
-const IMAGE_KEY = process.env.NEXT_PUBLIC_IMAGE_SERVER_API_KEY;
+const IMAGE_KEY = process.env.NEXT_PUBLIC_IMAGE_SERVER_API_KEY || process.env.NEXT_PUBLIC_3SPEAK_API_KEY;
 
 const HANGOUT_THUMBNAIL = 'https://files.peakd.com/file/peakd-hive/meno/AKDgvpgFrvsp3fEazRgb971Pm8N7NqV3TUt1dF4TUY9798tUJHfZvwHE2BZB56Y.png';
 

--- a/components/hangouts/HangoutPreviewCard.tsx
+++ b/components/hangouts/HangoutPreviewCard.tsx
@@ -79,6 +79,8 @@ export default function HangoutPreviewCard({ roomName }: HangoutPreviewCardProps
           height="80px"
           objectFit="cover"
           display="block"
+          fallbackStrategy="onError"
+          fallback={<></>}
         />
       )}
       <Box p={4}>

--- a/components/hangouts/HangoutPreviewCard.tsx
+++ b/components/hangouts/HangoutPreviewCard.tsx
@@ -4,15 +4,13 @@ import { useState, useEffect } from 'react';
 import { HangoutsApiClient, type Room } from '@snapie/hangouts-react';
 import { useHangout } from '@/contexts/HangoutContext';
 
-type RoomWithBackground = Room & { backgroundImage?: string };
-
 interface HangoutPreviewCardProps {
   roomName: string;
 }
 
 export default function HangoutPreviewCard({ roomName }: HangoutPreviewCardProps) {
   const { openRoom } = useHangout();
-  const [room, setRoom] = useState<RoomWithBackground | null>(null);
+  const [room, setRoom] = useState<Room | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -24,7 +22,7 @@ export default function HangoutPreviewCard({ roomName }: HangoutPreviewCardProps
       baseUrl: process.env.NEXT_PUBLIC_HANGOUTS_API_URL!,
     });
     client.getRoom(roomName).then((found) => {
-      setRoom(found as RoomWithBackground);
+      setRoom(found);
       setLoading(false);
     }).catch(() => {
       setError('Failed to load hangout');

--- a/components/hangouts/HangoutPreviewCard.tsx
+++ b/components/hangouts/HangoutPreviewCard.tsx
@@ -1,8 +1,10 @@
 'use client';
-import { Box, HStack, VStack, Text, Avatar, Badge } from '@chakra-ui/react';
+import { Box, HStack, VStack, Text, Avatar, Badge, Image } from '@chakra-ui/react';
 import { useState, useEffect } from 'react';
 import { HangoutsApiClient, type Room } from '@snapie/hangouts-react';
 import { useHangout } from '@/contexts/HangoutContext';
+
+type RoomWithBackground = Room & { backgroundImage?: string };
 
 interface HangoutPreviewCardProps {
   roomName: string;
@@ -10,7 +12,7 @@ interface HangoutPreviewCardProps {
 
 export default function HangoutPreviewCard({ roomName }: HangoutPreviewCardProps) {
   const { openRoom } = useHangout();
-  const [room, setRoom] = useState<Room | null>(null);
+  const [room, setRoom] = useState<RoomWithBackground | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -22,7 +24,7 @@ export default function HangoutPreviewCard({ roomName }: HangoutPreviewCardProps
       baseUrl: process.env.NEXT_PUBLIC_HANGOUTS_API_URL!,
     });
     client.getRoom(roomName).then((found) => {
-      setRoom(found);
+      setRoom(found as RoomWithBackground);
       setLoading(false);
     }).catch(() => {
       setError('Failed to load hangout');
@@ -61,16 +63,27 @@ export default function HangoutPreviewCard({ roomName }: HangoutPreviewCardProps
       width="100%"
       textAlign="left"
       aria-label={`Join hangout: ${room.title}`}
-      p={4}
       borderWidth="1px"
       borderColor="border"
       borderRadius="xl"
       bg="muted"
+      overflow="hidden"
       onClick={() => openRoom(room.name)}
       _hover={{ borderColor: 'primary' }}
       _focus={{ outline: '2px solid', outlineColor: 'primary', outlineOffset: '2px' }}
       transition="border-color 0.15s"
     >
+      {room.backgroundImage && (
+        <Image
+          src={room.backgroundImage}
+          alt=""
+          width="100%"
+          height="80px"
+          objectFit="cover"
+          display="block"
+        />
+      )}
+      <Box p={4}>
       <HStack spacing={3}>
         <Avatar
           size="md"
@@ -92,6 +105,7 @@ export default function HangoutPreviewCard({ roomName }: HangoutPreviewCardProps
           <Text fontSize="xs" color="primary">listening</Text>
         </VStack>
       </HStack>
+      </Box>
     </Box>
   );
 }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,3 @@
+export const IMAGE_SERVER_API_KEY =
+  process.env.NEXT_PUBLIC_IMAGE_SERVER_API_KEY ||
+  process.env.NEXT_PUBLIC_3SPEAK_API_KEY;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@hiveio/dhive": "1.3.1-beta",
     "@livekit/components-react": "^2.9.20",
     "@snapie/composer": "workspace:*",
-    "@snapie/hangouts-react": "^0.3.7",
+    "@snapie/hangouts-react": "^0.3.8",
     "@snapie/operations": "workspace:*",
     "@snapie/renderer": "workspace:*",
     "@supabase/supabase-js": "^2.45.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@livekit/components-react": "^2.9.20",
     "@snapie/composer": "workspace:*",
     "@snapie/hangouts-core": "0.3.2",
-    "@snapie/hangouts-react": "^0.3.9",
+    "@snapie/hangouts-react": "^0.3.10",
     "@snapie/operations": "workspace:*",
     "@snapie/renderer": "workspace:*",
     "@supabase/supabase-js": "^2.45.4",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@hiveio/dhive": "1.3.1-beta",
     "@livekit/components-react": "^2.9.20",
     "@snapie/composer": "workspace:*",
+    "@snapie/hangouts-core": "0.3.2",
     "@snapie/hangouts-react": "^0.3.8",
     "@snapie/operations": "workspace:*",
     "@snapie/renderer": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@livekit/components-react": "^2.9.20",
     "@snapie/composer": "workspace:*",
     "@snapie/hangouts-core": "0.3.2",
-    "@snapie/hangouts-react": "^0.3.8",
+    "@snapie/hangouts-react": "^0.3.9",
     "@snapie/operations": "workspace:*",
     "@snapie/renderer": "workspace:*",
     "@supabase/supabase-js": "^2.45.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@hiveio/dhive": "1.3.1-beta",
     "@livekit/components-react": "^2.9.20",
     "@snapie/composer": "workspace:*",
-    "@snapie/hangouts-react": "^0.3.5",
+    "@snapie/hangouts-react": "^0.3.7",
     "@snapie/operations": "workspace:*",
     "@snapie/renderer": "workspace:*",
     "@supabase/supabase-js": "^2.45.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: workspace:*
         version: link:packages/composer
       '@snapie/hangouts-react':
-        specifier: ^0.3.5
-        version: 0.3.5(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
+        specifier: ^0.3.7
+        version: 0.3.7(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
       '@snapie/operations':
         specifier: workspace:*
         version: link:packages/operations
@@ -1022,8 +1022,8 @@ packages:
   '@snapie/hangouts-core@0.3.1':
     resolution: {integrity: sha512-OfjewQrOsHwnScMM3rsbKV9qZMqc5Vn527RGohCWJjYlE8FVkMYUWOE3qdGAulOjjmJx4nYoXaCq1qPopFW0EQ==}
 
-  '@snapie/hangouts-react@0.3.5':
-    resolution: {integrity: sha512-yyWDXU4KMYDAExU5GWClwUQ/Mq9RTe+TAKw8WAvatdf37BbDGEuGzeIiCHs5nx7uCO9yTUxgltp1R6AIt77ZdQ==}
+  '@snapie/hangouts-react@0.3.7':
+    resolution: {integrity: sha512-8LQmA1nRHuCxuiYKtagORmL6Q4qc4FWk0uJPb8ganNY0BAidnw5qUZYCge1tVuf0w+A9K4F9LL4WwrnXu9DuuA==}
     peerDependencies:
       '@livekit/components-react': ^2.0.0
       livekit-client: ^2.0.0
@@ -4519,7 +4519,7 @@ snapshots:
 
   '@snapie/hangouts-core@0.3.1': {}
 
-  '@snapie/hangouts-react@0.3.5(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
+  '@snapie/hangouts-react@0.3.7(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
     dependencies:
       '@livekit/components-react': 2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@snapie/hangouts-core': 0.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: 0.3.2
         version: 0.3.2
       '@snapie/hangouts-react':
-        specifier: ^0.3.8
-        version: 0.3.8(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
+        specifier: ^0.3.9
+        version: 0.3.9(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
       '@snapie/operations':
         specifier: workspace:*
         version: link:packages/operations
@@ -1025,8 +1025,8 @@ packages:
   '@snapie/hangouts-core@0.3.2':
     resolution: {integrity: sha512-odDBptvcY+CbGiOGgu/003EaAcROzCagTD40PDdSf0YRkyTkKxl8SxnwmDHhl+Bx1BhP3/QbFYFfOijHyHcnZg==}
 
-  '@snapie/hangouts-react@0.3.8':
-    resolution: {integrity: sha512-oiskxQEi9PCLmTo+M20SL4GcuWmB9mK7m9/xXl77fkDINZl074Dkt/cVmc3Xyd34JXQuuElU8s947kdzOGg8Zg==}
+  '@snapie/hangouts-react@0.3.9':
+    resolution: {integrity: sha512-kszGNXfp6ncrAXVzfC51zuwmHjhMd+V7ONeHCk+gX3XpX2YKdbc6q783xmdnrPdoMnEeanxv18tOuAlKCQK1Ew==}
     peerDependencies:
       '@livekit/components-react': ^2.0.0
       livekit-client: ^2.0.0
@@ -4522,7 +4522,7 @@ snapshots:
 
   '@snapie/hangouts-core@0.3.2': {}
 
-  '@snapie/hangouts-react@0.3.8(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
+  '@snapie/hangouts-react@0.3.9(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
     dependencies:
       '@livekit/components-react': 2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@snapie/hangouts-core': 0.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: workspace:*
         version: link:packages/composer
       '@snapie/hangouts-react':
-        specifier: ^0.3.7
-        version: 0.3.7(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
+        specifier: ^0.3.8
+        version: 0.3.8(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
       '@snapie/operations':
         specifier: workspace:*
         version: link:packages/operations
@@ -1022,8 +1022,8 @@ packages:
   '@snapie/hangouts-core@0.3.1':
     resolution: {integrity: sha512-OfjewQrOsHwnScMM3rsbKV9qZMqc5Vn527RGohCWJjYlE8FVkMYUWOE3qdGAulOjjmJx4nYoXaCq1qPopFW0EQ==}
 
-  '@snapie/hangouts-react@0.3.7':
-    resolution: {integrity: sha512-8LQmA1nRHuCxuiYKtagORmL6Q4qc4FWk0uJPb8ganNY0BAidnw5qUZYCge1tVuf0w+A9K4F9LL4WwrnXu9DuuA==}
+  '@snapie/hangouts-react@0.3.8':
+    resolution: {integrity: sha512-oiskxQEi9PCLmTo+M20SL4GcuWmB9mK7m9/xXl77fkDINZl074Dkt/cVmc3Xyd34JXQuuElU8s947kdzOGg8Zg==}
     peerDependencies:
       '@livekit/components-react': ^2.0.0
       livekit-client: ^2.0.0
@@ -4519,7 +4519,7 @@ snapshots:
 
   '@snapie/hangouts-core@0.3.1': {}
 
-  '@snapie/hangouts-react@0.3.7(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
+  '@snapie/hangouts-react@0.3.8(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
     dependencies:
       '@livekit/components-react': 2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@snapie/hangouts-core': 0.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: 0.3.2
         version: 0.3.2
       '@snapie/hangouts-react':
-        specifier: ^0.3.9
-        version: 0.3.9(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
+        specifier: ^0.3.10
+        version: 0.3.10(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
       '@snapie/operations':
         specifier: workspace:*
         version: link:packages/operations
@@ -1025,8 +1025,8 @@ packages:
   '@snapie/hangouts-core@0.3.2':
     resolution: {integrity: sha512-odDBptvcY+CbGiOGgu/003EaAcROzCagTD40PDdSf0YRkyTkKxl8SxnwmDHhl+Bx1BhP3/QbFYFfOijHyHcnZg==}
 
-  '@snapie/hangouts-react@0.3.9':
-    resolution: {integrity: sha512-kszGNXfp6ncrAXVzfC51zuwmHjhMd+V7ONeHCk+gX3XpX2YKdbc6q783xmdnrPdoMnEeanxv18tOuAlKCQK1Ew==}
+  '@snapie/hangouts-react@0.3.10':
+    resolution: {integrity: sha512-lpQ+A6CMCjK5u3996HFYLg1WyOYOnbh4UmhvaBl4unsZNDCHN4HK9pLF+l/3Wft2KnqkgFzHXUYdccDFIM/STQ==}
     peerDependencies:
       '@livekit/components-react': ^2.0.0
       livekit-client: ^2.0.0
@@ -4522,7 +4522,7 @@ snapshots:
 
   '@snapie/hangouts-core@0.3.2': {}
 
-  '@snapie/hangouts-react@0.3.9(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
+  '@snapie/hangouts-react@0.3.10(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
     dependencies:
       '@livekit/components-react': 2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@snapie/hangouts-core': 0.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@snapie/composer':
         specifier: workspace:*
         version: link:packages/composer
+      '@snapie/hangouts-core':
+        specifier: 0.3.2
+        version: 0.3.2
       '@snapie/hangouts-react':
         specifier: ^0.3.8
         version: 0.3.8(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
@@ -1019,8 +1022,8 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@snapie/hangouts-core@0.3.1':
-    resolution: {integrity: sha512-OfjewQrOsHwnScMM3rsbKV9qZMqc5Vn527RGohCWJjYlE8FVkMYUWOE3qdGAulOjjmJx4nYoXaCq1qPopFW0EQ==}
+  '@snapie/hangouts-core@0.3.2':
+    resolution: {integrity: sha512-odDBptvcY+CbGiOGgu/003EaAcROzCagTD40PDdSf0YRkyTkKxl8SxnwmDHhl+Bx1BhP3/QbFYFfOijHyHcnZg==}
 
   '@snapie/hangouts-react@0.3.8':
     resolution: {integrity: sha512-oiskxQEi9PCLmTo+M20SL4GcuWmB9mK7m9/xXl77fkDINZl074Dkt/cVmc3Xyd34JXQuuElU8s947kdzOGg8Zg==}
@@ -4517,12 +4520,12 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@snapie/hangouts-core@0.3.1': {}
+  '@snapie/hangouts-core@0.3.2': {}
 
   '@snapie/hangouts-react@0.3.8(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
     dependencies:
       '@livekit/components-react': 2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
-      '@snapie/hangouts-core': 0.3.1
+      '@snapie/hangouts-core': 0.3.2
       livekit-client: 2.18.0(@types/dom-mediacapture-record@1.0.22)
       react: 18.3.1
 


### PR DESCRIPTION
## Summary

- **Room background images** — hosts can upload a background image when creating a room (`CreateRoomDialog` image picker, enabled by passing `imageServerApiKey` to `HangoutsProvider`). Reuses `NEXT_PUBLIC_3SPEAK_API_KEY` so no new credentials are needed.
- **Lobby card thumbnails** — the room list (`RoomLobby`) now shows the background image as a 200px banner at the top of each card, giving the lobby a much richer look.
- **Snap preview card thumbnails** — `HangoutPreviewCard` shows the background image when a hangout link is shared in a snap.
- **Announcement snap image** — when a host creates a room with a background image, it's automatically included in the snap posted to the feed.
- **Accurate upload preview** — the image picker preview in `CreateRoomDialog` is sized to 200px to match the card exactly, so hosts see the precise crop before creating the room.
- **SDK bumps** — `@snapie/hangouts-react` 0.3.5 → 0.3.10, `@snapie/hangouts-core` 0.3.1 → 0.3.2 (adds `backgroundImage` to the `Room` type).

## Test plan

- [ ] Create a room with a background image — verify the image picker preview shows the correct crop at 200px
- [ ] Confirm the created room appears in the lobby with the background image banner
- [ ] Share a hangout link in a snap — verify the preview card shows the background image
- [ ] Confirm the auto-posted announcement snap includes the image
- [ ] Create a room without a background image — verify cards and snaps look unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying background images in hangout rooms and composition interface

* **Style**
  * Enhanced hangout preview card layout with optimized image banner display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->