### PR TITLE
feat: add grouped notifications

### DIFF
--- a/components/layout/FooterNavigation.tsx
+++ b/components/layout/FooterNavigation.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { FiBell, FiBook, FiCreditCard, FiHome, FiUser, FiLogIn, FiLogOut, FiMessageSquare, FiChevronLeft, FiChevronRight, FiRadio } from 'react-icons/fi';
 import { useState, useRef, useEffect } from 'react';
 import { useOpenPodsCount } from '@/hooks/useOpenPodsCount';
+import { useHiveNotifications } from '@/hooks/useHiveNotifications';
 
 interface FooterNavigationProps {
     isChatOpen: boolean;
@@ -24,6 +25,7 @@ export default function FooterNavigation({ isChatOpen, setIsChatOpen, chatUnread
     const [showLeftFade, setShowLeftFade] = useState(false);
     const [showRightFade, setShowRightFade] = useState(false);
     const openPodsCount = useOpenPodsCount();
+    const { unreadCount } = useHiveNotifications(user, { limit: 1 });
     
     const handleNavigation = (path: string) => {
         if (router) {
@@ -152,15 +154,18 @@ export default function FooterNavigation({ isChatOpen, setIsChatOpen, chatUnread
                 {user ? (
                     <>
                         <Tooltip label="Notifications" aria-label="Notifications tooltip">
-                            <Button
-                                onClick={() => handleNavigation("/@" + user + "/notifications")}
-                                variant="ghost"
-                                color="white"
-                                size="sm"
-                                minW="40px"
-                                _hover={{ bg: 'whiteAlpha.200' }}
-                                leftIcon={<Icon as={FiBell} boxSize={4} />}
-                            />
+                            <Box position="relative">
+                                <Button
+                                    onClick={() => handleNavigation("/@" + user + "/notifications")}
+                                    variant="ghost"
+                                    color="white"
+                                    size="sm"
+                                    minW="40px"
+                                    _hover={{ bg: 'whiteAlpha.200' }}
+                                    leftIcon={<Icon as={FiBell} boxSize={4} color={unreadCount > 0 ? 'red.300' : 'white'} />}
+                                />
+                                <CountBadge count={unreadCount} colorScheme="red" top="-2px" right="-2px" />
+                            </Box>
                         </Tooltip>
 
                         <Tooltip label="Wallet" aria-label="Wallet tooltip">

--- a/components/layout/FooterNavigation.tsx
+++ b/components/layout/FooterNavigation.tsx
@@ -25,7 +25,7 @@ export default function FooterNavigation({ isChatOpen, setIsChatOpen, chatUnread
     const [showLeftFade, setShowLeftFade] = useState(false);
     const [showRightFade, setShowRightFade] = useState(false);
     const openPodsCount = useOpenPodsCount();
-    const { unreadCount } = useHiveNotifications(user, { limit: 1 });
+    const { unreadCount } = useHiveNotifications(user, { limit: 1, poll: false });
     
     const handleNavigation = (path: string) => {
         if (router) {

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -6,11 +6,11 @@ import { useRouter, usePathname } from 'next/navigation';
 import { useAioha } from '@aioha/react-ui';
 import { useLoginModal } from '@/contexts/LoginModalContext';
 import { FiHome, FiBell, FiUser, FiShoppingCart, FiBook, FiCreditCard, FiLogIn, FiLogOut, FiMessageSquare, FiRadio, FiInfo } from 'react-icons/fi';
-import { Notifications } from '@hiveio/dhive';
-import { fetchNewNotifications, getCommunityInfo, getProfile } from '@/lib/hive/client-functions';
+import { getCommunityInfo, getProfile } from '@/lib/hive/client-functions';
 import { animate, color, motion, px } from 'framer-motion';
 import { getHiveAvatarUrl } from '@/lib/utils/avatarUtils';
 import { useOpenPodsCount } from '@/hooks/useOpenPodsCount';
+import { useHiveNotifications } from '@/hooks/useHiveNotifications';
 
 interface ProfileInfo {
     metadata: {
@@ -41,13 +41,13 @@ export default function Sidebar({ isChatOpen, setIsChatOpen, chatUnreadCount = 0
     const logout = () => aioha.logout();
     const router = useRouter();
     const pathname = usePathname();
-    const [notifications, setNotifications] = useState<Notifications[]>([]);
     const [communityInfo, setCommunityInfo] = useState<CommunityInfo | null>(null); // State to hold community info
     const [profileInfo, setProfileInfo] = useState<ProfileInfo | null>(null); // State to hold profile info
     const [loading, setLoading] = useState(true); // Loading state
     const { colorMode } = useColorMode();
     const toast = useToast();
     const openPodsCount = useOpenPodsCount();
+    const { unreadCount } = useHiveNotifications(user, { limit: 1 });
 
     // Check if we should force compact mode (compose page)
     const forceCompact = pathname === '/compose';
@@ -59,21 +59,6 @@ export default function Sidebar({ isChatOpen, setIsChatOpen, chatUnreadCount = 0
     
     // Detect if we're in compact mode for tooltip logic
     const isCompactMode = useBreakpointValue({ base: false, sm: true, md: false }) || forceCompact;
-
-    useEffect(() => {
-        const loadNotifications = async () => {
-            if (user) {
-                try {
-                    const newNotifications = await fetchNewNotifications(user);
-                    setNotifications(newNotifications);
-                } catch (error) {
-                    console.error("Failed to fetch notifications:", error);
-                }
-            }
-        };
-
-        loadNotifications();
-    }, [user]);
 
     useEffect(() => {
         const fetchData = async () => {
@@ -211,14 +196,14 @@ export default function Sidebar({ isChatOpen, setIsChatOpen, chatUnreadCount = 0
                     {user && (
                         <>
                             <Tooltip label="Notifications" placement="right" hasArrow isDisabled={!isCompactMode}>
-                                <Box w="full">
+                                <Box w="full" position="relative">
                                     <Button
                                         onClick={() => handleNavigation("/@" + user + "/notifications")}
                                         variant="ghost"
                                         w="full"
                                         justifyContent={iconJustify}
                                         leftIcon={
-                                            notifications.length > 0 ? (
+                                            unreadCount > 0 ? (
                                                 <motion.div
                                                     animate={{ rotate: [0, 45, 0, -45, 0] }}
                                                     transition={{ duration: 0.6, repeat: Infinity }}
@@ -234,6 +219,7 @@ export default function Sidebar({ isChatOpen, setIsChatOpen, chatUnreadCount = 0
                                     >
                                         <Text display={textDisplay}>Notifications</Text>
                                     </Button>
+                                    <CountBadge count={unreadCount} colorScheme="red" />
                                 </Box>
                             </Tooltip>
                             <Tooltip label="Profile" placement="right" hasArrow isDisabled={!isCompactMode}>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -47,7 +47,7 @@ export default function Sidebar({ isChatOpen, setIsChatOpen, chatUnreadCount = 0
     const { colorMode } = useColorMode();
     const toast = useToast();
     const openPodsCount = useOpenPodsCount();
-    const { unreadCount } = useHiveNotifications(user, { limit: 1 });
+    const { unreadCount } = useHiveNotifications(user, { limit: 1, poll: false });
 
     // Check if we should force compact mode (compose page)
     const forceCompact = pathname === '/compose';

--- a/components/notifications/NotificationsComp.tsx
+++ b/components/notifications/NotificationsComp.tsx
@@ -1,76 +1,637 @@
-import { useEffect, useState } from 'react';
-import { fetchNewNotifications, broadcastWithKeychain } from '@/lib/hive/client-functions';
-import { Box, Text, Stack, Spinner, Button, HStack } from '@chakra-ui/react';
+'use client';
+
+import { ReactNode, useMemo, useState } from 'react';
+import {
+  Avatar,
+  Badge,
+  Box,
+  Button,
+  Flex,
+  HStack,
+  Icon,
+  IconButton,
+  SimpleGrid,
+  Spinner,
+  Stack,
+  Text,
+  useToast,
+  VStack,
+} from '@chakra-ui/react';
 import { useAioha } from '@aioha/react-ui';
 import { Notifications } from '@hiveio/dhive';
-import NotificationItem from './NotificationItem'; 
+import { useRouter } from 'next/navigation';
+import {
+  FiAtSign,
+  FiBell,
+  FiCheckCircle,
+  FiChevronDown,
+  FiChevronRight,
+  FiMessageCircle,
+  FiRefreshCw,
+  FiRepeat,
+  FiSend,
+  FiThumbsUp,
+  FiUserPlus,
+} from 'react-icons/fi';
+import { IconType } from 'react-icons';
+import { useHiveNotifications } from '@/hooks/useHiveNotifications';
+import {
+  formatNotificationTime,
+  getNotificationActor,
+  getNotificationRoute,
+  getNotificationTypeLabel,
+  NOTIFICATION_CATEGORIES,
+  NotificationFilter,
+  parseHiveDate,
+} from '@/lib/utils/notificationHelpers';
+import { groupNotifications, NotificationGroup } from '@/lib/utils/notificationGrouping';
+import { getHiveAvatarUrl } from '@/lib/utils/avatarUtils';
 
 interface NotificationCompProps {
   username: string
 }
 
-export default function NotificationsComp({ username } : NotificationCompProps) {
+type BucketKey = 'today' | 'yesterday' | 'this_week' | 'this_month' | 'older';
+
+interface ActivitySummary {
+  total: number;
+  votes: number;
+  uniqueVoters: number;
+  totalEarnings: number;
+  replies: number;
+  mentions: number;
+  follows: number;
+  reblogs: number;
+  transfers: number;
+}
+
+const BUCKET_LABELS: Record<BucketKey, string> = {
+  today: 'Today',
+  yesterday: 'Yesterday',
+  this_week: 'This Week',
+  this_month: 'This Month',
+  older: 'Older',
+};
+
+const BUCKET_ORDER: BucketKey[] = ['today', 'yesterday', 'this_week', 'this_month', 'older'];
+const CATEGORY_ENTRIES = Object.entries(NOTIFICATION_CATEGORIES) as Array<[
+  Exclude<NotificationFilter, 'unread'>,
+  { label: string; types: readonly string[] | null },
+]>;
+const MAX_STACKED_AVATARS = 5;
+
+function getTimeBucket(dateString: string): BucketKey {
+  const date = parseHiveDate(dateString);
+  const now = new Date();
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const yesterdayStart = new Date(todayStart);
+  yesterdayStart.setDate(yesterdayStart.getDate() - 1);
+  const weekStart = new Date(todayStart);
+  weekStart.setDate(weekStart.getDate() - 7);
+  const monthStart = new Date(todayStart);
+  monthStart.setMonth(monthStart.getMonth() - 1);
+
+  if (date >= todayStart) return 'today';
+  if (date >= yesterdayStart) return 'yesterday';
+  if (date >= weekStart) return 'this_week';
+  if (date >= monthStart) return 'this_month';
+  return 'older';
+}
+
+function bucketize(groups: NotificationGroup[]) {
+  return groups.reduce<Record<BucketKey, NotificationGroup[]>>((buckets, group) => {
+    buckets[getTimeBucket(group.date)].push(group);
+    return buckets;
+  }, {
+    today: [],
+    yesterday: [],
+    this_week: [],
+    this_month: [],
+    older: [],
+  });
+}
+
+function computeSummary(notifications: Notifications[]): ActivitySummary {
+  const votes = notifications.filter((notification) => notification.type === 'vote');
+  const uniqueVoters = new Set(votes.map(getNotificationActor).filter(Boolean));
+  const totalEarnings = votes.reduce((sum, notification) => {
+    const match = notification.msg?.match(/\(\$([0-9]+(?:\.[0-9]+)?)\)/);
+    return sum + (match ? parseFloat(match[1]) : 0);
+  }, 0);
+
+  return {
+    total: notifications.length,
+    votes: votes.length,
+    uniqueVoters: uniqueVoters.size,
+    totalEarnings: Math.round(totalEarnings * 1000) / 1000,
+    replies: notifications.filter((notification) => ['reply', 'reply_comment'].includes(notification.type)).length,
+    mentions: notifications.filter((notification) => notification.type === 'mention').length,
+    follows: notifications.filter((notification) => notification.type === 'follow').length,
+    reblogs: notifications.filter((notification) => notification.type === 'reblog').length,
+    transfers: notifications.filter((notification) => notification.type === 'transfer').length,
+  };
+}
+
+function getSummaryItems(summary: ActivitySummary) {
+  return [
+    summary.votes > 0 && {
+      key: 'votes',
+      icon: FiThumbsUp,
+      value: summary.votes,
+      label: 'Votes',
+      detail: `${summary.uniqueVoters} voter${summary.uniqueVoters === 1 ? '' : 's'}`,
+      sub: summary.totalEarnings > 0 ? `$${summary.totalEarnings.toFixed(2)}` : null,
+      filter: 'votes' as NotificationFilter,
+      color: 'green',
+    },
+    summary.replies > 0 && {
+      key: 'replies',
+      icon: FiMessageCircle,
+      value: summary.replies,
+      label: 'Replies',
+      filter: 'replies' as NotificationFilter,
+      color: 'blue',
+    },
+    summary.follows > 0 && {
+      key: 'follows',
+      icon: FiUserPlus,
+      value: summary.follows,
+      label: 'New Followers',
+      filter: 'follows' as NotificationFilter,
+      color: 'purple',
+    },
+    summary.mentions > 0 && {
+      key: 'mentions',
+      icon: FiAtSign,
+      value: summary.mentions,
+      label: 'Mentions',
+      filter: 'mentions' as NotificationFilter,
+      color: 'orange',
+    },
+    summary.reblogs > 0 && {
+      key: 'reblogs',
+      icon: FiRepeat,
+      value: summary.reblogs,
+      label: 'Reblogs',
+      filter: 'reblogs' as NotificationFilter,
+      color: 'cyan',
+    },
+    summary.transfers > 0 && {
+      key: 'transfers',
+      icon: FiSend,
+      value: summary.transfers,
+      label: 'Transfers',
+      filter: 'transfers' as NotificationFilter,
+      color: 'pink',
+    },
+  ].filter(Boolean) as Array<{
+    key: string;
+    icon: IconType;
+    value: number;
+    label: string;
+    detail?: string;
+    sub?: string | null;
+    filter: NotificationFilter;
+    color: string;
+  }>;
+}
+
+export default function NotificationsComp({ username }: NotificationCompProps) {
   const { user } = useAioha();
-  const [notifications, setNotifications] = useState<Notifications[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(true); // Add isLoading state
+  const router = useRouter();
+  const toast = useToast();
+  const [filter, setFilter] = useState<NotificationFilter>('all');
+  const [summaryRange, setSummaryRange] = useState<'today' | 'week' | 'month'>('week');
+  const canViewNotifications = Boolean(user && user === username);
 
-  useEffect(() => {
-    const loadNotifications = async () => {
-      if (user) {
-        try {
-          setIsLoading(true); 
-          const newNotifications = await fetchNewNotifications(username);
-          setNotifications(newNotifications);
-        } catch (error) {
-          console.error("Failed to fetch notifications:", error);
-        } finally {
-          setIsLoading(false); 
-        }
-      }
-    };
+  const {
+    notifications,
+    loading,
+    loadingMore,
+    hasMore,
+    error,
+    refetch,
+    loadMore,
+    unreadCount,
+    markAllAsRead,
+    markingAsRead,
+    isUnread,
+  } = useHiveNotifications(canViewNotifications ? username : null, { limit: 50 });
 
-    loadNotifications();
-  }, [user, username]);
+  const filtered = useMemo(() => {
+    if (filter === 'unread') {
+      return notifications.filter(isUnread);
+    }
 
-  async function handleMarkAsRead () {
-    if (!user) return;
-    
-    const now = new Date().toISOString(); 
-    const json = JSON.stringify(["setLastRead", { date: now }]);
-    const result = await broadcastWithKeychain(user, [
-      ['custom_json', {
-        required_auths: [],
-        required_posting_auths: [user],
-        id: 'notify',
-        json: json,
-      }]
-    ], 'posting')
-    console.log("Mark as Read clicked", result);
+    const allowedTypes = NOTIFICATION_CATEGORIES[filter].types as readonly string[] | null;
+    return allowedTypes
+      ? notifications.filter((notification) => allowedTypes.includes(notification.type))
+      : notifications;
+  }, [filter, isUnread, notifications]);
+
+  const grouped = useMemo(() => groupNotifications(filtered), [filtered]);
+  const bucketed = useMemo(() => bucketize(grouped), [grouped]);
+
+  const summary = useMemo(() => {
+    const now = new Date();
+    const cutoff = new Date(now);
+
+    if (summaryRange === 'today') {
+      cutoff.setHours(0, 0, 0, 0);
+    } else if (summaryRange === 'week') {
+      cutoff.setDate(cutoff.getDate() - 7);
+    } else {
+      cutoff.setMonth(cutoff.getMonth() - 1);
+    }
+
+    return computeSummary(notifications.filter((notification) => parseHiveDate(notification.date) >= cutoff));
+  }, [notifications, summaryRange]);
+
+  const handleMarkAllAsRead = async () => {
+    try {
+      await markAllAsRead();
+      toast({ title: 'Notifications marked as read', status: 'success', duration: 2500 });
+    } catch {
+      toast({ title: 'Could not mark notifications as read', status: 'error', duration: 3500 });
+    }
   };
 
+  const handleNotificationClick = (notification: Notifications) => {
+    const route = getNotificationRoute(notification);
+    if (route) router.push(route);
+  };
+
+  if (!canViewNotifications) {
+    return (
+      <Box p={4} w="full">
+        <EmptyState title="Please log in to view your notifications." />
+      </Box>
+    );
+  }
+
   return (
-    <Box p={4} w="full">
-    <HStack mb={4} spacing={4} align="center" justify="space-between">
-      <Text fontSize="2xl" fontWeight="bold">
-        Notifications
-      </Text>
-      {(user == username) && (
-        <Button onClick={handleMarkAsRead} size="sm">
-          Mark as Read
+    <Box p={{ base: 3, md: 6 }} w="full" maxW="980px" mx="auto">
+      <Flex justify="space-between" align={{ base: 'start', md: 'center' }} gap={3} mb={5} flexWrap="wrap">
+        <Box>
+          <HStack spacing={3}>
+            <Text fontSize={{ base: '2xl', md: '3xl' }} fontWeight="bold">
+              Notifications
+            </Text>
+            {unreadCount > 0 && (
+              <Badge colorScheme="red" borderRadius="full" px={3} py={1}>
+                {unreadCount} new
+              </Badge>
+            )}
+          </HStack>
+          <Text fontSize="sm" color="text" opacity={0.75}>
+            Grouped activity from Hive, routed back into Snapie.
+          </Text>
+        </Box>
+        <HStack>
+          {unreadCount > 0 && (
+            <Button
+              leftIcon={<Icon as={FiCheckCircle} />}
+              size="sm"
+              onClick={handleMarkAllAsRead}
+              isLoading={markingAsRead}
+            >
+              Mark all read
+            </Button>
+          )}
+          <IconButton
+            aria-label="Refresh notifications"
+            icon={<Icon as={FiRefreshCw} />}
+            size="sm"
+            onClick={refetch}
+            isLoading={loading}
+          />
+        </HStack>
+      </Flex>
+
+      <HStack spacing={2} overflowX="auto" pb={2} mb={4}>
+        {CATEGORY_ENTRIES.map(([key, category]) => (
+          <Button
+            key={key}
+            size="sm"
+            variant={filter === key ? 'solid' : 'outline'}
+            onClick={() => setFilter(key)}
+            flexShrink={0}
+          >
+            {category.label}
+          </Button>
+        ))}
+        <Button
+          size="sm"
+          variant={filter === 'unread' ? 'solid' : 'outline'}
+          colorScheme="red"
+          onClick={() => setFilter('unread')}
+          flexShrink={0}
+        >
+          Unread {unreadCount > 0 ? `(${unreadCount})` : ''}
         </Button>
+      </HStack>
+
+      <ActivitySummaryCard
+        summary={summary}
+        range={summaryRange}
+        onRangeChange={setSummaryRange}
+        onFilter={setFilter}
+      />
+
+      {Boolean(error) && (
+        <Box bg="red.500" color="white" borderRadius="base" p={3} mb={4}>
+          Could not load notifications. <Button size="xs" ml={2} onClick={refetch}>Retry</Button>
+        </Box>
       )}
-    </HStack>
-      {isLoading ? (
-        <Spinner size="lg" />
-      ) : notifications.length > 0 ? (
-        <Stack spacing={4} w="full">
-          {notifications.map(notification => (
-            <NotificationItem key={notification.id} notification={notification} />
-          ))}
+
+      {loading && filtered.length === 0 ? (
+        <Flex justify="center" py={12}>
+          <Spinner size="lg" />
+        </Flex>
+      ) : grouped.length > 0 ? (
+        <Stack spacing={6}>
+          {BUCKET_ORDER.map((bucket) => {
+            const items = bucketed[bucket];
+            if (!items.length) return null;
+
+            return (
+              <Box key={bucket}>
+                <Text fontSize="sm" fontWeight="bold" textTransform="uppercase" letterSpacing="wide" opacity={0.7} mb={2}>
+                  {BUCKET_LABELS[bucket]}
+                </Text>
+                <Stack spacing={3}>
+                  {items.map((group) => (
+                    <NotificationRow
+                      key={group.id}
+                      group={group}
+                      isUnread={isUnread}
+                      onClick={handleNotificationClick}
+                    />
+                  ))}
+                </Stack>
+              </Box>
+            );
+          })}
+          {hasMore && (
+            <Button onClick={loadMore} isLoading={loadingMore} alignSelf="center" variant="outline">
+              Load more
+            </Button>
+          )}
         </Stack>
       ) : (
-        <Text>No notifications</Text>
+        <EmptyState
+          title={
+            filter === 'all'
+              ? 'You have no notifications yet.'
+              : filter === 'unread'
+                ? 'No unread notifications.'
+                : `No ${NOTIFICATION_CATEGORIES[filter].label.toLowerCase()} yet.`
+          }
+        />
       )}
+    </Box>
+  );
+}
+
+function ActivitySummaryCard({
+  summary,
+  range,
+  onRangeChange,
+  onFilter,
+}: {
+  summary: ActivitySummary;
+  range: 'today' | 'week' | 'month';
+  onRangeChange: (range: 'today' | 'week' | 'month') => void;
+  onFilter: (filter: NotificationFilter) => void;
+}) {
+  const summaryItems = getSummaryItems(summary);
+
+  return (
+    <Box bg="muted" border="tb1" borderRadius="base" p={4} mb={5}>
+      <Flex justify="space-between" align="center" gap={3} mb={4} flexWrap="wrap">
+        <HStack>
+          <Icon as={FiBell} />
+          <Text fontWeight="bold">Activity</Text>
+        </HStack>
+        <HStack spacing={2}>
+          {[
+            ['today', 'Today'],
+            ['week', 'This Week'],
+            ['month', 'This Month'],
+          ].map(([key, label]) => (
+            <Button
+              key={key}
+              size="xs"
+              variant={range === key ? 'solid' : 'ghost'}
+              onClick={() => onRangeChange(key as 'today' | 'week' | 'month')}
+            >
+              {label}
+            </Button>
+          ))}
+        </HStack>
+      </Flex>
+      {summaryItems.length > 0 ? (
+        <SimpleGrid columns={{ base: 2, md: 3, lg: 6 }} spacing={3}>
+          {summaryItems.map((item) => (
+            <Button
+              key={item.key}
+              h="auto"
+              py={3}
+              px={3}
+              variant="outline"
+              borderColor={`${item.color}.300`}
+              onClick={() => onFilter(item.filter)}
+            >
+              <VStack spacing={1}>
+                <Icon as={item.icon} color={`${item.color}.400`} />
+                <Text fontSize="xl" fontWeight="bold">{item.value}</Text>
+                <Text fontSize="xs">{item.label}</Text>
+                {item.sub && <Text fontSize="xs" opacity={0.75}>{item.sub}</Text>}
+                {item.detail && <Text fontSize="xs" opacity={0.65}>{item.detail}</Text>}
+              </VStack>
+            </Button>
+          ))}
+        </SimpleGrid>
+      ) : (
+        <Text fontSize="sm" opacity={0.7}>No activity in this range yet.</Text>
+      )}
+    </Box>
+  );
+}
+
+function NotificationRow({
+  group,
+  isUnread,
+  onClick,
+}: {
+  group: NotificationGroup;
+  isUnread: (notification: Notifications) => boolean;
+  onClick: (notification: Notifications) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (group.type === 'single') {
+    return (
+      <SingleNotificationRow
+        notification={group.notification}
+        unread={isUnread(group.notification)}
+        onClick={() => onClick(group.notification)}
+      />
+    );
+  }
+
+  const hasUnread = group.items.some(isUnread);
+  const topActors = group.actors.slice(0, MAX_STACKED_AVATARS);
+  const remainingActors = group.actors.length - MAX_STACKED_AVATARS;
+  const actorLabel = group.actors.length <= 2
+    ? group.actors.map((actor) => `@${actor}`).join(' and ')
+    : `@${group.actors[0]} and ${group.actors.length - 1} others`;
+  const label = group.notifType === 'vote'
+    ? `${actorLabel} voted on your post${group.totalValue ? ` ($${group.totalValue.toFixed(2)})` : ''}`
+    : group.notifType === 'follow'
+      ? `${actorLabel} followed you`
+      : `${group.items.length} ${group.notifType} notifications`;
+
+  return (
+    <Box>
+      <NotificationShell
+        unread={hasUnread}
+        onClick={() => setExpanded((value) => !value)}
+      >
+        <AvatarStack actors={topActors} remaining={remainingActors} />
+        <Box flex="1" minW={0}>
+          <Text fontWeight="semibold">{label}</Text>
+          <HStack fontSize="sm" opacity={0.72} spacing={2}>
+            <Text>{group.items.length} {group.notifType}{group.items.length === 1 ? '' : 's'}</Text>
+            <Text>·</Text>
+            <Text>{formatNotificationTime(group.date)}</Text>
+            <HStack spacing={1}>
+              <Icon as={expanded ? FiChevronDown : FiChevronRight} />
+              <Text>{expanded ? 'collapse' : 'expand'}</Text>
+            </HStack>
+          </HStack>
+        </Box>
+      </NotificationShell>
+      {expanded && (
+        <Stack spacing={2} mt={2} pl={{ base: 3, md: 10 }}>
+          {group.items.map((notification) => (
+            <SingleNotificationRow
+              key={notification.id}
+              notification={notification}
+              unread={isUnread(notification)}
+              onClick={() => onClick(notification)}
+              nested
+            />
+          ))}
+        </Stack>
+      )}
+    </Box>
+  );
+}
+
+function SingleNotificationRow({
+  notification,
+  unread,
+  onClick,
+  nested = false,
+}: {
+  notification: Notifications;
+  unread: boolean;
+  onClick: () => void;
+  nested?: boolean;
+}) {
+  const actor = getNotificationActor(notification);
+
+  return (
+    <NotificationShell unread={unread} onClick={onClick} nested={nested}>
+      <Avatar size="sm" src={actor ? getHiveAvatarUrl(actor, 'small') : undefined} name={actor || undefined} />
+      <Box flex="1" minW={0}>
+        <Text fontWeight="semibold">{notification.msg || getNotificationTypeLabel(notification.type)}</Text>
+        <HStack fontSize="sm" opacity={0.72} spacing={2}>
+          <Text>{getNotificationTypeLabel(notification.type)}</Text>
+          <Text>·</Text>
+          <Text>{formatNotificationTime(notification.date)}</Text>
+        </HStack>
+      </Box>
+    </NotificationShell>
+  );
+}
+
+function NotificationShell({
+  children,
+  unread,
+  onClick,
+  nested = false,
+}: {
+  children: ReactNode;
+  unread: boolean;
+  onClick: () => void;
+  nested?: boolean;
+}) {
+  return (
+    <HStack
+      as="button"
+      type="button"
+      textAlign="left"
+      w="full"
+      spacing={3}
+      p={nested ? 3 : 4}
+      bg={unread ? 'secondary' : 'muted'}
+      border="tb1"
+      borderRadius="base"
+      align="center"
+      position="relative"
+      _hover={{ transform: 'translateY(-1px)', boxShadow: 'md' }}
+      transition="all 0.15s ease"
+      onClick={onClick}
+    >
+      {children}
+      {unread && (
+        <Box w="9px" h="9px" bg="red.400" borderRadius="full" flexShrink={0} aria-hidden="true" />
+      )}
+    </HStack>
+  );
+}
+
+function AvatarStack({ actors, remaining }: { actors: string[]; remaining: number }) {
+  return (
+    <HStack spacing={0} minW={`${Math.min(actors.length, MAX_STACKED_AVATARS) * 22 + (remaining > 0 ? 28 : 0)}px`}>
+      {actors.map((actor, index) => (
+        <Avatar
+          key={actor}
+          size="sm"
+          src={getHiveAvatarUrl(actor, 'small')}
+          name={actor}
+          ml={index === 0 ? 0 : '-10px'}
+          border="2px solid"
+          borderColor="muted"
+        />
+      ))}
+      {remaining > 0 && (
+        <Flex
+          ml="-10px"
+          boxSize="32px"
+          borderRadius="full"
+          align="center"
+          justify="center"
+          bg="background"
+          border="2px solid"
+          borderColor="muted"
+          fontSize="xs"
+          fontWeight="bold"
+        >
+          +{remaining}
+        </Flex>
+      )}
+    </HStack>
+  );
+}
+
+function EmptyState({ title }: { title: string }) {
+  return (
+    <Box bg="muted" border="tb1" borderRadius="base" p={8} textAlign="center">
+      <Icon as={FiBell} boxSize={8} opacity={0.45} mb={3} />
+      <Text>{title}</Text>
     </Box>
   );
 }

--- a/components/notifications/NotificationsComp.tsx
+++ b/components/notifications/NotificationsComp.tsx
@@ -486,10 +486,11 @@ function NotificationRow({
   const actorLabel = group.actors.length <= 2
     ? group.actors.map((actor) => `@${actor}`).join(' and ')
     : `@${group.actors[0]} and ${group.actors.length - 1} others`;
+  const actorPrefix = actorLabel ? `${actorLabel} ` : 'Someone ';
   const label = group.notifType === 'vote'
-    ? `${actorLabel} voted on your post${group.totalValue ? ` ($${group.totalValue.toFixed(2)})` : ''}`
+    ? `${actorPrefix}voted on your post${group.totalValue ? ` ($${group.totalValue.toFixed(2)})` : ''}`
     : group.notifType === 'follow'
-      ? `${actorLabel} followed you`
+      ? `${actorPrefix}followed you`
       : `${group.items.length} ${group.notifType} notifications`;
 
   return (

--- a/hooks/useHiveNotifications.ts
+++ b/hooks/useHiveNotifications.ts
@@ -1,0 +1,210 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Notifications } from '@hiveio/dhive';
+import HiveClient from '@/lib/hive/hiveclient';
+import { customJsonWithAioha, KeyTypes } from '@/lib/hive/aioha';
+import { parseHiveDate } from '@/lib/utils/notificationHelpers';
+
+const POLL_INTERVAL_MS = 60_000;
+
+interface UnreadNotificationState {
+  lastread?: string;
+  unread?: number;
+}
+
+interface UseHiveNotificationsOptions {
+  limit?: number;
+  poll?: boolean;
+}
+
+async function fetchNotifications(account: string, limit: number, lastId?: number | string | null): Promise<Notifications[]> {
+  const params: Record<string, string | number> = { account, limit };
+  if (lastId !== undefined && lastId !== null) params.last_id = lastId;
+
+  const result = await HiveClient.call('bridge', 'account_notifications', params);
+  return Array.isArray(result) ? result : [];
+}
+
+async function fetchUnreadState(account: string): Promise<UnreadNotificationState> {
+  const result = await HiveClient.call('bridge', 'unread_notifications', { account });
+  return result || { lastread: '1970-01-01T00:00:00', unread: 0 };
+}
+
+export function useHiveNotifications(
+  account: string | null | undefined,
+  { limit = 50, poll = true }: UseHiveNotificationsOptions = {},
+) {
+  const [notifications, setNotifications] = useState<Notifications[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const [error, setError] = useState<unknown>(null);
+  const [lastRead, setLastRead] = useState('1970-01-01T00:00:00');
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [markingAsRead, setMarkingAsRead] = useState(false);
+
+  const accountRef = useRef(account);
+  accountRef.current = account;
+
+  const fetchUnread = useCallback(async () => {
+    if (!account) return;
+
+    try {
+      const state = await fetchUnreadState(account);
+      if (accountRef.current === account) {
+        setLastRead(state.lastread || '1970-01-01T00:00:00');
+        setUnreadCount(state.unread || 0);
+      }
+    } catch {
+      // Notification unread state is nice-to-have; the list can still render.
+    }
+  }, [account]);
+
+  const refetch = useCallback(async () => {
+    if (!account) {
+      setNotifications([]);
+      setHasMore(true);
+      setUnreadCount(0);
+      setLastRead('1970-01-01T00:00:00');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await fetchNotifications(account, limit);
+      if (accountRef.current === account) {
+        setNotifications(data);
+        setHasMore(data.length >= limit);
+      }
+    } catch (err) {
+      console.error('[notifications] fetch failed:', err);
+      if (accountRef.current === account) setError(err);
+    } finally {
+      if (accountRef.current === account) setLoading(false);
+    }
+
+    fetchUnread();
+  }, [account, fetchUnread, limit]);
+
+  const loadMore = useCallback(async () => {
+    if (!account || loadingMore || !hasMore) return;
+
+    const oldestId = notifications[notifications.length - 1]?.id;
+    if (!oldestId) return;
+
+    setLoadingMore(true);
+    setError(null);
+
+    try {
+      const data = await fetchNotifications(account, limit, oldestId);
+      if (accountRef.current === account) {
+        setNotifications((prev) => {
+          const seen = new Set(prev.map((notification) => notification.id));
+          return [...prev, ...data.filter((notification) => !seen.has(notification.id))];
+        });
+        setHasMore(data.length >= limit);
+      }
+    } catch (err) {
+      console.error('[notifications] load more failed:', err);
+      if (accountRef.current === account) setError(err);
+    } finally {
+      if (accountRef.current === account) setLoadingMore(false);
+    }
+  }, [account, hasMore, limit, loadingMore, notifications]);
+
+  const markAllAsRead = useCallback(async () => {
+    if (!account || markingAsRead || unreadCount === 0) return;
+
+    setMarkingAsRead(true);
+    try {
+      const readThroughDate = new Date().toISOString().replace('Z', '');
+
+      await customJsonWithAioha(
+        KeyTypes.Posting,
+        'notify',
+        JSON.stringify(['setLastRead', { date: readThroughDate }]),
+        'Mark notifications as read',
+        'Mark notifications as read',
+      );
+
+      setLastRead(readThroughDate);
+      setUnreadCount(0);
+    } catch (err) {
+      console.error('[notifications] mark all as read failed:', err);
+      throw err;
+    } finally {
+      setMarkingAsRead(false);
+    }
+  }, [account, markingAsRead, unreadCount]);
+
+  const markAsRead = useCallback(async (notificationDate: string) => {
+    if (!account || markingAsRead || parseHiveDate(notificationDate) <= parseHiveDate(lastRead)) return;
+
+    setMarkingAsRead(true);
+    try {
+      await customJsonWithAioha(
+        KeyTypes.Posting,
+        'notify',
+        JSON.stringify(['setLastRead', { date: notificationDate }]),
+        'Mark notification as read',
+        'Mark notification as read',
+      );
+
+      setLastRead(notificationDate);
+      const newLastRead = parseHiveDate(notificationDate);
+      setUnreadCount(notifications.filter((notification) => parseHiveDate(notification.date) > newLastRead).length);
+    } catch (err) {
+      console.error('[notifications] mark as read failed:', err);
+      throw err;
+    } finally {
+      setMarkingAsRead(false);
+    }
+  }, [account, lastRead, markingAsRead, notifications]);
+
+  const isUnread = useCallback(
+    (notification: Notifications) => parseHiveDate(notification.date) > parseHiveDate(lastRead),
+    [lastRead],
+  );
+
+  useEffect(() => {
+    setNotifications([]);
+    setHasMore(true);
+    setLastRead('1970-01-01T00:00:00');
+    setUnreadCount(0);
+    if (account) refetch();
+  }, [account, refetch]);
+
+  useEffect(() => {
+    if (!account || !poll) return;
+
+    const intervalId = window.setInterval(refetch, POLL_INTERVAL_MS);
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') refetch();
+    };
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => {
+      window.clearInterval(intervalId);
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [account, poll, refetch]);
+
+  return {
+    notifications,
+    loading,
+    loadingMore,
+    hasMore,
+    error,
+    refetch,
+    loadMore,
+    unreadCount,
+    lastRead,
+    markAllAsRead,
+    markAsRead,
+    markingAsRead,
+    isUnread,
+  };
+}

--- a/lib/utils/notificationGrouping.ts
+++ b/lib/utils/notificationGrouping.ts
@@ -1,4 +1,5 @@
 import { Notifications } from '@hiveio/dhive';
+import { extractNotificationActor } from './notificationHelpers';
 
 const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
 
@@ -29,14 +30,8 @@ function extractVoteValue(message?: string): number {
   return match ? parseFloat(match[1]) : 0;
 }
 
-function extractActor(message?: string): string | null {
-  if (!message) return null;
-  const match = message.match(/@([a-z0-9._-]+)/i);
-  return match ? match[1] : null;
-}
-
 function makeSingle(notification: Notifications): NotificationGroup {
-  const actor = extractActor(notification.msg);
+  const actor = extractNotificationActor(notification.msg);
   const group: NotificationGroup = {
     id: notification.id,
     type: 'single',
@@ -62,7 +57,7 @@ function makeGroup(items: Notifications[], notifType: string): NotificationGroup
   const actors: string[] = [];
 
   for (const notification of sorted) {
-    const actor = extractActor(notification.msg);
+    const actor = extractNotificationActor(notification.msg);
     if (actor && !seen.has(actor)) {
       seen.add(actor);
       actors.push(actor);
@@ -97,7 +92,12 @@ export function groupNotifications(notifications: Notifications[]): Notification
 
   for (const notification of notifications) {
     if (notification.type === 'vote') {
-      const key = notification.url || '__no_url__';
+      if (!notification.url) {
+        result.push(makeSingle(notification));
+        continue;
+      }
+
+      const key = notification.url;
       votesByUrl.set(key, [...(votesByUrl.get(key) || []), notification]);
     } else if (notification.type === 'follow') {
       followBucket.push(notification);

--- a/lib/utils/notificationGrouping.ts
+++ b/lib/utils/notificationGrouping.ts
@@ -1,0 +1,141 @@
+import { Notifications } from '@hiveio/dhive';
+
+const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
+
+export type NotificationGroup =
+  | {
+      id: number | string;
+      type: 'single';
+      notifType: string;
+      items: Notifications[];
+      date: string;
+      notification: Notifications;
+      actors: string[];
+      totalValue?: number;
+    }
+  | {
+      id: number | string;
+      type: 'group';
+      notifType: string;
+      items: Notifications[];
+      date: string;
+      actors: string[];
+      totalValue?: number;
+    };
+
+function extractVoteValue(message?: string): number {
+  if (!message) return 0;
+  const match = message.match(/\(\$([0-9]+(?:\.[0-9]+)?)\)/);
+  return match ? parseFloat(match[1]) : 0;
+}
+
+function extractActor(message?: string): string | null {
+  if (!message) return null;
+  const match = message.match(/@([a-z0-9._-]+)/i);
+  return match ? match[1] : null;
+}
+
+function makeSingle(notification: Notifications): NotificationGroup {
+  const actor = extractActor(notification.msg);
+  const group: NotificationGroup = {
+    id: notification.id,
+    type: 'single',
+    notifType: notification.type,
+    items: [notification],
+    date: notification.date,
+    notification,
+    actors: actor ? [actor] : [],
+  };
+
+  if (notification.type === 'vote') {
+    group.totalValue = extractVoteValue(notification.msg);
+  }
+
+  return group;
+}
+
+function makeGroup(items: Notifications[], notifType: string): NotificationGroup {
+  const sorted = [...items].sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+  );
+  const seen = new Set<string>();
+  const actors: string[] = [];
+
+  for (const notification of sorted) {
+    const actor = extractActor(notification.msg);
+    if (actor && !seen.has(actor)) {
+      seen.add(actor);
+      actors.push(actor);
+    }
+  }
+
+  const group: NotificationGroup = {
+    id: sorted[0].id,
+    type: 'group',
+    notifType,
+    items: sorted,
+    date: sorted[0].date,
+    actors,
+  };
+
+  if (notifType === 'vote') {
+    group.totalValue = Math.round(
+      sorted.reduce((sum, notification) => sum + extractVoteValue(notification.msg), 0) * 1000,
+    ) / 1000;
+  }
+
+  return group;
+}
+
+export function groupNotifications(notifications: Notifications[]): NotificationGroup[] {
+  if (!notifications.length) return [];
+
+  const result: NotificationGroup[] = [];
+  const votesByUrl = new Map<string, Notifications[]>();
+  const followBucket: Notifications[] = [];
+  const others: Notifications[] = [];
+
+  for (const notification of notifications) {
+    if (notification.type === 'vote') {
+      const key = notification.url || '__no_url__';
+      votesByUrl.set(key, [...(votesByUrl.get(key) || []), notification]);
+    } else if (notification.type === 'follow') {
+      followBucket.push(notification);
+    } else {
+      others.push(notification);
+    }
+  }
+
+  for (const votes of votesByUrl.values()) {
+    const sorted = [...votes].sort(
+      (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+    );
+    let windowStart = new Date(sorted[0].date).getTime();
+    let currentWindow = [sorted[0]];
+
+    for (let i = 1; i < sorted.length; i++) {
+      const timestamp = new Date(sorted[i].date).getTime();
+      if (timestamp - windowStart <= TWENTY_FOUR_HOURS) {
+        currentWindow.push(sorted[i]);
+      } else {
+        result.push(currentWindow.length === 1 ? makeSingle(currentWindow[0]) : makeGroup(currentWindow, 'vote'));
+        currentWindow = [sorted[i]];
+        windowStart = timestamp;
+      }
+    }
+
+    result.push(currentWindow.length === 1 ? makeSingle(currentWindow[0]) : makeGroup(currentWindow, 'vote'));
+  }
+
+  if (followBucket.length === 1) {
+    result.push(makeSingle(followBucket[0]));
+  } else if (followBucket.length > 1) {
+    result.push(makeGroup(followBucket, 'follow'));
+  }
+
+  for (const notification of others) {
+    result.push(makeSingle(notification));
+  }
+
+  return result.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+}

--- a/lib/utils/notificationHelpers.ts
+++ b/lib/utils/notificationHelpers.ts
@@ -1,0 +1,123 @@
+import { Notifications } from '@hiveio/dhive';
+
+export const NOTIFICATION_CATEGORIES = {
+  all: { label: 'All', types: null },
+  replies: { label: 'Replies', types: ['reply', 'reply_comment'] },
+  mentions: { label: 'Mentions', types: ['mention'] },
+  votes: { label: 'Votes', types: ['vote'] },
+  reblogs: { label: 'Reblogs', types: ['reblog'] },
+  follows: { label: 'Follows', types: ['follow'] },
+  transfers: { label: 'Transfers', types: ['transfer'] },
+} as const;
+
+export type NotificationFilter = keyof typeof NOTIFICATION_CATEGORIES | 'unread';
+
+const TYPE_LABELS: Record<string, string> = {
+  reply: 'replied',
+  reply_comment: 'replied',
+  mention: 'mentioned you',
+  vote: 'upvoted',
+  follow: 'followed you',
+  reblog: 'reblogged',
+  transfer: 'sent you',
+  delegate_vests: 'delegated HP to you',
+  receive_vesting: 'sent you HP',
+  powerdown: 'started a power down',
+  subscribe: 'subscribed',
+  pin_post: 'pinned your post',
+  unpin_post: 'unpinned your post',
+};
+
+function stripKnownFrontendUrl(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl);
+    const knownHosts = ['peakd.com', 'hive.blog', 'ecency.com', '3speak.tv', 'www.3speak.tv'];
+    if (!knownHosts.some((host) => url.hostname === host || url.hostname.endsWith(`.${host}`))) {
+      return rawUrl;
+    }
+
+    const path = url.pathname.replace(/^\/+/, '');
+    if (url.hostname.includes('3speak.tv') && url.searchParams.get('v')) {
+      return url.searchParams.get('v') || rawUrl;
+    }
+
+    return path || rawUrl;
+  } catch {
+    return rawUrl;
+  }
+}
+
+export function getNotificationPostKey(notification: Notifications): string | null {
+  if (!notification?.url) return null;
+  const raw = stripKnownFrontendUrl(notification.url);
+  if (raw.startsWith('trx:')) return null;
+  if (raw.startsWith('@') && !raw.includes('/')) return null;
+
+  const normalized = raw.startsWith('/') ? raw.slice(1) : raw;
+  const parts = normalized.split('/').filter(Boolean);
+  const postParts = parts.length >= 3 && parts[1]?.startsWith('@') ? parts.slice(1) : parts;
+  const author = postParts[0]?.replace(/^@/, '');
+  const permlink = postParts[1];
+
+  return author && permlink ? `${author}/${permlink}` : null;
+}
+
+export function getNotificationRoute(notification: Notifications): string | null {
+  if (!notification?.url) return null;
+
+  const raw = stripKnownFrontendUrl(notification.url);
+  if (raw.startsWith('trx:')) return null;
+
+  const normalized = raw.replace(/^\/+/, '');
+  if (normalized.startsWith('@') && !normalized.includes('/')) {
+    return `/${normalized}`;
+  }
+
+  const parts = normalized.split('/').filter(Boolean);
+  if (parts.length >= 3 && parts[1]?.startsWith('@')) {
+    return `/${parts[0]}/${parts[1]}/${parts[2]}`;
+  }
+
+  const author = parts[0]?.replace(/^@/, '');
+  const permlink = parts[1];
+  if (author && permlink) return `/@${author}/${permlink}`;
+  if (author) return `/@${author}`;
+
+  return null;
+}
+
+export function getNotificationActor(notification: Notifications): string | null {
+  if (!notification?.msg) return null;
+  const match = notification.msg.match(/^@([a-z0-9.-]+)/i);
+  return match ? match[1] : null;
+}
+
+export function getNotificationTypeLabel(type: string): string {
+  return TYPE_LABELS[type] || type || 'activity';
+}
+
+export function formatNotificationTime(dateString: string): string {
+  if (!dateString) return '';
+  const date = new Date(dateString + (dateString.endsWith('Z') ? '' : 'Z'));
+  const diffSec = Math.max(0, Math.floor((Date.now() - date.getTime()) / 1000));
+  if (diffSec < 60) return `${diffSec}s`;
+
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m`;
+
+  const diffHours = Math.floor(diffMin / 60);
+  if (diffHours < 24) return `${diffHours}h`;
+
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 30) return `${diffDays}d`;
+
+  const diffMonths = Math.floor(diffDays / 30);
+  if (diffMonths < 12) return `${diffMonths}mo`;
+
+  return `${Math.floor(diffMonths / 12)}y`;
+}
+
+export function parseHiveDate(dateString?: string): Date {
+  if (!dateString) return new Date(0);
+  return new Date(dateString + (dateString.endsWith('Z') ? '' : 'Z'));
+}

--- a/lib/utils/notificationHelpers.ts
+++ b/lib/utils/notificationHelpers.ts
@@ -86,10 +86,14 @@ export function getNotificationRoute(notification: Notifications): string | null
   return null;
 }
 
-export function getNotificationActor(notification: Notifications): string | null {
-  if (!notification?.msg) return null;
-  const match = notification.msg.match(/^@([a-z0-9.-]+)/i);
+export function extractNotificationActor(message?: string): string | null {
+  if (!message) return null;
+  const match = message.match(/^@([a-z0-9.-]+)/i);
   return match ? match[1] : null;
+}
+
+export function getNotificationActor(notification: Notifications): string | null {
+  return extractNotificationActor(notification?.msg);
 }
 
 export function getNotificationTypeLabel(type: string): string {


### PR DESCRIPTION
## Summary
- Replace the notifications page with grouped Hive activity, filters, unread state, activity summaries, and expandable vote/follow groups.
- Normalize notification URLs to internal Snapie routes so mentions, replies, and post links stay inside the app.
- Show Hive unread counts on desktop and mobile notification navigation badges.

## Test plan
- pnpm lint
- pnpm exec tsc --noEmit


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Notification bell icons now display unread count badges across the app
  * Redesigned Notifications center with filtering by category (votes, replies, mentions, follows, etc.)
  * Notifications are grouped and bucketed by time ranges (today, yesterday, this week, etc.)
  * New activity summary card showing engagement metrics (votes, replies, mentions)
  * Added "Mark all as read" functionality and manual refresh option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->