### PR TITLE
feat: peer-sponsored Hive account creation at /join

### DIFF
--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Suspense } from 'react';
+import { Box, Spinner } from '@chakra-ui/react';
+import { useSearchParams } from 'next/navigation';
+import CreateAccountForm from '@/components/join/CreateAccountForm';
+import SponsorFlow from '@/components/join/SponsorFlow';
+
+function JoinPageInner() {
+  const searchParams = useSearchParams();
+  const code = searchParams.get('code');
+
+  if (code) return <SponsorFlow code={code} />;
+  return <CreateAccountForm />;
+}
+
+export default function JoinPage() {
+  return (
+    <Suspense fallback={<Box display="flex" justifyContent="center" py={16}><Spinner /></Box>}>
+      <JoinPageInner />
+    </Suspense>
+  );
+}

--- a/components/join/CreateAccountForm.tsx
+++ b/components/join/CreateAccountForm.tsx
@@ -56,6 +56,7 @@ export default function CreateAccountForm() {
   const [isAvailable, setIsAvailable] = useState(false);
   const [hasBeenValid, setHasBeenValid] = useState(false);
   const checkTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const checkRequestIdRef = useRef(0);
 
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
@@ -82,9 +83,11 @@ export default function CreateAccountForm() {
 
   const onUsernameChange = useCallback((raw: string) => {
     const cleaned = raw.toLowerCase().trim();
+    const requestId = ++checkRequestIdRef.current;
     setUsername(cleaned);
     setIsAvailable(false);
     setUsernameError(null);
+    setKeys(null);
     setBackupDownloaded(false);
     setAcceptedBackup(false);
 
@@ -102,6 +105,7 @@ export default function CreateAccountForm() {
     checkTimeoutRef.current = setTimeout(async () => {
       try {
         const available = await checkAccountAvailability(cleaned);
+        if (requestId !== checkRequestIdRef.current) return;
         if (!available) {
           setUsernameError('Username already taken');
           setIsAvailable(false);
@@ -110,9 +114,10 @@ export default function CreateAccountForm() {
           setHasBeenValid(true);
         }
       } catch {
+        if (requestId !== checkRequestIdRef.current) return;
         setUsernameError('Could not check availability — try again');
       } finally {
-        setIsChecking(false);
+        if (requestId === checkRequestIdRef.current) setIsChecking(false);
       }
     }, DEBOUNCE_MS);
   }, []);
@@ -129,10 +134,13 @@ export default function CreateAccountForm() {
     setAcceptedBackup(false);
   };
 
-  const copyPassword = () => {
-    navigator.clipboard.writeText(password).then(() => {
+  const copyPassword = async () => {
+    try {
+      await navigator.clipboard.writeText(password);
       toast({ title: 'Password copied', status: 'success', duration: 1500, isClosable: true });
-    });
+    } catch {
+      toast({ title: 'Could not copy password', status: 'error', duration: 2500, isClosable: true });
+    }
   };
 
   const onDownloadBackup = () => {
@@ -151,6 +159,15 @@ export default function CreateAccountForm() {
       onDownload: () => {
         setBackupDownloaded(true);
         toast({ title: 'Backup downloaded', status: 'success', duration: 1500, isClosable: true });
+      },
+      onError: () => {
+        toast({
+          title: 'Could not save backup',
+          description: 'Open the keys panel and copy each key manually before continuing.',
+          status: 'error',
+          duration: 6000,
+          isClosable: true,
+        });
       },
     });
   };
@@ -172,8 +189,11 @@ export default function CreateAccountForm() {
   useEffect(() => {
     if (!polling || !username) return;
     let cancelled = false;
+    let inFlight = false;
 
     const check = async () => {
+      if (cancelled || inFlight) return;
+      inFlight = true;
       try {
         const accounts = await HiveClient.database.getAccounts([username]);
         if (cancelled) return;
@@ -190,6 +210,8 @@ export default function CreateAccountForm() {
         }
       } catch {
         // network blip — keep trying
+      } finally {
+        inFlight = false;
       }
     };
 
@@ -290,7 +312,7 @@ export default function CreateAccountForm() {
             leftIcon={<FaDownload />}
             variant="outline"
             onClick={onDownloadBackup}
-            isDisabled={locked}
+            isDisabled={locked || !isAvailable || !keys}
             color={backupDownloaded ? 'green.400' : 'orange.300'}
             borderColor={backupDownloaded ? 'green.400' : 'orange.400'}
           >

--- a/components/join/CreateAccountForm.tsx
+++ b/components/join/CreateAccountForm.tsx
@@ -1,0 +1,358 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  AlertIcon,
+  Box,
+  Button,
+  Checkbox,
+  Heading,
+  IconButton,
+  Input,
+  InputGroup,
+  InputRightElement,
+  Spinner,
+  Stack,
+  Text,
+  useDisclosure,
+  useToast,
+} from '@chakra-ui/react';
+import {
+  FaCheck,
+  FaDownload,
+  FaEdit,
+  FaEye,
+  FaEyeSlash,
+  FaKey,
+  FaRedo,
+  FaTimes,
+} from 'react-icons/fa';
+import HiveClient from '@/lib/hive/hiveclient';
+import {
+  generatePassword,
+  generateKeys,
+  validateAccountName,
+  checkAccountAvailability,
+  downloadBackupFile,
+  type PrivateKeys,
+} from '@/lib/hive/account-create-client';
+import {
+  generateShareableLink,
+  type ShareableAccountData,
+} from '@/lib/hive/share-link';
+import KeysModal from './KeysModal';
+import ShareLinkDialog from './ShareLinkDialog';
+
+const DEBOUNCE_MS = 500;
+const POLL_INTERVAL_MS = 5000;
+
+export default function CreateAccountForm() {
+  const toast = useToast();
+
+  const [username, setUsername] = useState('');
+  const [usernameError, setUsernameError] = useState<string | null>(null);
+  const [isChecking, setIsChecking] = useState(false);
+  const [isAvailable, setIsAvailable] = useState(false);
+  const [hasBeenValid, setHasBeenValid] = useState(false);
+  const checkTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [isEditingPassword, setIsEditingPassword] = useState(false);
+  const [tempPassword, setTempPassword] = useState('');
+
+  const [keys, setKeys] = useState<PrivateKeys | null>(null);
+
+  const [backupDownloaded, setBackupDownloaded] = useState(false);
+  const [acceptedBackup, setAcceptedBackup] = useState(false);
+
+  const keysModal = useDisclosure();
+  const shareDialog = useDisclosure();
+
+  const [shareLink, setShareLink] = useState('');
+  const [polling, setPolling] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  const locked = polling || success;
+
+  useEffect(() => {
+    if (!password) setPassword(generatePassword());
+  }, [password]);
+
+  const onUsernameChange = useCallback((raw: string) => {
+    const cleaned = raw.toLowerCase().trim();
+    setUsername(cleaned);
+    setIsAvailable(false);
+    setUsernameError(null);
+    setBackupDownloaded(false);
+    setAcceptedBackup(false);
+
+    if (checkTimeoutRef.current) clearTimeout(checkTimeoutRef.current);
+
+    if (cleaned.length === 0) return;
+
+    const validation = validateAccountName(cleaned);
+    if (!validation.isValid) {
+      setUsernameError(validation.error!);
+      return;
+    }
+
+    setIsChecking(true);
+    checkTimeoutRef.current = setTimeout(async () => {
+      try {
+        const available = await checkAccountAvailability(cleaned);
+        if (!available) {
+          setUsernameError('Username already taken');
+          setIsAvailable(false);
+        } else {
+          setIsAvailable(true);
+          setHasBeenValid(true);
+        }
+      } catch {
+        setUsernameError('Could not check availability — try again');
+      } finally {
+        setIsChecking(false);
+      }
+    }, DEBOUNCE_MS);
+  }, []);
+
+  useEffect(() => {
+    if (username && password && isAvailable) {
+      setKeys(generateKeys(username, password));
+    }
+  }, [username, password, isAvailable]);
+
+  const regeneratePassword = () => {
+    setPassword(generatePassword());
+    setBackupDownloaded(false);
+    setAcceptedBackup(false);
+  };
+
+  const copyPassword = () => {
+    navigator.clipboard.writeText(password).then(() => {
+      toast({ title: 'Password copied', status: 'success', duration: 1500, isClosable: true });
+    });
+  };
+
+  const onDownloadBackup = () => {
+    if (!keys || !username) return;
+    downloadBackupFile(username, password, keys, {
+      onClipboardFallback: () => {
+        toast({
+          title: 'Backup copied to clipboard',
+          description: 'Paste it somewhere safe before continuing.',
+          status: 'info',
+          duration: 4000,
+          isClosable: true,
+        });
+        setBackupDownloaded(true);
+      },
+      onDownload: () => {
+        setBackupDownloaded(true);
+        toast({ title: 'Backup downloaded', status: 'success', duration: 1500, isClosable: true });
+      },
+    });
+  };
+
+  const onGenerateLink = () => {
+    if (!keys || !username) return;
+    const data: ShareableAccountData = {
+      username,
+      ownerPubkey: keys.ownerPubkey,
+      activePubkey: keys.activePubkey,
+      postingPubkey: keys.postingPubkey,
+      memoPubkey: keys.memoPubkey,
+    };
+    setShareLink(generateShareableLink(data));
+    shareDialog.onOpen();
+    setPolling(true);
+  };
+
+  useEffect(() => {
+    if (!polling || !username) return;
+    let cancelled = false;
+
+    const check = async () => {
+      try {
+        const accounts = await HiveClient.database.getAccounts([username]);
+        if (cancelled) return;
+        if (accounts.length > 0) {
+          setSuccess(true);
+          setPolling(false);
+          toast({
+            title: `Welcome, @${username}!`,
+            description: 'Your Hive account has been created.',
+            status: 'success',
+            duration: 6000,
+            isClosable: true,
+          });
+        }
+      } catch {
+        // network blip — keep trying
+      }
+    };
+
+    check();
+    const interval = setInterval(check, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [polling, username, toast]);
+
+  const canGenerateLink = isAvailable && acceptedBackup && backupDownloaded && !!keys && !locked;
+
+  return (
+    <Stack spacing={6} maxW="md" mx="auto" w="full" px={4} py={8}>
+      <Box textAlign="center">
+        <Heading size="xl" color="white" mb={2}>
+          Join Snapie
+        </Heading>
+        <Text color="gray.400" fontSize="sm">
+          Pick a username and create your Hive account. Anyone with an existing Hive account can sponsor yours in one click.
+        </Text>
+      </Box>
+
+      <Box>
+        <Text fontSize="sm" color="white" mb={1}>Username</Text>
+        <Text fontSize="xs" color="gray.400" mb={2}>
+          3–16 characters, lowercase. Start each segment with a letter.
+        </Text>
+        <InputGroup>
+          <Input
+            value={username}
+            onChange={(e) => onUsernameChange(e.target.value)}
+            placeholder="yourname"
+            autoComplete="off"
+            fontFamily="mono"
+            bg="rgba(4, 16, 29, 0.72)"
+            borderColor={usernameError ? 'red.400' : isAvailable ? 'green.400' : 'whiteAlpha.200'}
+            color="white"
+            isDisabled={locked}
+          />
+          <InputRightElement>
+            {isChecking ? <Spinner size="sm" /> : isAvailable ? <Box color="green.400"><FaCheck /></Box> : null}
+          </InputRightElement>
+        </InputGroup>
+        <Box minH="20px" mt={1}>
+          {usernameError && !isChecking && (
+            <Text fontSize="xs" color="red.400">{usernameError}</Text>
+          )}
+          {isAvailable && !isChecking && !usernameError && (
+            <Text fontSize="xs" color="green.400">Available</Text>
+          )}
+        </Box>
+      </Box>
+
+      {hasBeenValid && (
+        <Box>
+          <Text fontSize="sm" color="white" mb={1}>Master password</Text>
+          <Text fontSize="xs" color="gray.400" mb={2}>
+            Auto-generated. Back it up — this is the only way to recover your account.
+          </Text>
+          <InputGroup>
+            <Input
+              type={showPassword ? 'text' : 'password'}
+              value={isEditingPassword ? tempPassword : password}
+              onChange={(e) => setTempPassword(e.target.value)}
+              isReadOnly={!isEditingPassword || locked}
+              onClick={() => {
+                if (!isEditingPassword && !locked) copyPassword();
+              }}
+              fontFamily="mono"
+              bg="rgba(4, 16, 29, 0.72)"
+              borderColor="whiteAlpha.200"
+              color="white"
+              cursor={!isEditingPassword && !locked ? 'pointer' : 'text'}
+              pr="7rem"
+            />
+            <InputRightElement w="7rem" justifyContent="flex-end" pr={1}>
+              {!isEditingPassword ? (
+                <>
+                  <IconButton aria-label="Toggle password visibility" icon={showPassword ? <FaEyeSlash /> : <FaEye />} size="xs" variant="ghost" onClick={() => setShowPassword(!showPassword)} isDisabled={locked} />
+                  <IconButton aria-label="Regenerate password" icon={<FaRedo />} size="xs" variant="ghost" onClick={regeneratePassword} isDisabled={locked} />
+                  <IconButton aria-label="Edit password" icon={<FaEdit />} size="xs" variant="ghost" onClick={() => { setIsEditingPassword(true); setTempPassword(password); }} isDisabled={locked} />
+                  <IconButton aria-label="View keys" icon={<FaKey />} size="xs" variant="ghost" onClick={keysModal.onOpen} />
+                </>
+              ) : (
+                <>
+                  <IconButton aria-label="Confirm new password" icon={<FaCheck />} size="xs" variant="ghost" onClick={() => { setPassword(tempPassword); setIsEditingPassword(false); setBackupDownloaded(false); setAcceptedBackup(false); }} />
+                  <IconButton aria-label="Cancel edit" icon={<FaTimes />} size="xs" variant="ghost" onClick={() => { setIsEditingPassword(false); setTempPassword(''); }} />
+                </>
+              )}
+            </InputRightElement>
+          </InputGroup>
+
+          <Button
+            mt={3}
+            w="full"
+            leftIcon={<FaDownload />}
+            variant="outline"
+            onClick={onDownloadBackup}
+            isDisabled={locked}
+            color={backupDownloaded ? 'green.400' : 'orange.300'}
+            borderColor={backupDownloaded ? 'green.400' : 'orange.400'}
+          >
+            {backupDownloaded ? 'Backup downloaded' : 'Download backup file'}
+          </Button>
+        </Box>
+      )}
+
+      {hasBeenValid && !success && (
+        <Stack spacing={3}>
+          <Checkbox
+            isChecked={acceptedBackup}
+            onChange={(e) => setAcceptedBackup(e.target.checked)}
+            colorScheme="blue"
+            isDisabled={!backupDownloaded || locked}
+          >
+            <Text fontSize="sm" color="gray.300">
+              I&apos;ve saved my keys somewhere safe. I understand Hive has no password reset.
+            </Text>
+          </Checkbox>
+
+          <Button
+            onClick={onGenerateLink}
+            isDisabled={!canGenerateLink}
+            colorScheme="blue"
+            size="lg"
+            w="full"
+          >
+            Generate invite link
+          </Button>
+
+          {polling && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={shareDialog.onOpen}
+              color="gray.400"
+            >
+              Show invite link again
+            </Button>
+          )}
+        </Stack>
+      )}
+
+      {success && (
+        <Alert status="success" bg="rgba(72, 187, 120, 0.1)" border="1px solid" borderColor="green.400" color="white" borderRadius="md">
+          <AlertIcon color="green.400" />
+          <Box>
+            <Text fontWeight="bold">@{username} is live on Hive!</Text>
+            <Text fontSize="sm" color="gray.300">You can now log in to Snapie with your new account.</Text>
+          </Box>
+        </Alert>
+      )}
+
+      <KeysModal isOpen={keysModal.isOpen} onClose={keysModal.onClose} keys={keys} />
+      <ShareLinkDialog
+        isOpen={shareDialog.isOpen}
+        onClose={shareDialog.onClose}
+        link={shareLink}
+        username={username}
+        waitingForSponsor={polling && !success}
+      />
+    </Stack>
+  );
+}

--- a/components/join/KeysModal.tsx
+++ b/components/join/KeysModal.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import {
+  Box,
+  Button,
+  IconButton,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Stack,
+  Text,
+  useToast,
+} from '@chakra-ui/react';
+import { FaCopy } from 'react-icons/fa';
+import type { PrivateKeys } from '@/lib/hive/account-create-client';
+
+interface KeysModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  keys: PrivateKeys | null;
+}
+
+const ROLES: Array<{
+  label: string;
+  privKey: keyof PrivateKeys;
+  pubKey: keyof PrivateKeys;
+  hint: string;
+}> = [
+  { label: 'Owner', privKey: 'owner', pubKey: 'ownerPubkey', hint: 'Recovery only — never paste online' },
+  { label: 'Active', privKey: 'active', pubKey: 'activePubkey', hint: 'Wallet, transfers, account management' },
+  { label: 'Posting', privKey: 'posting', pubKey: 'postingPubkey', hint: 'Posts, votes, comments — daily use' },
+  { label: 'Memo', privKey: 'memo', pubKey: 'memoPubkey', hint: 'Encrypted memos' },
+];
+
+export default function KeysModal({ isOpen, onClose, keys }: KeysModalProps) {
+  const toast = useToast();
+
+  const copy = (text: string, label: string) => {
+    navigator.clipboard.writeText(text).then(() => {
+      toast({ title: `${label} copied`, status: 'success', duration: 1500, isClosable: true });
+    });
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="xl" scrollBehavior="inside">
+      <ModalOverlay />
+      <ModalContent bg="rgba(8, 24, 40, 0.96)" color="white" border="1px solid" borderColor="whiteAlpha.200">
+        <ModalHeader>Your Hive Keys</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody pb={6}>
+          <Stack spacing={5}>
+            {keys && ROLES.map(({ label, privKey, pubKey, hint }) => (
+              <Box key={label} bg="rgba(4, 16, 29, 0.72)" p={3} borderRadius="md" border="1px solid" borderColor="whiteAlpha.100">
+                <Text fontSize="sm" fontWeight="bold" mb={1}>{label}</Text>
+                <Text fontSize="xs" color="gray.400" mb={2}>{hint}</Text>
+
+                <Text fontSize="xs" color="gray.500" mt={1}>Private</Text>
+                <Box display="flex" alignItems="center" gap={2}>
+                  <Box flex={1} bg="blackAlpha.500" p={2} borderRadius="sm" fontFamily="mono" fontSize="xs" wordBreak="break-all">
+                    {keys[privKey]}
+                  </Box>
+                  <IconButton
+                    aria-label={`Copy ${label} private key`}
+                    icon={<FaCopy />}
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => copy(keys[privKey], `${label} private key`)}
+                  />
+                </Box>
+
+                <Text fontSize="xs" color="gray.500" mt={2}>Public</Text>
+                <Box display="flex" alignItems="center" gap={2}>
+                  <Box flex={1} bg="blackAlpha.300" p={2} borderRadius="sm" fontFamily="mono" fontSize="xs" wordBreak="break-all" color="gray.300">
+                    {keys[pubKey]}
+                  </Box>
+                  <IconButton
+                    aria-label={`Copy ${label} public key`}
+                    icon={<FaCopy />}
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => copy(keys[pubKey], `${label} public key`)}
+                  />
+                </Box>
+              </Box>
+            ))}
+          </Stack>
+          <Button mt={5} w="full" onClick={onClose}>Close</Button>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/components/join/KeysModal.tsx
+++ b/components/join/KeysModal.tsx
@@ -38,10 +38,13 @@ const ROLES: Array<{
 export default function KeysModal({ isOpen, onClose, keys }: KeysModalProps) {
   const toast = useToast();
 
-  const copy = (text: string, label: string) => {
-    navigator.clipboard.writeText(text).then(() => {
+  const copy = async (text: string, label: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
       toast({ title: `${label} copied`, status: 'success', duration: 1500, isClosable: true });
-    });
+    } catch {
+      toast({ title: `Could not copy ${label.toLowerCase()}`, status: 'error', duration: 2500, isClosable: true });
+    }
   };
 
   return (

--- a/components/join/ShareLinkDialog.tsx
+++ b/components/join/ShareLinkDialog.tsx
@@ -35,11 +35,14 @@ export default function ShareLinkDialog({ isOpen, onClose, link, username, waiti
   const toast = useToast();
   const [qrExpanded, setQrExpanded] = useState(false);
 
-  const copyLink = () => {
+  const copyLink = async () => {
     if (!link) return;
-    navigator.clipboard.writeText(link).then(() => {
+    try {
+      await navigator.clipboard.writeText(link);
       toast({ title: 'Link copied', status: 'success', duration: 1500, isClosable: true });
-    });
+    } catch {
+      toast({ title: 'Could not copy link', status: 'error', duration: 2500, isClosable: true });
+    }
   };
 
   const nativeShare = async () => {

--- a/components/join/ShareLinkDialog.tsx
+++ b/components/join/ShareLinkDialog.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Alert,
+  AlertIcon,
+  Box,
+  Button,
+  HStack,
+  IconButton,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Spinner,
+  Stack,
+  Text,
+  useToast,
+} from '@chakra-ui/react';
+import { FaCopy, FaShareAlt } from 'react-icons/fa';
+import { QRCodeSVG } from 'qrcode.react';
+
+interface ShareLinkDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  link: string;
+  username: string;
+  waitingForSponsor: boolean;
+}
+
+export default function ShareLinkDialog({ isOpen, onClose, link, username, waitingForSponsor }: ShareLinkDialogProps) {
+  const toast = useToast();
+  const [qrExpanded, setQrExpanded] = useState(false);
+
+  const copyLink = () => {
+    if (!link) return;
+    navigator.clipboard.writeText(link).then(() => {
+      toast({ title: 'Link copied', status: 'success', duration: 1500, isClosable: true });
+    });
+  };
+
+  const nativeShare = async () => {
+    if (!link) return;
+    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+      try {
+        await navigator.share({
+          title: 'Sponsor my Snapie account',
+          text: `Hi! I'd like to join Snapie as @${username}. Can you sponsor my account creation?`,
+          url: link,
+        });
+      } catch {
+        // user dismissed or share failed; no-op
+      }
+    } else {
+      copyLink();
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="lg" scrollBehavior="inside">
+      <ModalOverlay />
+      <ModalContent bg="rgba(8, 24, 40, 0.96)" color="white" border="1px solid" borderColor="whiteAlpha.200">
+        <ModalHeader>Share your invite link</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody pb={6}>
+          <Stack spacing={4}>
+            <Alert status="info" bg="rgba(24, 168, 255, 0.08)" border="1px solid" borderColor="rgba(24, 168, 255, 0.3)" borderRadius="md" color="white">
+              <AlertIcon color="rgba(24, 168, 255, 1)" />
+              <Text fontSize="sm">
+                Send this link to a friend who already has a Hive account.
+                They&apos;ll be able to create <Text as="span" fontFamily="mono" fontWeight="bold">@{username}</Text> for you in one click.
+              </Text>
+            </Alert>
+
+            <Box>
+              <Input
+                value={link}
+                isReadOnly
+                onClick={copyLink}
+                fontFamily="mono"
+                fontSize="sm"
+                bg="blackAlpha.500"
+                borderColor="whiteAlpha.200"
+                cursor="pointer"
+                pr={12}
+              />
+              <Box mt={-10} mr={2} display="flex" justifyContent="flex-end" position="relative" zIndex={1}>
+                <IconButton
+                  aria-label="Copy link"
+                  icon={<FaCopy />}
+                  size="sm"
+                  variant="ghost"
+                  onClick={copyLink}
+                />
+              </Box>
+            </Box>
+
+            <Stack align="center" spacing={1}>
+              <Box
+                onClick={() => setQrExpanded(!qrExpanded)}
+                bg="white"
+                p={qrExpanded ? 3 : 2}
+                borderRadius="md"
+                cursor="pointer"
+                transition="padding 0.15s"
+              >
+                <QRCodeSVG
+                  value={link}
+                  size={qrExpanded ? 220 : 96}
+                  level="H"
+                  bgColor="#ffffff"
+                  fgColor="#000000"
+                />
+              </Box>
+              <Text fontSize="xs" color="gray.400">{qrExpanded ? 'Tap to collapse' : 'Tap to enlarge'}</Text>
+            </Stack>
+
+            <HStack>
+              <Button flex={1} leftIcon={<FaCopy />} onClick={copyLink} variant="outline">
+                Copy link
+              </Button>
+              <Button flex={1} leftIcon={<FaShareAlt />} onClick={nativeShare} bg="rgba(24, 168, 255, 0.15)" _hover={{ bg: 'rgba(24, 168, 255, 0.25)' }}>
+                Share
+              </Button>
+            </HStack>
+
+            {waitingForSponsor && (
+              <Box
+                bg="rgba(255, 255, 255, 0.03)"
+                border="1px dashed"
+                borderColor="whiteAlpha.300"
+                borderRadius="md"
+                p={3}
+                display="flex"
+                alignItems="center"
+                gap={3}
+              >
+                <Spinner size="sm" />
+                <Box>
+                  <Text fontSize="sm" fontWeight="medium">Waiting for a sponsor…</Text>
+                  <Text fontSize="xs" color="gray.400">
+                    This page will update automatically once your account is created on Hive.
+                  </Text>
+                </Box>
+              </Box>
+            )}
+          </Stack>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/components/join/SponsorFlow.tsx
+++ b/components/join/SponsorFlow.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Alert,
+  AlertIcon,
+  Box,
+  Button,
+  Code,
+  Heading,
+  Link,
+  Spinner,
+  Stack,
+  Text,
+} from '@chakra-ui/react';
+import { FaExternalLinkAlt } from 'react-icons/fa';
+import HiveClient from '@/lib/hive/hiveclient';
+import { broadcastOps, KeyTypes } from '@/lib/hive/aioha';
+import { useHiveUser } from '@/contexts/UserContext';
+import { useLoginModal } from '@/contexts/LoginModalContext';
+import { decodeAccountData, type ShareableAccountData } from '@/lib/hive/share-link';
+
+interface SponsorFlowProps {
+  code: string;
+}
+
+type Mode = 'loading' | 'invalid' | 'needLogin' | 'ready' | 'broadcasting' | 'success' | 'error';
+type Variant = 'claimed' | 'paid' | 'claim_first';
+
+function buildAuth(pub: string) {
+  return {
+    weight_threshold: 1,
+    account_auths: [] as Array<[string, number]>,
+    key_auths: [[pub, 1]] as Array<[string, number]>,
+  };
+}
+
+export default function SponsorFlow({ code }: SponsorFlowProps) {
+  const { hiveUser } = useHiveUser();
+  const { openLoginModal } = useLoginModal();
+
+  const [data, setData] = useState<ShareableAccountData | null>(null);
+  const [pendingAct, setPendingAct] = useState<number>(0);
+  const [nameStillAvailable, setNameStillAvailable] = useState<boolean | null>(null);
+  const [mode, setMode] = useState<Mode>('loading');
+  const [error, setError] = useState<string | null>(null);
+  const [txId, setTxId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const decoded = decodeAccountData(code);
+    if (!decoded) {
+      setMode('invalid');
+      return;
+    }
+    setData(decoded);
+  }, [code]);
+
+  // Pull sponsor's ACT count + verify name is still free
+  useEffect(() => {
+    if (!data) return;
+    if (!hiveUser?.name) {
+      setMode('needLogin');
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const [sponsorAccts, targetAccts] = await Promise.all([
+          HiveClient.database.getAccounts([hiveUser.name]),
+          HiveClient.database.getAccounts([data.username]),
+        ]);
+        if (cancelled) return;
+        if (sponsorAccts.length === 0) {
+          setError('Could not load your account');
+          setMode('error');
+          return;
+        }
+        const acct = sponsorAccts[0] as unknown as { pending_claimed_accounts?: number };
+        setPendingAct(acct.pending_claimed_accounts ?? 0);
+        setNameStillAvailable(targetAccts.length === 0);
+        setMode('ready');
+      } catch (e) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : 'Failed to load account data');
+        setMode('error');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [data, hiveUser?.name]);
+
+  const broadcast = async (variant: Variant) => {
+    if (!data || !hiveUser?.name) return;
+    setMode('broadcasting');
+    setError(null);
+    try {
+      let op: [string, Record<string, unknown>];
+      let title: string;
+
+      if (variant === 'claim_first') {
+        op = ['claim_account', {
+          creator: hiveUser.name,
+          fee: '0.000 HIVE',
+          extensions: [],
+        }];
+        title = 'Claim 1 Account Creation Token';
+      } else if (variant === 'claimed') {
+        op = ['create_claimed_account', {
+          creator: hiveUser.name,
+          new_account_name: data.username,
+          owner: buildAuth(data.ownerPubkey),
+          active: buildAuth(data.activePubkey),
+          posting: buildAuth(data.postingPubkey),
+          memo_key: data.memoPubkey,
+          json_metadata: '',
+          extensions: [],
+        }];
+        title = `Sponsor @${data.username}`;
+      } else {
+        op = ['account_create', {
+          fee: '3.000 HIVE',
+          creator: hiveUser.name,
+          new_account_name: data.username,
+          owner: buildAuth(data.ownerPubkey),
+          active: buildAuth(data.activePubkey),
+          posting: buildAuth(data.postingPubkey),
+          memo_key: data.memoPubkey,
+          json_metadata: '',
+        }];
+        title = `Create @${data.username} for 3 HIVE`;
+      }
+
+      const result = await broadcastOps([op], KeyTypes.Active, title);
+      const broadcastResult = result.result as { id?: string; tx_id?: string } | undefined;
+      const id = broadcastResult?.tx_id ?? broadcastResult?.id ?? null;
+
+      if (variant === 'claim_first') {
+        setPendingAct((n) => n + 1);
+        setMode('ready');
+      } else {
+        setTxId(id);
+        setMode('success');
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Broadcast failed');
+      setMode('error');
+    }
+  };
+
+  if (mode === 'loading') {
+    return (
+      <Box display="flex" justifyContent="center" py={16}>
+        <Spinner color="white" />
+      </Box>
+    );
+  }
+
+  if (mode === 'invalid') {
+    return (
+      <Stack maxW="md" mx="auto" px={4} py={8}>
+        <Alert status="error" borderRadius="md">
+          <AlertIcon />
+          This invite link is invalid or corrupted.
+        </Alert>
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack spacing={5} maxW="md" mx="auto" w="full" px={4} py={8}>
+      <Box textAlign="center">
+        <Heading size="lg" color="white" mb={2}>
+          Sponsor a Hive account
+        </Heading>
+        <Text fontSize="sm" color="gray.400">
+          Someone is asking you to create{' '}
+          <Code colorScheme="blue" fontFamily="mono">
+            @{data?.username}
+          </Code>{' '}
+          for them. They generated the keys on their own device — you only sign the on-chain transaction.
+        </Text>
+      </Box>
+
+      {nameStillAvailable === false && (
+        <Alert status="warning" borderRadius="md">
+          <AlertIcon />
+          <Text fontSize="sm">
+            <Text as="span" fontFamily="mono">@{data?.username}</Text> is already taken. Ask them to generate a new link with a different username.
+          </Text>
+        </Alert>
+      )}
+
+      <Accordion allowToggle>
+        <AccordionItem border="1px solid" borderColor="whiteAlpha.200" borderRadius="md">
+          <AccordionButton _hover={{ bg: 'whiteAlpha.50' }}>
+            <Box flex="1" textAlign="left" fontSize="sm" color="white">
+              View public keys being assigned
+            </Box>
+            <AccordionIcon color="white" />
+          </AccordionButton>
+          <AccordionPanel pb={4}>
+            {data && (
+              <Stack spacing={2}>
+                {(
+                  [
+                    ['Owner', data.ownerPubkey],
+                    ['Active', data.activePubkey],
+                    ['Posting', data.postingPubkey],
+                    ['Memo', data.memoPubkey],
+                  ] as const
+                ).map(([label, key]) => (
+                  <Box key={label}>
+                    <Text fontSize="xs" color="gray.500">{label}</Text>
+                    <Code fontSize="xs" wordBreak="break-all" w="full" bg="blackAlpha.500" color="gray.200">
+                      {key}
+                    </Code>
+                  </Box>
+                ))}
+              </Stack>
+            )}
+          </AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+
+      {mode === 'needLogin' && (
+        <Button colorScheme="blue" size="lg" onClick={openLoginModal}>
+          Log in with Hive to sponsor
+        </Button>
+      )}
+
+      {mode === 'ready' && nameStillAvailable !== false && (
+        <Stack spacing={3}>
+          <Text fontSize="sm" color="gray.300">
+            Signed in as <Text as="span" fontWeight="bold" color="white">@{hiveUser?.name}</Text>.
+            You hold{' '}
+            <Text as="span" fontWeight="bold" color="white">{pendingAct}</Text>{' '}
+            Account Creation Token{pendingAct === 1 ? '' : 's'}.
+          </Text>
+
+          {pendingAct > 0 ? (
+            <Button colorScheme="green" size="lg" onClick={() => broadcast('claimed')}>
+              Sponsor @{data?.username} (free, uses 1 ACT)
+            </Button>
+          ) : (
+            <Stack spacing={2}>
+              <Text fontSize="xs" color="gray.400">
+                You don&apos;t have any Account Creation Tokens. Choose how to proceed:
+              </Text>
+              <Button variant="outline" onClick={() => broadcast('claim_first')}>
+                Claim 1 ACT first (uses Resource Credits — free)
+              </Button>
+              <Button variant="outline" colorScheme="orange" onClick={() => broadcast('paid')}>
+                Pay 3 HIVE to create the account directly
+              </Button>
+            </Stack>
+          )}
+        </Stack>
+      )}
+
+      {mode === 'broadcasting' && (
+        <Box display="flex" alignItems="center" gap={3} bg="whiteAlpha.50" p={3} borderRadius="md">
+          <Spinner size="sm" color="white" />
+          <Text fontSize="sm" color="white">Approve the transaction in your wallet…</Text>
+        </Box>
+      )}
+
+      {mode === 'success' && (
+        <Alert status="success" flexDirection="column" alignItems="flex-start" gap={2} borderRadius="md">
+          <Box display="flex" alignItems="center">
+            <AlertIcon />
+            <Text fontWeight="bold">@{data?.username} is live on Hive.</Text>
+          </Box>
+          {txId && (
+            <Link href={`https://hiveblocks.com/tx/${txId}`} isExternal fontSize="sm" color="blue.600">
+              View transaction <Box as="span" display="inline-block" ml={1}><FaExternalLinkAlt /></Box>
+            </Link>
+          )}
+        </Alert>
+      )}
+
+      {mode === 'error' && (
+        <Alert status="error" flexDirection="column" alignItems="flex-start" gap={2} borderRadius="md">
+          <Box display="flex" alignItems="center">
+            <AlertIcon />
+            <Text fontSize="sm">{error || 'Something went wrong.'}</Text>
+          </Box>
+          <Button size="sm" onClick={() => setMode('ready')}>
+            Try again
+          </Button>
+        </Alert>
+      )}
+    </Stack>
+  );
+}

--- a/components/join/SponsorFlow.tsx
+++ b/components/join/SponsorFlow.tsx
@@ -50,6 +50,7 @@ export default function SponsorFlow({ code }: SponsorFlowProps) {
   const [mode, setMode] = useState<Mode>('loading');
   const [error, setError] = useState<string | null>(null);
   const [txId, setTxId] = useState<string | null>(null);
+  const [reloadTick, setReloadTick] = useState(0);
 
   useEffect(() => {
     const decoded = decodeAccountData(code);
@@ -67,6 +68,7 @@ export default function SponsorFlow({ code }: SponsorFlowProps) {
       setMode('needLogin');
       return;
     }
+    setMode('loading');
     let cancelled = false;
     (async () => {
       try {
@@ -93,7 +95,7 @@ export default function SponsorFlow({ code }: SponsorFlowProps) {
     return () => {
       cancelled = true;
     };
-  }, [data, hiveUser?.name]);
+  }, [data, hiveUser?.name, reloadTick]);
 
   const broadcast = async (variant: Variant) => {
     if (!data || !hiveUser?.name) return;
@@ -290,7 +292,7 @@ export default function SponsorFlow({ code }: SponsorFlowProps) {
             <AlertIcon />
             <Text fontSize="sm">{error || 'Something went wrong.'}</Text>
           </Box>
-          <Button size="sm" onClick={() => setMode('ready')}>
+          <Button size="sm" onClick={() => setReloadTick((n) => n + 1)}>
             Try again
           </Button>
         </Alert>

--- a/components/layout/FooterNavigation.tsx
+++ b/components/layout/FooterNavigation.tsx
@@ -3,7 +3,7 @@ import { useLoginModal } from '@/contexts/LoginModalContext';
 import { Box, Button, HStack, Icon, Tooltip, useColorMode } from '@chakra-ui/react';
 import { CountBadge } from '@/components/ui/CountBadge';
 import { useRouter } from 'next/navigation';
-import { FiBell, FiBook, FiCreditCard, FiHome, FiUser, FiLogIn, FiLogOut, FiMessageSquare, FiChevronLeft, FiChevronRight, FiRadio } from 'react-icons/fi';
+import { FiBell, FiBook, FiCreditCard, FiHome, FiUser, FiLogIn, FiLogOut, FiMessageSquare, FiChevronLeft, FiChevronRight, FiRadio, FiUserPlus } from 'react-icons/fi';
 import { useState, useRef, useEffect } from 'react';
 import { useOpenPodsCount } from '@/hooks/useOpenPodsCount';
 import { useHiveNotifications } from '@/hooks/useHiveNotifications';
@@ -231,18 +231,32 @@ export default function FooterNavigation({ isChatOpen, setIsChatOpen, chatUnread
                         </Tooltip>
                     </>
                 ) : (
-                    <Tooltip label="Login" aria-label="Login tooltip">
-                        <Button
-                            onClick={openLoginModal}
-                            variant="ghost"
-                            color="white"
-                            size="sm"
-                            minW="40px"
-                            borderRadius="full"
-                            _hover={{ bg: 'whiteAlpha.200' }}
-                            leftIcon={<Icon as={FiLogIn} boxSize={4} />}
-                        />
-                    </Tooltip>
+                    <>
+                        <Tooltip label="Login" aria-label="Login tooltip">
+                            <Button
+                                onClick={openLoginModal}
+                                variant="ghost"
+                                color="white"
+                                size="sm"
+                                minW="40px"
+                                borderRadius="full"
+                                _hover={{ bg: 'whiteAlpha.200' }}
+                                leftIcon={<Icon as={FiLogIn} boxSize={4} />}
+                            />
+                        </Tooltip>
+                        <Tooltip label="Create account" aria-label="Create account tooltip">
+                            <Button
+                                onClick={() => handleNavigation('/join')}
+                                variant="ghost"
+                                color="white"
+                                size="sm"
+                                minW="40px"
+                                borderRadius="full"
+                                _hover={{ bg: 'whiteAlpha.200' }}
+                                leftIcon={<Icon as={FiUserPlus} boxSize={4} />}
+                            />
+                        </Tooltip>
+                    </>
                 )}
             </HStack>
             </Box>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,7 +1,6 @@
 'use client'
 import React, { useEffect, useState } from 'react';
-import { Box, Flex, Text, Button, Image, Stack, useColorMode, useToast } from '@chakra-ui/react';
-import { useRouter } from 'next/navigation';
+import { Box, Flex, Text, Button, Image, useColorMode, useToast } from '@chakra-ui/react';
 import { getCommunityInfo, getProfile } from '@/lib/hive/client-functions';
 import { useAioha } from '@aioha/react-ui';
 import { useLoginModal } from '@/contexts/LoginModalContext';
@@ -15,7 +14,6 @@ export default function Header() {
     const { openLoginModal } = useLoginModal();
     const isLoggedIn = !!user;
     const toast = useToast();
-    const router = useRouter();
 
     const communityTag = process.env.NEXT_PUBLIC_HIVE_COMMUNITY_TAG;
 
@@ -87,14 +85,9 @@ export default function Header() {
                         Logout ({user})
                     </Button>
                 ) : (
-                    <Stack spacing={1} align="flex-end">
-                        <Button onClick={openLoginModal}>
-                            Login
-                        </Button>
-                        <Button variant="link" size="xs" onClick={() => router.push('/join')}>
-                            Create account
-                        </Button>
-                    </Stack>
+                    <Button onClick={openLoginModal}>
+                        Login
+                    </Button>
                 )}
             </Flex>
         </Box>

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React, { useEffect, useState } from 'react';
-import { Box, Flex, Text, Button, Image, useColorMode, useToast } from '@chakra-ui/react';
+import { Box, Flex, Text, Button, Image, Stack, useColorMode, useToast } from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
 import { getCommunityInfo, getProfile } from '@/lib/hive/client-functions';
 import { useAioha } from '@aioha/react-ui';
 import { useLoginModal } from '@/contexts/LoginModalContext';
@@ -14,6 +15,7 @@ export default function Header() {
     const { openLoginModal } = useLoginModal();
     const isLoggedIn = !!user;
     const toast = useToast();
+    const router = useRouter();
 
     const communityTag = process.env.NEXT_PUBLIC_HIVE_COMMUNITY_TAG;
 
@@ -85,9 +87,14 @@ export default function Header() {
                         Logout ({user})
                     </Button>
                 ) : (
-                    <Button onClick={openLoginModal}>
-                        Login
-                    </Button>
+                    <Stack spacing={1} align="flex-end">
+                        <Button onClick={openLoginModal}>
+                            Login
+                        </Button>
+                        <Button variant="link" size="xs" onClick={() => router.push('/join')}>
+                            Create account
+                        </Button>
+                    </Stack>
                 )}
             </Flex>
         </Box>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -5,7 +5,7 @@ import { CountBadge } from '@/components/ui/CountBadge';
 import { useRouter, usePathname } from 'next/navigation';
 import { useAioha } from '@aioha/react-ui';
 import { useLoginModal } from '@/contexts/LoginModalContext';
-import { FiHome, FiBell, FiUser, FiShoppingCart, FiBook, FiCreditCard, FiLogIn, FiLogOut, FiMessageSquare, FiRadio, FiInfo } from 'react-icons/fi';
+import { FiHome, FiBell, FiUser, FiShoppingCart, FiBook, FiCreditCard, FiLogIn, FiLogOut, FiMessageSquare, FiRadio, FiInfo, FiUserPlus } from 'react-icons/fi';
 import { getCommunityInfo, getProfile } from '@/lib/hive/client-functions';
 import { animate, color, motion, px } from 'framer-motion';
 import { getHiveAvatarUrl } from '@/lib/utils/avatarUtils';
@@ -312,6 +312,24 @@ export default function Sidebar({ isChatOpen, setIsChatOpen, chatUnreadCount = 0
                             </Button>
                         </Box>
                     </Tooltip>
+                    {!isLoggedIn && (
+                        <Tooltip label="Create account" placement="right" hasArrow isDisabled={!isCompactMode}>
+                            <Box w="full">
+                                <Button
+                                    onClick={() => router.push('/join')}
+                                    variant="ghost"
+                                    w="full"
+                                    justifyContent={iconJustify}
+                                    leftIcon={<Icon as={FiUserPlus} boxSize={4} />}
+                                    px={3}
+                                    borderRadius="18px"
+                                    _hover={{ bg: 'rgba(24, 168, 255, 0.14)', color: 'accent' }}
+                                >
+                                    <Text display={textDisplay}>Create account</Text>
+                                </Button>
+                            </Box>
+                        </Tooltip>
+                    )}
                     <Tooltip label="About Snapie" placement="right" hasArrow isDisabled={!isCompactMode}>
                         <Box w="full">
                             <Button

--- a/lib/hive/account-create-client.ts
+++ b/lib/hive/account-create-client.ts
@@ -104,6 +104,7 @@ WARNING
 export interface DownloadBackupCallbacks {
   onClipboardFallback?: () => void;
   onDownload?: () => void;
+  onError?: () => void;
 }
 
 export function downloadBackupFile(
@@ -116,19 +117,33 @@ export function downloadBackupFile(
   const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
   const isIOSInApp = /iPhone|iPad|iPod/.test(ua) && !/Safari\//.test(ua);
 
+  const tryDownload = (): boolean => {
+    try {
+      const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `hive-${username}-keys.txt`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      callbacks.onDownload?.();
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
   if (isIOSInApp && navigator.clipboard?.writeText) {
-    navigator.clipboard.writeText(content).then(() => callbacks.onClipboardFallback?.());
+    navigator.clipboard
+      .writeText(content)
+      .then(() => callbacks.onClipboardFallback?.())
+      .catch(() => {
+        if (!tryDownload()) callbacks.onError?.();
+      });
     return;
   }
 
-  const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = `hive-${username}-keys.txt`;
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  URL.revokeObjectURL(url);
-  callbacks.onDownload?.();
+  if (!tryDownload()) callbacks.onError?.();
 }

--- a/lib/hive/account-create-client.ts
+++ b/lib/hive/account-create-client.ts
@@ -1,0 +1,134 @@
+'use client';
+
+import { PrivateKey, type KeyRole } from '@hiveio/dhive';
+import HiveClient from './hiveclient';
+
+export interface PrivateKeys {
+  owner: string;
+  active: string;
+  posting: string;
+  memo: string;
+  ownerPubkey: string;
+  activePubkey: string;
+  postingPubkey: string;
+  memoPubkey: string;
+}
+
+export interface ShareableAccountData {
+  username: string;
+  ownerPubkey: string;
+  activePubkey: string;
+  postingPubkey: string;
+  memoPubkey: string;
+}
+
+const ROLES: KeyRole[] = ['owner', 'active', 'posting', 'memo'];
+
+export function generatePassword(): string {
+  const array = new Uint32Array(10);
+  crypto.getRandomValues(array);
+  const wif = PrivateKey.fromSeed(array.toString()).toString();
+  return wif.substring(0, 25);
+}
+
+export function generateKeys(username: string, password: string): PrivateKeys {
+  const out: Record<string, string> = {};
+  for (const role of ROLES) {
+    const priv = PrivateKey.fromLogin(username, password, role);
+    out[role] = priv.toString();
+    out[`${role}Pubkey`] = priv.createPublic().toString();
+  }
+  return out as unknown as PrivateKeys;
+}
+
+export interface AccountNameValidation {
+  isValid: boolean;
+  error?: string;
+}
+
+export function validateAccountName(name: string): AccountNameValidation {
+  if (!name) return { isValid: false, error: 'Username is required' };
+  if (name.length < 3) return { isValid: false, error: 'Username must be at least 3 characters' };
+  if (name.length > 16) return { isValid: false, error: 'Username must be at most 16 characters' };
+
+  const segments = name.split('.');
+  for (const segment of segments) {
+    if (segment.length === 0) return { isValid: false, error: 'Username cannot contain empty segments' };
+    if (segment.length < 3) return { isValid: false, error: 'Each segment must be at least 3 characters' };
+    if (!/^[a-z]/.test(segment)) return { isValid: false, error: 'Each segment must start with a letter' };
+    if (!/[a-z0-9]$/.test(segment)) return { isValid: false, error: 'Each segment must end with a letter or digit' };
+    if (!/^[a-z0-9-]+$/.test(segment)) return { isValid: false, error: 'Only lowercase letters, digits, and hyphens are allowed' };
+    if (/--/.test(segment)) return { isValid: false, error: 'No consecutive hyphens allowed' };
+  }
+  return { isValid: true };
+}
+
+export async function checkAccountAvailability(name: string): Promise<boolean> {
+  const accounts = await HiveClient.database.getAccounts([name]);
+  return accounts.length === 0;
+}
+
+const BACKUP_TEMPLATE = (username: string, password: string, keys: PrivateKeys) =>
+  `SNAPIE / HIVE ACCOUNT BACKUP
+============================
+Generated: ${new Date().toISOString()}
+
+Username: ${username}
+
+Master Password (regenerates all keys below):
+${password}
+
+Owner key   (recovery only — never paste online):
+  Private: ${keys.owner}
+  Public:  ${keys.ownerPubkey}
+
+Active key  (wallet, transfers, account management):
+  Private: ${keys.active}
+  Public:  ${keys.activePubkey}
+
+Posting key (posts, votes, comments — daily use):
+  Private: ${keys.posting}
+  Public:  ${keys.postingPubkey}
+
+Memo key    (encrypted memos):
+  Private: ${keys.memo}
+  Public:  ${keys.memoPubkey}
+
+WARNING
+=======
+- These keys are the ONLY way to access this account. Hive has no password reset.
+- Anyone holding the OWNER key can take full control of the account.
+- Store this file offline (USB, password manager, printout). Do not email or screenshot it.
+`;
+
+export interface DownloadBackupCallbacks {
+  onClipboardFallback?: () => void;
+  onDownload?: () => void;
+}
+
+export function downloadBackupFile(
+  username: string,
+  password: string,
+  keys: PrivateKeys,
+  callbacks: DownloadBackupCallbacks = {},
+): void {
+  const content = BACKUP_TEMPLATE(username, password, keys);
+  const ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+  const isIOSInApp = /iPhone|iPad|iPod/.test(ua) && !/Safari\//.test(ua);
+
+  if (isIOSInApp && navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(content).then(() => callbacks.onClipboardFallback?.());
+    return;
+  }
+
+  const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `hive-${username}-keys.txt`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+  callbacks.onDownload?.();
+}

--- a/lib/hive/share-link.ts
+++ b/lib/hive/share-link.ts
@@ -1,0 +1,62 @@
+import type { ShareableAccountData } from './account-create-client';
+
+export type { ShareableAccountData };
+
+function base64UrlEncode(str: string): string {
+  if (typeof window === 'undefined') {
+    return Buffer.from(str, 'utf8').toString('base64url');
+  }
+  const bytes = new TextEncoder().encode(str);
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlDecode(str: string): string {
+  if (typeof window === 'undefined') {
+    return Buffer.from(str, 'base64url').toString('utf8');
+  }
+  let s = str.replace(/-/g, '+').replace(/_/g, '/');
+  while (s.length % 4) s += '=';
+  const bin = atob(s);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+
+export function encodeAccountData(data: ShareableAccountData): string {
+  const compact = {
+    u: data.username,
+    o: data.ownerPubkey,
+    a: data.activePubkey,
+    p: data.postingPubkey,
+    m: data.memoPubkey,
+  };
+  return base64UrlEncode(JSON.stringify(compact));
+}
+
+export function decodeAccountData(encoded: string): ShareableAccountData | null {
+  if (!encoded || typeof encoded !== 'string') return null;
+  try {
+    const json = base64UrlDecode(encoded);
+    const obj = JSON.parse(json) as Record<string, unknown>;
+    const { u, o, a, p, m } = obj;
+    if (
+      typeof u !== 'string' || !u ||
+      typeof o !== 'string' || !o ||
+      typeof a !== 'string' || !a ||
+      typeof p !== 'string' || !p ||
+      typeof m !== 'string' || !m
+    ) {
+      return null;
+    }
+    return { username: u, ownerPubkey: o, activePubkey: a, postingPubkey: p, memoPubkey: m };
+  } catch {
+    return null;
+  }
+}
+
+export function generateShareableLink(data: ShareableAccountData, origin?: string): string {
+  const base = origin ?? (typeof window !== 'undefined' ? window.location.origin : '');
+  return `${base}/join?code=${encodeAccountData(data)}`;
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "keychain": "^1.5.0",
     "livekit-client": "^2.18.0",
     "next": "14.2.35",
+    "qrcode.react": "^4.2.0",
     "react": "^18",
     "react-dom": "^18",
     "react-dropzone": "^14.3.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       next:
         specifier: 14.2.35
         version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@18.3.1)
       react:
         specifier: ^18
         version: 18.3.1
@@ -2877,6 +2880,11 @@ packages:
 
   qr.js@0.0.0:
     resolution: {integrity: sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
@@ -6590,6 +6598,10 @@ snapshots:
   punycode@2.3.1: {}
 
   qr.js@0.0.0: {}
+
+  qrcode.react@4.2.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   querystringify@2.2.0: {}
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,131 @@
+# Plan — Peer-Sponsored Account Creation (à la hive.io /join)
+
+## Goal
+Let a prospective Snapie user generate Hive keys client-side, download/back them up, and produce a shareable link. Anyone with claimed account tokens (or willing to pay 3 HIVE) can open that link, sign in with their existing wallet, and broadcast the account-creation transaction. The new user lands on Snapie with a working account.
+
+## Reference (hive.io)
+- `apps/web/src/components/join/CreateHiveAccount.tsx` — requester form, key gen, backup, share-link
+- `apps/web/src/components/join/JoinFlow.tsx` — sponsor flow, decodes `?code=`, broadcasts via existing auth
+- `lib/share-link.ts` (in their hive-lib) — `generateShareableLink` / `decodeAccountData`
+- They use `@hiveio/hive-lib` (their wrapper); we'll re-implement equivalents on top of `@hiveio/dhive` + Aioha, both already in this repo.
+
+## What snapie-io already has
+- `@hiveio/dhive` 1.3.1-beta — `PrivateKey.fromLogin(account, password, role)` for deterministic key derivation.
+- Aioha (`@aioha/aioha`, `@aioha/react-provider`) — `getAioha()` singleton in `lib/hive/aioha.ts` already registers Keychain, HiveAuth, PeakVault, Ledger. `aioha.signAndBroadcastTx(ops, KeyTypes.Active)` will work for sponsors.
+- `lib/hive/server-functions.ts:43` — server-side `createAccount` using `ACCOUNT_CREATOR` env (Snapie-paid path; reusable as a third option, not the primary one).
+- Login is already wired through `LoginModalContext` + Aioha modal.
+
+## Decisions (locked)
+
+- [x] **Sponsor signing transport** — Aioha (already wired). Keychain/HiveAuth/PeakVault/Ledger all work without new code.
+- [x] **Paid vs claimed** — default `create_claimed_account_operation`. If sponsor has no ACTs, surface two explicit options: claim one first (`claim_account_operation`, RC cost) or pay 3 HIVE (`account_create_operation`). No silent fallback.
+- [x] **Snapie-sponsored option** — deferred to **Phase 7** (post-launch). v1 ships peer-sponsor only.
+- [x] **Route** — single `/join` page, mode-switches on `?code=` param (matches hive.io).
+- [x] **QR rendering** — add `qrcode.react` dep.
+- [x] **Styling** — Chakra UI to match the rest of the app.
+
+## Threat model & non-negotiables
+- **Master password and private keys must never leave the browser.** All key derivation client-side. Password is only used to derive keys, then discarded after the user downloads the backup.
+- **The shareable link contains ONLY public keys + the requested username.** Confirm with an encode→decode round-trip before showing the link (hive.io does this in `CreateHiveAccount.tsx:336`).
+- **Username availability is advisory, not authoritative.** Final check happens at broadcast time on the sponsor side; show a clear error if the name was claimed in the gap.
+- **Sponsor confirms they understand they're paying RC / ACT / 3 HIVE** before signing. No silent broadcasts.
+
+---
+
+## Phase 1 — Client-side key generation library
+
+- [ ] Create `lib/hive/account-create-client.ts` (client-only, no `'use server'`):
+  - [ ] `generatePassword()` — `Uint32Array(10)` + `crypto.getRandomValues` + `PrivateKey.fromSeed(...).toString().slice(0, 25)` (mirror `server-functions.ts:25` but client-side).
+  - [ ] `generateKeys(username, password)` → `{ owner, ownerPubkey, active, activePubkey, posting, postingPubkey, memo, memoPubkey }`.
+  - [ ] `validateAccountName(name)` → `{ isValid, error? }`. Rules: 3–16 chars, lowercase, segments separated by `-` or `.`, each segment starts with a letter, no consecutive separators, no trailing separator. Match Hive's `is_valid_account_name`.
+  - [ ] `checkAccountAvailability(name)` — `dhive.database.getAccounts([name])`; return `accounts.length === 0`.
+  - [ ] `downloadBackupFile(account, password, keys)` — generate plain-text or PDF blob with username, master password, all four private keys (WIF) and public keys, recovery instructions; trigger download. Detect iOS in-app browser → fall back to clipboard copy.
+
+- [ ] Create `lib/hive/share-link.ts`:
+  - [ ] `type ShareableAccountData = { username, ownerPubkey, activePubkey, postingPubkey, memoPubkey }`
+  - [ ] `encodeAccountData(data)` → base64url(JSON.stringify(data)) using a compact key map (`{u, o, a, p, m}`) to keep URLs <300 chars.
+  - [ ] `decodeAccountData(encoded)` → `ShareableAccountData | null` (returns null on malformed input — never throw).
+  - [ ] `generateShareableLink(data)` → `${window.location.origin}/join?code=${encoded}`.
+
+## Phase 2 — Requester form (`components/join/CreateAccountForm.tsx`)
+
+- [ ] Username input with 500ms-debounced availability check (mirrors hive.io `handleAccountChange`).
+- [ ] Auto-generate a master password on mount; allow regenerate / show / hide / edit / copy.
+- [ ] Live-derive keys whenever (username, password) both valid.
+- [ ] "View keys" modal showing all four key pairs (private + public, copy buttons).
+- [ ] "Download backup" button → `downloadBackupFile`. Backup-confirmation checkbox is required to proceed.
+- [ ] Primary action: **"Generate share link"** → encodes share data, opens dialog with copy field + QR (`qrcode.react` not yet in deps, see Phase 5) + Discord/Telegram quick-share buttons.
+- [ ] Poll `database.getAccounts([username])` every 5s while share dialog is open; flip to success state when account exists. Show "View on Hive" link to `https://hiveblocks.com/@username`.
+- [ ] Skip the "logged-in user creates with their own ACTs" path for v1 — that's a separate flow and isn't what was asked.
+
+## Phase 3 — Sponsor flow (`components/join/SponsorFlow.tsx`)
+
+- [ ] Decode `?code=` from `useSearchParams()`. Show error card if invalid/missing.
+- [ ] Display: requested username, expandable accordion of the four public keys, plain-language explanation ("Someone is asking you to sponsor their Snapie account by spending one Account Creation Token, or 3 HIVE").
+- [ ] If not authenticated → CTA opens existing `LoginModalContext` (which uses Aioha).
+- [ ] On authenticated:
+  - [ ] Look up sponsor's `pending_claimed_accounts` via `database.getAccounts([sponsor])`.
+  - [ ] If `>0` → primary button "Sponsor with 1 ACT (free)" broadcasts `create_claimed_account` (op shape from `server-functions.ts:48-72`, but with sponsor as `creator`).
+  - [ ] If `=0` → show two options: (a) "Claim an ACT first" (broadcasts `claim_account` with `fee: 0 HIVE`, requires RC), then retry; (b) "Pay 3 HIVE instead" (broadcasts `account_create` with full new-account fields and `fee: '3.000 HIVE'`).
+  - [ ] All broadcasts via `aioha.signAndBroadcastTx([op], KeyTypes.Active)`.
+- [ ] On success: show tx id + `https://hiveblocks.com/tx/{id}` link, plus a "Tell @username they can log in now" CTA.
+
+## Phase 4 — Routing
+
+- [ ] `app/join/page.tsx` — `'use client'` page that reads `?code=` and renders either `<CreateAccountForm />` or `<SponsorFlow encodedData={code} />`. Wrap in `<Suspense>` for `useSearchParams`.
+- [ ] Add a "Create account" link in `components/auth/LoginModal.tsx` and on the marketing/landing area pointing to `/join`.
+- [ ] No other route changes (the `[...slug]` catch-all handles Hive @username slugs and shouldn't conflict with `/join`).
+
+## Phase 5 — Dependencies & infra
+
+- [ ] Add `qrcode.react` (BSD-licensed, ~12 KB) for the share dialog QR. If we want zero new deps, generate via the public `https://api.qrserver.com` endpoint instead — slower and a privacy trade since the link transits a third party. Recommend the lib.
+- [ ] No new build/runtime infra required. No env vars (the existing `ACCOUNT_CREATOR`/`ACCOUNT_KEY` server vars are unrelated to the peer-sponsor flow).
+
+## Phase 6 — Verify
+
+- [ ] Manual: generate a link in dev, decode round-trip, confirm public keys match. Verify backup file contains all keys + password.
+- [ ] Username validation: try `ab` (too short), `Foo` (uppercase), `foo--bar` (consecutive sep), `1foo` (digit-leading segment), `foo.` (trailing sep) — each must be rejected with a specific message.
+- [ ] On mainnet (or testnet if available) with a sponsor account holding ≥1 ACT: complete the full flow end-to-end. Confirm new account is created and the requester's polling auto-flips to success.
+- [ ] Sponsor with 0 ACTs and 0 RC for `claim_account`: confirm the 3-HIVE fallback path works (or is gated cleanly).
+- [ ] Mobile / iOS in-app browser: backup-file fallback (clipboard copy) works; QR scans correctly.
+- [ ] Invalid `?code=`: page shows the error card, doesn't crash.
+
+## Phase 7 — Snapie-sponsored option (post-launch)
+
+Adds a "Get sponsored by Snapie" button to the requester form for users with no friend on Hive. Same trust model as Ecency/InLeo's free-signup.
+
+- [ ] `POST /api/join/sponsor` — accepts `{ username, ownerPubkey, activePubkey, postingPubkey, memoPubkey, turnstileToken }`. **Never accepts a password or private key.** Validates name format + availability + captcha, then broadcasts `create_claimed_account` server-side using `ACCOUNT_CREATOR` / `ACCOUNT_KEY` env.
+- [ ] Cloudflare Turnstile (or hCaptcha) integration.
+- [ ] Rate-limit: 1 signup per IP per hour, sliding window.
+- [ ] Daily cap on `ACCOUNT_CREATOR` outflow (env-configurable) so a leak can't drain the ACT pool overnight.
+- [ ] Monitoring: log `pending_claimed_accounts` on `ACCOUNT_CREATOR`; alert when low so ACTs can be refilled.
+- [ ] Deprecate / lock down the existing `createAccount(username, password)` in `lib/hive/server-functions.ts:43` — current signature accepts the master password server-side, which is unsafe. Replace usages with the new pubkey-only path.
+
+## Out of scope for v1
+- i18n (hive.io has heavy `next-intl` use; we ship English first).
+- Keychain "Add account" deep-link after success (`window.hive_keychain.requestAddAccount`) — nice-to-have.
+- Email-based account recovery / Snapie-managed keys.
+- Captcha / rate-limit on the availability-check endpoint (low risk, pure read).
+
+## Files to create
+1. `lib/hive/account-create-client.ts`
+2. `lib/hive/share-link.ts`
+3. `components/join/CreateAccountForm.tsx`
+4. `components/join/SponsorFlow.tsx`
+5. `components/join/KeysModal.tsx`
+6. `components/join/ShareLinkDialog.tsx`
+7. `app/join/page.tsx`
+
+## Files to touch
+- `package.json` — add `qrcode.react`.
+- `components/auth/LoginModal.tsx` — link to `/join` for new users.
+- (Optional) homepage / header — surface "Create an account" entry point.
+
+## Effort estimate
+- Phase 1 (libs): ~3–4 hrs
+- Phase 2 (requester UI): ~5–6 hrs
+- Phase 3 (sponsor UI): ~3–4 hrs
+- Phase 4 (route + entry points): ~1 hr
+- Phase 6 (verify on chain): ~2 hrs (needs a sponsor account with ACT)
+
+Total: ~1.5–2 focused dev days for a working v1.


### PR DESCRIPTION
## Summary

Adds a hive.io-style account creation flow so users without a Hive account can sign up by getting a friend (or anyone with Account Creation Tokens) to sponsor them.

- **`/join`** — requester picks a username, gets auto-generated keys derived client-side from a master password, downloads a backup file, and generates a shareable invite link containing only public keys.
- **`/join?code=...`** — sponsor opens the link, logs in via Aioha, sees the requested username + ACT balance, and broadcasts `create_claimed_account` in one click. If the sponsor has zero ACTs, they can claim one (RC-funded) or pay 3 HIVE via `account_create` instead.
- Requester's page polls Hive every 5s and auto-flips to a success state once the account exists on chain.
- Header gets a "Create account" link below "Login" for logged-out users.

Private keys and the master password never leave the requester's browser. The shareable link contains only the four public keys + the requested username (base64url-encoded JSON, ~370 chars — fits any URL field and QR-renders cleanly).

## Test plan
- [x] Project type-checks (`tsc --noEmit -p .`)
- [x] Round-trip encode/decode of share data (`encodeAccountData` → `decodeAccountData`)
- [x] Username validation rejects bad inputs (`ab`, `Foo`, `foo--bar`, `1foo`, `foo.`)
- [x] Username availability check (debounced 500ms) against `database.getAccounts`
- [x] **End-to-end mainnet test**: requester generated a link, sponsor signed via Aioha (Keychain), `create_claimed_account` accepted, new account is live on Hive.
- [ ] Sponsor flow on an account with 0 ACTs — claim-first path (not yet exercised)
- [ ] Sponsor flow on an account with 0 ACTs — 3 HIVE paid path (not yet exercised)
- [ ] Invalid `?code=` shows error card without crashing
- [ ] iOS in-app browser falls back to clipboard for the key backup

## Out of scope (tracked in `tasks/todo.md`)
- Phase 7: Snapie-sponsored option (server API + Turnstile + rate-limit) — deferred post-launch.
- i18n, Keychain `requestAddAccount` deep-link after success, email-based recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added peer-to-peer account creation flow accessible via `/join` path
  * Users can generate secure account credentials with automatic key pair generation
  * Download or copy account backup files for safekeeping
  * Generate and share invite links with QR codes to facilitate peer sponsorship
  * Sponsors can fund new accounts via blockchain transactions

* **UI Updates**
  * Added "Create account" button to header navigation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mantequilla-Soft/snapie-io/pull/47)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->