### PR TITLE
fix: show new comments/replies immediately without page refresh

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,7 +26,6 @@ export default function Home() {
   const [conversation, setConversation] = useState<Comment | undefined>();
   const [reply, setReply] = useState<Comment>();
   const [isOpen, setIsOpen] = useState(false);
-  const [newComment, setNewComment] = useState<Comment | null>(null); // Define the state
   const [activeFilter, setActiveFilter] = useState<SnapFilterType>('community');
   const [communityName, setCommunityName] = useState<string>('Community');
 
@@ -59,8 +58,8 @@ export default function Home() {
   const onOpen = () => setIsOpen(true);
   const onClose = () => setIsOpen(false);
 
-  const handleNewComment = (newComment: Partial<Comment> | CharacterData) => {
-    setNewComment(newComment as Comment);
+  const handleReply = (_partial: Partial<Comment>) => {
+    setTimeout(() => snaps.refresh?.(), 3000);
   };
 
   const handleFilterChange = (filter: SnapFilterType) => {
@@ -105,7 +104,6 @@ export default function Home() {
             setConversation={setConversation}
             onOpen={onOpen}
             setReply={setReply}
-            newComment={newComment}
             data={{...snaps, refresh: snaps.refresh}}
           />
         ) : (
@@ -113,7 +111,7 @@ export default function Home() {
         )}
       </Box>
       <RightSidebar />
-      {isOpen && <SnapReplyModal isOpen={isOpen} onClose={onClose} comment={reply} onNewReply={handleNewComment} />}
+      {isOpen && <SnapReplyModal isOpen={isOpen} onClose={onClose} comment={reply} onNewReply={handleReply} />}
     </Flex>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,6 +26,7 @@ export default function Home() {
   const [conversation, setConversation] = useState<Comment | undefined>();
   const [reply, setReply] = useState<Comment>();
   const [isOpen, setIsOpen] = useState(false);
+  const [conversationRefreshTrigger, setConversationRefreshTrigger] = useState(0);
   const [activeFilter, setActiveFilter] = useState<SnapFilterType>('community');
   const [communityName, setCommunityName] = useState<string>('Community');
 
@@ -59,7 +60,10 @@ export default function Home() {
   const onClose = () => setIsOpen(false);
 
   const handleReply = (_partial: Partial<Comment>) => {
-    setTimeout(() => snaps.refresh?.(), 3000);
+    setTimeout(() => {
+      snaps.refresh?.();
+      setConversationRefreshTrigger(t => t + 1);
+    }, 3000);
   };
 
   const handleFilterChange = (filter: SnapFilterType) => {
@@ -107,7 +111,7 @@ export default function Home() {
             data={{...snaps, refresh: snaps.refresh}}
           />
         ) : (
-          <Conversation comment={conversation} setConversation={setConversation} onOpen={onOpen} setReply={setReply} />
+          <Conversation comment={conversation} setConversation={setConversation} onOpen={onOpen} setReply={setReply} refreshTrigger={conversationRefreshTrigger} />
         )}
       </Box>
       <RightSidebar />

--- a/components/blog/PostPage.tsx
+++ b/components/blog/PostPage.tsx
@@ -30,6 +30,7 @@ export default function PostPage({ author, permlink }: PostPageProps) {
   const [conversation, setConversation] = useState<Comment | undefined>();
   const [reply, setReply] = useState<Comment>();
   const [isOpen, setIsOpen] = useState(false);
+  const [conversationRefreshTrigger, setConversationRefreshTrigger] = useState(0);
 
   // Only fetch comments if NOT in embed mode
   const data = useComments(isEmbedMode ? '' : author, isEmbedMode ? '' : permlink, !isEmbedMode, hiveUser?.name);
@@ -81,7 +82,10 @@ export default function PostPage({ author, permlink }: PostPageProps) {
   };
 
   const handleReply = (_partial: Partial<Comment>) => {
-    setTimeout(() => data.updateComments(), 3000);
+    setTimeout(() => {
+      data.updateComments();
+      setConversationRefreshTrigger(t => t + 1);
+    }, 3000);
   };
 
   if (isLoading || (!post || !author || !permlink)) {
@@ -109,7 +113,7 @@ export default function PostPage({ author, permlink }: PostPageProps) {
           />
         </>
       ) : !isEmbedMode && conversation ? (
-        <Conversation comment={conversation} setConversation={setConversation} onOpen={onOpen} setReply={setReply} />
+        <Conversation comment={conversation} setConversation={setConversation} onOpen={onOpen} setReply={setReply} refreshTrigger={conversationRefreshTrigger} />
       ) : null}
       {!isEmbedMode && isOpen && <SnapReplyModal isOpen={isOpen} onClose={onClose} comment={reply} onNewReply={handleReply} />}
     </Box>

--- a/components/blog/PostPage.tsx
+++ b/components/blog/PostPage.tsx
@@ -30,14 +30,13 @@ export default function PostPage({ author, permlink }: PostPageProps) {
   const [conversation, setConversation] = useState<Comment | undefined>();
   const [reply, setReply] = useState<Comment>();
   const [isOpen, setIsOpen] = useState(false);
-  const [newComment, setNewComment] = useState<Comment | null>(null); // Define the state
 
   // Only fetch comments if NOT in embed mode
   const data = useComments(isEmbedMode ? '' : author, isEmbedMode ? '' : permlink, !isEmbedMode, hiveUser?.name);
   const commentsData = {
-    ...data, 
-    loadNextPage: () => {}, 
-    hasMore: false,         
+    ...data,
+    loadNextPage: () => {},
+    hasMore: false,
   };
 
   useEffect(() => {
@@ -59,8 +58,24 @@ export default function PostPage({ author, permlink }: PostPageProps) {
   const onOpen = () => setIsOpen(true);
   const onClose = () => setIsOpen(false);
 
-  const handleNewComment = (newComment: Partial<Comment> | CharacterData) => {
-    setNewComment(newComment as Comment); // Type assertion
+  const handleTopLevelComment = (partial: Partial<Comment>) => {
+    const optimistic = {
+      author: partial.author ?? '',
+      permlink: partial.permlink ?? `optimistic-${Date.now()}`,
+      body: partial.body ?? '',
+      created: new Date().toISOString(),
+      active_votes: [],
+      children: 0,
+      replies: [],
+      parent_author: author,
+      parent_permlink: permlink,
+    } as unknown as Comment;
+    data.addComment(optimistic);
+    setTimeout(() => data.updateComments(), 3000);
+  };
+
+  const handleReply = (_partial: Partial<Comment>) => {
+    setTimeout(() => data.updateComments(), 3000);
   };
 
   if (isLoading || (!post || !author || !permlink)) {
@@ -76,14 +91,13 @@ export default function PostPage({ author, permlink }: PostPageProps) {
       <PostDetails post={post} isEmbedMode={isEmbedMode} />
       {!isEmbedMode && !conversation ? (
         <>
-          <SnapComposer pa={author} pp={permlink} onNewComment={handleNewComment} post={true} onClose={() => {}} />
+          <SnapComposer pa={author} pp={permlink} onNewComment={handleTopLevelComment} post={true} onClose={() => {}} />
           <SnapList
             author={author}
             permlink={permlink}
             setConversation={setConversation}
             onOpen={onOpen}
             setReply={setReply}
-            newComment={newComment}
             post={true}
             data={commentsData}
           />
@@ -91,7 +105,7 @@ export default function PostPage({ author, permlink }: PostPageProps) {
       ) : !isEmbedMode && conversation ? (
         <Conversation comment={conversation} setConversation={setConversation} onOpen={onOpen} setReply={setReply} />
       ) : null}
-      {!isEmbedMode && isOpen && <SnapReplyModal isOpen={isOpen} onClose={onClose} comment={reply} onNewReply={handleNewComment} />}
+      {!isEmbedMode && isOpen && <SnapReplyModal isOpen={isOpen} onClose={onClose} comment={reply} onNewReply={handleReply} />}
     </Box>
   );
 }

--- a/components/blog/PostPage.tsx
+++ b/components/blog/PostPage.tsx
@@ -69,6 +69,12 @@ export default function PostPage({ author, permlink }: PostPageProps) {
       replies: [],
       parent_author: author,
       parent_permlink: permlink,
+      pending_payout_value: '0.000 HBD',
+      total_payout_value: '0.000 HBD',
+      curator_payout_value: '0.000 HBD',
+      net_votes: 0,
+      json_metadata: '{}',
+      title: '',
     } as unknown as Comment;
     data.addComment(optimistic);
     setTimeout(() => data.updateComments(), 3000);

--- a/components/homepage/Conversation.tsx
+++ b/components/homepage/Conversation.tsx
@@ -4,17 +4,23 @@ import { useComments } from '@/hooks/useComments';
 import { useHiveUser } from '@/contexts/UserContext';
 import { ArrowBackIcon } from "@chakra-ui/icons";
 import Snap from './Snap';
+import { useEffect } from 'react';
 
 interface ConversationProps {
     comment: Comment;
     setConversation: (conversation: Comment | undefined) => void;
     onOpen: () => void;
     setReply: (reply: Comment) => void;
+    refreshTrigger?: number;
 }
 
-const Conversation = ({ comment, setConversation, onOpen, setReply }: ConversationProps) => {
+const Conversation = ({ comment, setConversation, onOpen, setReply, refreshTrigger }: ConversationProps) => {
     const { hiveUser } = useHiveUser();
-    const { comments, isLoading, error } = useComments(comment.author, comment.permlink, true, hiveUser?.name);
+    const { comments, isLoading, error, updateComments } = useComments(comment.author, comment.permlink, true, hiveUser?.name);
+
+    useEffect(() => {
+        if (refreshTrigger && refreshTrigger > 0) updateComments();
+    }, [refreshTrigger]);
     const replies = comments
 
     function handleReplyModal() {

--- a/components/homepage/SnapList.tsx
+++ b/components/homepage/SnapList.tsx
@@ -12,7 +12,6 @@ interface SnapListProps {
   setConversation: (conversation: ExtendedComment) => void;
   onOpen: () => void;
   setReply: (reply: ExtendedComment) => void;
-  newComment: ExtendedComment | null;
   post?: boolean;
   data: InfiniteScrollData
 }
@@ -32,10 +31,9 @@ export default function SnapList(
     setConversation,
     onOpen,
     setReply,
-    newComment,
     post,
     data
-}: SnapListProps) {  
+}: SnapListProps) {
   const { comments, loadNextPage, isLoading, hasMore, refresh } = data
 
   const handleNewComment = () => {
@@ -50,8 +48,6 @@ export default function SnapList(
   comments.sort((a: ExtendedComment, b: ExtendedComment) => {
     return new Date(b.created).getTime() - new Date(a.created).getTime();
   });
-  // Handle new comment addition
-  //const updatedComments = newComment ? [newComment, ...comments] : comments;
 
   if (isLoading && comments.length === 0) {
     // Initial loading state

--- a/lib/hive/client-functions.ts
+++ b/lib/hive/client-functions.ts
@@ -680,6 +680,8 @@ export async function getPost(user: string, postId: string) {
 }
 
 export function getPayoutValue(post: any): string {
+  if (!post?.created) return "0.000";
+
   const createdDate = new Date(post.created);
   const now = new Date();
 
@@ -687,11 +689,9 @@ export function getPayoutValue(post: any): string {
   const timeDifferenceInDays = timeDifferenceInMs / (1000 * 60 * 60 * 24);
 
   if (timeDifferenceInDays >= 7) {
-    return post.total_payout_value.replace(" HBD", "");
-  } else if (timeDifferenceInDays < 7) {
-    return post.pending_payout_value.replace(" HBD", "");
+    return (post.total_payout_value ?? "0.000 HBD").replace(" HBD", "");
   } else {
-    return "0.000";
+    return (post.pending_payout_value ?? "0.000 HBD").replace(" HBD", "");
   }
 }
 


### PR DESCRIPTION
## Summary
- **Top-level comments on blog posts**: shown immediately via optimistic insert (`data.addComment`), then replaced with real chain data after a 3s delay (`data.updateComments`)
- **Replies (SnapReplyModal)**: trigger a `updateComments` refetch after 3s — nested replies appear without needing a manual refresh
- **Home feed replies**: same pattern, using `snaps.refresh` after 3s
- Removes the stale `newComment` prop from `SnapList` (it was wired to state but never actually rendered)

## Root cause
`useComments` already exposed `addComment` and `updateComments`, but no callback in the component tree ever invoked them after posting. `SnapList` had an optimistic-update line commented out, and `PostPage` set `newComment` state that was passed down but ignored.

## Test plan
- [ ] Post a top-level comment on a blog post — it should appear immediately in the list below
- [ ] Reply to a comment via the reply modal — the reply should appear within ~3 seconds
- [ ] Post a new snap on the home feed — feed refreshes after 3s (existing behaviour, unchanged)
- [ ] Reply to a snap on the home feed — reply appears within ~3 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved comment and reply submission handling with better update consistency
  * Streamlined how new comments appear across feeds and article pages
  * Enhanced data refresh mechanism for more reliable comment visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->