### PR TITLE
feat: rename Hangouts to OpenPods with live count badge

### DIFF
--- a/components/layout/FooterNavigation.tsx
+++ b/components/layout/FooterNavigation.tsx
@@ -1,6 +1,7 @@
 import { useAioha } from '@aioha/react-ui';
 import { useLoginModal } from '@/contexts/LoginModalContext';
-import { Badge, Box, Button, HStack, Icon, Tooltip, useColorMode } from '@chakra-ui/react';
+import { Box, Button, HStack, Icon, Tooltip, useColorMode } from '@chakra-ui/react';
+import { CountBadge } from '@/components/ui/CountBadge';
 import { useRouter } from 'next/navigation';
 import { FiBell, FiBook, FiCreditCard, FiHome, FiUser, FiLogIn, FiLogOut, FiMessageSquare, FiChevronLeft, FiChevronRight, FiRadio } from 'react-icons/fi';
 import { useState, useRef, useEffect } from 'react';
@@ -144,23 +145,7 @@ export default function FooterNavigation({ isChatOpen, setIsChatOpen, chatUnread
                             _hover={{ bg: 'whiteAlpha.200' }}
                             leftIcon={<Icon as={FiRadio} boxSize={4} />}
                         />
-                        {openPodsCount > 0 && (
-                            <Badge
-                                position="absolute"
-                                top="-2px"
-                                right="-2px"
-                                colorScheme="green"
-                                borderRadius="full"
-                                minW="18px"
-                                h="18px"
-                                display="flex"
-                                alignItems="center"
-                                justifyContent="center"
-                                fontSize="xs"
-                            >
-                                {openPodsCount > 99 ? '99+' : openPodsCount}
-                            </Badge>
-                        )}
+                        <CountBadge count={openPodsCount} top="-2px" right="-2px" />
                     </Box>
                 </Tooltip>
 
@@ -202,23 +187,7 @@ export default function FooterNavigation({ isChatOpen, setIsChatOpen, chatUnread
                                     _hover={{ bg: isChatOpen ? 'blue.600' : 'whiteAlpha.200' }}
                                     leftIcon={<Icon as={FiMessageSquare} boxSize={4} />}
                                 />
-                                {chatUnreadCount > 0 && !isChatOpen && (
-                                    <Badge
-                                        position="absolute"
-                                        top="-2px"
-                                        right="-2px"
-                                        colorScheme="red"
-                                        borderRadius="full"
-                                        minW="18px"
-                                        h="18px"
-                                        display="flex"
-                                        alignItems="center"
-                                        justifyContent="center"
-                                        fontSize="xs"
-                                    >
-                                        {chatUnreadCount > 99 ? '99+' : chatUnreadCount}
-                                    </Badge>
-                                )}
+                                <CountBadge count={!isChatOpen ? chatUnreadCount : 0} colorScheme="red" top="-2px" right="-2px" />
                             </Box>
                         </Tooltip>
 

--- a/components/layout/FooterNavigation.tsx
+++ b/components/layout/FooterNavigation.tsx
@@ -4,6 +4,7 @@ import { Badge, Box, Button, HStack, Icon, Tooltip, useColorMode } from '@chakra
 import { useRouter } from 'next/navigation';
 import { FiBell, FiBook, FiCreditCard, FiHome, FiUser, FiLogIn, FiLogOut, FiMessageSquare, FiChevronLeft, FiChevronRight, FiRadio } from 'react-icons/fi';
 import { useState, useRef, useEffect } from 'react';
+import { useOpenPodsCount } from '@/hooks/useOpenPodsCount';
 
 interface FooterNavigationProps {
     isChatOpen: boolean;
@@ -21,6 +22,7 @@ export default function FooterNavigation({ isChatOpen, setIsChatOpen, chatUnread
     const scrollRef = useRef<HTMLDivElement>(null);
     const [showLeftFade, setShowLeftFade] = useState(false);
     const [showRightFade, setShowRightFade] = useState(false);
+    const openPodsCount = useOpenPodsCount();
     
     const handleNavigation = (path: string) => {
         if (router) {
@@ -131,16 +133,35 @@ export default function FooterNavigation({ isChatOpen, setIsChatOpen, chatUnread
                     />
                 </Tooltip>
 
-                <Tooltip label="Hangouts" aria-label="Hangouts tooltip">
-                    <Button
-                        onClick={() => handleNavigation("/hangouts")}
-                        variant="ghost"
-                        color="white"
-                        size="sm"
-                        minW="40px"
-                        _hover={{ bg: 'whiteAlpha.200' }}
-                        leftIcon={<Icon as={FiRadio} boxSize={4} />}
-                    />
+                <Tooltip label="OpenPods" aria-label="OpenPods tooltip">
+                    <Box position="relative">
+                        <Button
+                            onClick={() => handleNavigation("/hangouts")}
+                            variant="ghost"
+                            color="white"
+                            size="sm"
+                            minW="40px"
+                            _hover={{ bg: 'whiteAlpha.200' }}
+                            leftIcon={<Icon as={FiRadio} boxSize={4} />}
+                        />
+                        {openPodsCount > 0 && (
+                            <Badge
+                                position="absolute"
+                                top="-2px"
+                                right="-2px"
+                                colorScheme="green"
+                                borderRadius="full"
+                                minW="18px"
+                                h="18px"
+                                display="flex"
+                                alignItems="center"
+                                justifyContent="center"
+                                fontSize="xs"
+                            >
+                                {openPodsCount > 99 ? '99+' : openPodsCount}
+                            </Badge>
+                        )}
+                    </Box>
                 </Tooltip>
 
                 {user ? (

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useEffect, useState } from 'react';
-import { Badge, Box, VStack, Button, Icon, Image, Spinner, Flex, Text, useColorMode, transition, Tooltip, useBreakpointValue, useToast } from '@chakra-ui/react';
+import { Box, VStack, Button, Icon, Image, Spinner, Flex, Text, useColorMode, transition, Tooltip, useBreakpointValue, useToast } from '@chakra-ui/react';
+import { CountBadge } from '@/components/ui/CountBadge';
 import { useRouter, usePathname } from 'next/navigation';
 import { useAioha } from '@aioha/react-ui';
 import { useLoginModal } from '@/contexts/LoginModalContext';
@@ -48,10 +49,6 @@ export default function Sidebar({ isChatOpen, setIsChatOpen, chatUnreadCount = 0
     const toast = useToast();
     const openPodsCount = useOpenPodsCount();
 
-    useEffect(() => {
-        console.log('🔵 Sidebar: isChatOpen changed to:', isChatOpen);
-    }, [isChatOpen]);
-    
     // Check if we should force compact mode (compose page)
     const forceCompact = pathname === '/compose';
     // Determine display values based on whether we're forcing compact or using responsive
@@ -208,23 +205,7 @@ export default function Sidebar({ isChatOpen, setIsChatOpen, chatUnreadCount = 0
                             >
                                 <Text display={textDisplay}>OpenPods</Text>
                             </Button>
-                            {openPodsCount > 0 && (
-                                <Badge
-                                    position="absolute"
-                                    top="2px"
-                                    right="2px"
-                                    colorScheme="green"
-                                    borderRadius="full"
-                                    minW="18px"
-                                    h="18px"
-                                    display="flex"
-                                    alignItems="center"
-                                    justifyContent="center"
-                                    fontSize="xs"
-                                >
-                                    {openPodsCount > 99 ? '99+' : openPodsCount}
-                                </Badge>
-                            )}
+                            <CountBadge count={openPodsCount} />
                         </Box>
                     </Tooltip>
                     {user && (
@@ -299,11 +280,7 @@ export default function Sidebar({ isChatOpen, setIsChatOpen, chatUnreadCount = 0
                             <Tooltip label="Chat" placement="right" hasArrow isDisabled={!isCompactMode}>
                                 <Box w="full" position="relative">
                                     <Button
-                                        onClick={() => {
-                                            console.log('🔵 Chat button clicked! Current state:', isChatOpen);
-                                            setIsChatOpen(!isChatOpen);
-                                            console.log('🔵 Setting chat to:', !isChatOpen);
-                                        }}
+                                        onClick={() => setIsChatOpen(!isChatOpen)}
                                         variant="ghost"
                                         w="full"
                                         justifyContent={iconJustify}
@@ -316,23 +293,7 @@ export default function Sidebar({ isChatOpen, setIsChatOpen, chatUnreadCount = 0
                                     >
                                         <Text display={textDisplay}>Chat</Text>
                                     </Button>
-                                    {chatUnreadCount > 0 && !isChatOpen && (
-                                        <Badge
-                                            position="absolute"
-                                            top="2px"
-                                            right="2px"
-                                            colorScheme="red"
-                                            borderRadius="full"
-                                            minW="18px"
-                                            h="18px"
-                                            display="flex"
-                                            alignItems="center"
-                                            justifyContent="center"
-                                            fontSize="xs"
-                                        >
-                                            {chatUnreadCount > 99 ? '99+' : chatUnreadCount}
-                                        </Badge>
-                                    )}
+                                    <CountBadge count={!isChatOpen ? chatUnreadCount : 0} colorScheme="red" />
                                 </Box>
                             </Tooltip>
                         </>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -4,11 +4,12 @@ import { Badge, Box, VStack, Button, Icon, Image, Spinner, Flex, Text, useColorM
 import { useRouter, usePathname } from 'next/navigation';
 import { useAioha } from '@aioha/react-ui';
 import { useLoginModal } from '@/contexts/LoginModalContext';
-import { FiHome, FiBell, FiUser, FiShoppingCart, FiBook, FiCreditCard, FiLogIn, FiLogOut, FiMessageSquare, FiRadio } from 'react-icons/fi';
+import { FiHome, FiBell, FiUser, FiShoppingCart, FiBook, FiCreditCard, FiLogIn, FiLogOut, FiMessageSquare, FiRadio, FiInfo } from 'react-icons/fi';
 import { Notifications } from '@hiveio/dhive';
 import { fetchNewNotifications, getCommunityInfo, getProfile } from '@/lib/hive/client-functions';
 import { animate, color, motion, px } from 'framer-motion';
 import { getHiveAvatarUrl } from '@/lib/utils/avatarUtils';
+import { useOpenPodsCount } from '@/hooks/useOpenPodsCount';
 
 interface ProfileInfo {
     metadata: {
@@ -45,6 +46,7 @@ export default function Sidebar({ isChatOpen, setIsChatOpen, chatUnreadCount = 0
     const [loading, setLoading] = useState(true); // Loading state
     const { colorMode } = useColorMode();
     const toast = useToast();
+    const openPodsCount = useOpenPodsCount();
 
     useEffect(() => {
         console.log('🔵 Sidebar: isChatOpen changed to:', isChatOpen);
@@ -193,8 +195,8 @@ export default function Sidebar({ isChatOpen, setIsChatOpen, chatUnreadCount = 0
                             </Button>
                         </Box>
                     </Tooltip>
-                    <Tooltip label="Hangouts" placement="right" hasArrow isDisabled={!isCompactMode}>
-                        <Box w="full">
+                    <Tooltip label="OpenPods" placement="right" hasArrow isDisabled={!isCompactMode}>
+                        <Box w="full" position="relative">
                             <Button
                                 onClick={() => handleNavigation("/hangouts")}
                                 variant="ghost"
@@ -204,8 +206,25 @@ export default function Sidebar({ isChatOpen, setIsChatOpen, chatUnreadCount = 0
                                 px={3}
                                 borderRadius="md"
                             >
-                                <Text display={textDisplay}>Hangouts</Text>
+                                <Text display={textDisplay}>OpenPods</Text>
                             </Button>
+                            {openPodsCount > 0 && (
+                                <Badge
+                                    position="absolute"
+                                    top="2px"
+                                    right="2px"
+                                    colorScheme="green"
+                                    borderRadius="full"
+                                    minW="18px"
+                                    h="18px"
+                                    display="flex"
+                                    alignItems="center"
+                                    justifyContent="center"
+                                    fontSize="xs"
+                                >
+                                    {openPodsCount > 99 ? '99+' : openPodsCount}
+                                </Badge>
+                            )}
                         </Box>
                     </Tooltip>
                     {user && (
@@ -333,6 +352,24 @@ export default function Sidebar({ isChatOpen, setIsChatOpen, chatUnreadCount = 0
                                 borderRadius="md"
                             >
                                 <Text display={textDisplay}>{isLoggedIn ? 'Logout' : 'Login'}</Text>
+                            </Button>
+                        </Box>
+                    </Tooltip>
+                    <Tooltip label="About Snapie" placement="right" hasArrow isDisabled={!isCompactMode}>
+                        <Box w="full">
+                            <Button
+                                as="a"
+                                href="https://about.snapie.io"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                variant="ghost"
+                                w="full"
+                                justifyContent={iconJustify}
+                                leftIcon={<Icon as={FiInfo} boxSize={4} />}
+                                px={3}
+                                borderRadius="md"
+                            >
+                                <Text display={textDisplay}>About</Text>
                             </Button>
                         </Box>
                     </Tooltip>

--- a/components/ui/CountBadge.tsx
+++ b/components/ui/CountBadge.tsx
@@ -1,0 +1,29 @@
+import { Badge } from '@chakra-ui/react';
+
+interface CountBadgeProps {
+    count: number;
+    colorScheme?: string;
+    top?: string;
+    right?: string;
+}
+
+export function CountBadge({ count, colorScheme = 'green', top = '2px', right = '2px' }: CountBadgeProps) {
+    if (count <= 0) return null;
+    return (
+        <Badge
+            position="absolute"
+            top={top}
+            right={right}
+            colorScheme={colorScheme}
+            borderRadius="full"
+            minW="18px"
+            h="18px"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            fontSize="xs"
+        >
+            {count > 99 ? '99+' : count}
+        </Badge>
+    );
+}

--- a/hooks/useOpenPodsCount.ts
+++ b/hooks/useOpenPodsCount.ts
@@ -2,22 +2,57 @@
 import { useEffect, useState } from 'react';
 import { HangoutsApiClient } from '@snapie/hangouts-react';
 
-const API_URL = process.env.NEXT_PUBLIC_HANGOUTS_API_URL!;
+const API_URL = process.env.NEXT_PUBLIC_HANGOUTS_API_URL;
 const POLL_INTERVAL_MS = 30_000;
 
+// Module-level singleton — Sidebar and FooterNavigation share one interval
+// instead of each mounting their own.
+type Subscriber = (count: number) => void;
+const subscribers = new Set<Subscriber>();
+let currentCount = 0;
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+function startPolling() {
+    if (intervalId !== null) return;
+    const client = new HangoutsApiClient({ baseUrl: API_URL! });
+
+    const fetchCount = () => {
+        client
+            .listRooms()
+            .then((rooms) => {
+                currentCount = rooms.length;
+                subscribers.forEach((cb) => cb(currentCount));
+            })
+            .catch((err) => console.error('[useOpenPodsCount] failed to fetch rooms:', err));
+    };
+
+    fetchCount();
+    intervalId = setInterval(fetchCount, POLL_INTERVAL_MS);
+}
+
+function stopPolling() {
+    if (intervalId !== null) {
+        clearInterval(intervalId);
+        intervalId = null;
+    }
+}
+
 export function useOpenPodsCount(): number {
-    const [count, setCount] = useState(0);
+    const [count, setCount] = useState(currentCount);
 
     useEffect(() => {
-        const client = new HangoutsApiClient({ baseUrl: API_URL });
+        if (!API_URL) {
+            console.error('[useOpenPodsCount] NEXT_PUBLIC_HANGOUTS_API_URL is not defined');
+            return;
+        }
 
-        const fetchCount = () => {
-            client.listRooms().then((rooms) => setCount(rooms.length)).catch(() => {});
+        subscribers.add(setCount);
+        if (subscribers.size === 1) startPolling();
+
+        return () => {
+            subscribers.delete(setCount);
+            if (subscribers.size === 0) stopPolling();
         };
-
-        fetchCount();
-        const id = setInterval(fetchCount, POLL_INTERVAL_MS);
-        return () => clearInterval(id);
     }, []);
 
     return count;

--- a/hooks/useOpenPodsCount.ts
+++ b/hooks/useOpenPodsCount.ts
@@ -1,0 +1,24 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { HangoutsApiClient } from '@snapie/hangouts-react';
+
+const API_URL = process.env.NEXT_PUBLIC_HANGOUTS_API_URL!;
+const POLL_INTERVAL_MS = 30_000;
+
+export function useOpenPodsCount(): number {
+    const [count, setCount] = useState(0);
+
+    useEffect(() => {
+        const client = new HangoutsApiClient({ baseUrl: API_URL });
+
+        const fetchCount = () => {
+            client.listRooms().then((rooms) => setCount(rooms.length)).catch(() => {});
+        };
+
+        fetchCount();
+        const id = setInterval(fetchCount, POLL_INTERVAL_MS);
+        return () => clearInterval(id);
+    }, []);
+
+    return count;
+}


### PR DESCRIPTION
## Summary
- Renames "Hangouts" to "OpenPods" in the sidebar (desktop) and footer navigation (mobile)
- Adds a green live count badge next to the OpenPods menu item showing how many rooms are currently active — polls the API every 30 seconds, only shows when count > 0
- Adds an "About" link at the bottom of the sidebar pointing to https://about.snapie.io so users can learn more and download the native app

## Test plan
- [ ] Sidebar shows "OpenPods" label and tooltip on desktop
- [ ] Footer nav shows "OpenPods" tooltip on mobile
- [ ] Green badge appears next to OpenPods when rooms are live, disappears when none are active
- [ ] Badge caps at "99+" for large counts
- [ ] "About" link in sidebar opens https://about.snapie.io in a new tab
- [ ] No regressions on other nav items (chat badge, notifications, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced "Hangouts" navigation with "OpenPods" button and real-time notification badge.
  * Badge displays the count of available open pods (capped at 99+) in both footer and sidebar navigation.
  * Added new "About Snapie" link in the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->