### PR TITLE
fix: stop Twitter embed reload loops in blog posts

### DIFF
--- a/components/blog/PostDetails.tsx
+++ b/components/blog/PostDetails.tsx
@@ -9,11 +9,13 @@ import NextLink from 'next/link';
 import InteractionBar from '@/components/shared/InteractionBar';
 import SnapieSpeakAudio from '@/components/shared/SnapieSpeakAudio';
 import ThreeSpeakVideoPlayer from '@/components/shared/ThreeSpeakVideoPlayer';
+import TwitterEmbed from '@/components/shared/TwitterEmbed';
 
 type BodySegment =
     | { type: 'html'; html: string }
     | { type: 'audio'; url: string }
-    | { type: 'speak-video'; author: string; permlink: string };
+    | { type: 'speak-video'; author: string; permlink: string }
+    | { type: 'twitter'; tweetId: string };
 
 interface PostDetailsProps {
     post: Discussion;
@@ -77,6 +79,21 @@ export default function PostDetails({ post, isEmbedMode = false }: PostDetailsPr
             }
         );
 
+        // Extract Twitter embed containers and replace with placeholders so they
+        // render as stable <TwitterEmbed> components instead of dangerouslySetInnerHTML.
+        const twitterMap = new Map<string, string>();
+        let twitterIdx = 0;
+        html = html.replace(
+            /<div\s+class="twitter-embed-container"[^>]*>[\s\S]*?<\/div>/gi,
+            (match) => {
+                const idMatch = match.match(/platform\.twitter\.com\/embed\/Tweet\.html\?id=(\d+)/i);
+                if (!idMatch) return match;
+                const key = `__TWITTER_${twitterIdx++}__`;
+                twitterMap.set(key, idMatch[1]);
+                return key;
+            }
+        );
+
         // Split at audio-container boundaries so each audio becomes a SnapieSpeakAudio component
         const rawSegments: BodySegment[] = [];
         const audioRegex = /<div class="audio-container">[\s\S]*?<\/div>/gi;
@@ -100,11 +117,11 @@ export default function PostDetails({ post, isEmbedMode = false }: PostDetailsPr
 
         const base = rawSegments.length > 0 ? rawSegments : [{ type: 'html' as const, html }];
 
-        // Fast path: no 3Speak videos in this post
-        if (speakVideoMap.size === 0) return base;
+        // Fast path: no extracted embeds
+        if (speakVideoMap.size === 0 && twitterMap.size === 0) return base;
 
-        // Expand speak-video placeholders within html segments
-        const placeholderRe = /(__SPEAKVIDEO_\d+__)/g;
+        // Expand speak-video and twitter placeholders within html segments
+        const placeholderRe = /(__SPEAKVIDEO_\d+__|__TWITTER_\d+__)/g;
         const expanded: BodySegment[] = [];
         for (const seg of base) {
             if (seg.type !== 'html') { expanded.push(seg); continue; }
@@ -113,7 +130,14 @@ export default function PostDetails({ post, isEmbedMode = false }: PostDetailsPr
                 const video = speakVideoMap.get(part);
                 if (video) {
                     expanded.push({ type: 'speak-video', author: video.author, permlink: video.permlink });
-                } else if (part) {
+                    continue;
+                }
+                const tweetId = twitterMap.get(part);
+                if (tweetId) {
+                    expanded.push({ type: 'twitter', tweetId });
+                    continue;
+                }
+                if (part) {
                     expanded.push({ type: 'html', html: part });
                 }
             }
@@ -163,6 +187,9 @@ export default function PostDetails({ post, isEmbedMode = false }: PostDetailsPr
                     }
                     if (seg.type === 'speak-video') {
                         return <ThreeSpeakVideoPlayer key={`${seg.author}/${seg.permlink}-${i}`} author={seg.author} permlink={seg.permlink} />;
+                    }
+                    if (seg.type === 'twitter') {
+                        return <TwitterEmbed key={`twitter-${seg.tweetId}-${i}`} tweetId={seg.tweetId} />;
                     }
                     return <Box key={`html-${i}`} dangerouslySetInnerHTML={{ __html: seg.html }} />;
                 })}

--- a/components/shared/MediaRenderer.tsx
+++ b/components/shared/MediaRenderer.tsx
@@ -10,6 +10,7 @@ import {
   finalizeAudio3SpeakEmbedUrl,
 } from "@/lib/utils/snapUtils";
 import SnapieSpeakAudio from "@/components/shared/SnapieSpeakAudio";
+import TwitterEmbed from "@/components/shared/TwitterEmbed";
 import DOMPurify from "isomorphic-dompurify";
 
 interface MediaRendererProps {
@@ -185,6 +186,13 @@ const MediaRenderer = ({ mediaContent }: MediaRendererProps) => {
                 playUrl={finalizeAudio3SpeakEmbedUrl(item.src)}
               />
             );
+          }
+
+          if (item.src.includes("platform.twitter.com")) {
+            const idMatch = item.src.match(/[?&]id=(\d+)/i);
+            if (idMatch) {
+              return <TwitterEmbed key={`twitter-${idMatch[1]}`} tweetId={idMatch[1]} />;
+            }
           }
 
           const speakKey = speakVideoKeyFromUrl(item.src);

--- a/components/shared/TwitterEmbed.tsx
+++ b/components/shared/TwitterEmbed.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { memo, useRef, useState, useEffect } from 'react';
+
+const TwitterEmbed = memo(function TwitterEmbed({ tweetId }: { tweetId: string }) {
+    const iframeRef = useRef<HTMLIFrameElement>(null);
+    const [height, setHeight] = useState(400);
+
+    useEffect(() => {
+        const handle = (e: MessageEvent) => {
+            if (!e.data || e.source !== iframeRef.current?.contentWindow) return;
+            try {
+                const d = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
+                const h = d?.height ?? d?.data?.params?.height;
+                if (typeof h === 'number' && h > 50) setHeight(h + 2);
+            } catch { /* ignore malformed messages */ }
+        };
+        window.addEventListener('message', handle);
+        return () => window.removeEventListener('message', handle);
+    }, []);
+
+    return (
+        <div style={{ maxWidth: '550px', margin: '0 auto 8px' }}>
+            <iframe
+                ref={iframeRef}
+                src={`https://platform.twitter.com/embed/Tweet.html?id=${tweetId}&dnt=true`}
+                width="100%"
+                height={height}
+                frameBorder={0}
+                scrolling="no"
+                loading="lazy"
+                style={{ border: 'none', borderRadius: '12px', display: 'block' }}
+            />
+        </div>
+    );
+});
+
+export default TwitterEmbed;

--- a/components/shared/TwitterEmbed.tsx
+++ b/components/shared/TwitterEmbed.tsx
@@ -4,14 +4,15 @@ import { memo, useRef, useState, useEffect } from 'react';
 
 const TwitterEmbed = memo(function TwitterEmbed({ tweetId }: { tweetId: string }) {
     const iframeRef = useRef<HTMLIFrameElement>(null);
-    const [height, setHeight] = useState(400);
+    const [height, setHeight] = useState(600);
 
     useEffect(() => {
         const handle = (e: MessageEvent) => {
             if (!e.data || e.source !== iframeRef.current?.contentWindow) return;
             try {
                 const d = typeof e.data === 'string' ? JSON.parse(e.data) : e.data;
-                const h = d?.height ?? d?.data?.params?.height;
+                // Twitter sends { params: { height } } or { data: { params: { height } } }
+                const h = d?.height ?? d?.params?.height ?? d?.data?.params?.height ?? d?.data?.height;
                 if (typeof h === 'number' && h > 50) setHeight(h + 2);
             } catch { /* ignore malformed messages */ }
         };

--- a/lib/utils/snapUtils.ts
+++ b/lib/utils/snapUtils.ts
@@ -416,7 +416,7 @@ export const parseMediaContent = (mediaContent: string): MediaItem[] => {
     // Handle plain Twitter/X URLs
     const twitterId = extractTwitterId(trimmedItem);
     if (twitterId && !trimmedItem.includes('<iframe') && !trimmedItem.includes('![')) {
-      const embedUrl = `https://platform.twitter.com/embed/Tweet.html?id=${twitterId}`;
+      const embedUrl = `https://platform.twitter.com/embed/Tweet.html?id=${twitterId}&dnt=true`;
       mediaItems.push({
         type: "iframe",
         content: `<iframe src="${embedUrl}" width="100%" style="max-width: 550px; min-height: 500px; height: auto; margin: 0 auto; border: 1px solid #e1e8ed; border-radius: 12px; overflow: hidden;" frameborder="0" scrolling="no"></iframe>`,


### PR DESCRIPTION
## Summary

- Twitter iframes in blog posts were rendered inside `dangerouslySetInnerHTML` HTML blobs. Any parent re-render (state update, refetch, etc.) destroyed and recreated the entire DOM including the iframe — triggering the same reload loop that 3Speak had before PR #42.
- **Root cause is identical to the old 3Speak problem**: HTML blobs inside `dangerouslySetInnerHTML` are not stable React subtrees; every render wipes and rewrites the DOM.

## Fix

Mirrors the PR #42 approach for 3Speak, applied to Twitter:

1. **`components/shared/TwitterEmbed.tsx`** (new) — stable `memo()` component that renders the Twitter iframe with a `postMessage` height listener. Same structure as `ThreeSpeakVideoPlayer`.
2. **`components/blog/PostDetails.tsx`** — regex-extracts `<div class="twitter-embed-container">` blocks from the rendered HTML, replaces them with `__TWITTER_N__` placeholders, then expands placeholders into `<TwitterEmbed>` React components at render time. Twitter embeds are now stable across parent re-renders.
3. **`components/shared/MediaRenderer.tsx`** — routes Twitter iframes in snap cards through `<TwitterEmbed>` instead of `IframeEmbedBox` (which uses its own `dangerouslySetInnerHTML`).
4. **`lib/utils/snapUtils.ts`** — adds missing `&dnt=true` to the Twitter embed URL (was already present in the markdown renderer but not in the snap media parser).

## Test plan

- [ ] Open a blog post with an embedded tweet — confirm it loads and stays stable (no reload loop)
- [ ] Scroll away and back — tweet should not reload
- [ ] Open a snap card containing a Twitter link — confirm it renders via `TwitterEmbed`
- [ ] Confirm 3Speak videos in blog posts are unaffected
- [ ] Confirm audio embeds in blog posts are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)