### PR TITLE
Fix video recording upload to audio endpoint

### DIFF
--- a/components/hangouts/HangoutModal.tsx
+++ b/components/hangouts/HangoutModal.tsx
@@ -112,26 +112,10 @@ function RoomBody({ roomName, onClose }: RoomBodyProps) {
   }, [router, user, buildComposeUrl, onClose]);
 
   const handleVideoHandoff = useCallback(async (file: { blob: Blob; filename: string; duration: number; size: number }) => {
-    const filename = file.filename.replace(/\.(mp4|m4a|mov)$/i, '.mp3');
-    triggerBlobDownload(file.blob, filename);
-
-    if (user) {
-      try {
-        const { uploadAudioTo3Speak } = await import('@/lib/hive/client-functions');
-        const result = await uploadAudioTo3Speak(file.blob, file.duration, user);
-        if (result.success && result.playUrl) {
-          router.push(buildComposeUrl(result.playUrl));
-        } else {
-          router.push(buildComposeUrl());
-        }
-      } catch {
-        router.push(buildComposeUrl());
-      }
-    } else {
-      router.push(buildComposeUrl());
-    }
+    triggerBlobDownload(file.blob, file.filename);
+    router.push(buildComposeUrl());
     onClose();
-  }, [router, user, buildComposeUrl, onClose]);
+  }, [router, buildComposeUrl, onClose]);
 
   return (
     <HangoutsRoom


### PR DESCRIPTION
## Summary
- Prevent video recordings from uploading to the audio endpoint
- Keep original video file format (.mp4, .mov) instead of renaming to .mp3
- Audio recordings continue to upload to 3Speak audio endpoint as intended

## Changes
- Modified `handleVideoHandoff` to only download video files without attempting audio upload
- Removed incorrect `uploadAudioTo3Speak` call for video recordings
- Preserve original filename for video downloads

## Test plan
- Record a video in an openpod session and verify:
  - [ ] Video file downloads with correct format (.mp4, .mov, etc.)
  - [ ] User is redirected to compose without an audio URL
  - [ ] No upload attempt to audio endpoint
- Record audio in an openpod session and verify:
  - [ ] Audio uploads to 3Speak
  - [ ] User is redirected to compose with audio playUrl

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the video handoff workflow within hangout experiences. The handoff process now directly downloads content and prepares it for composition, eliminating unnecessary intermediate steps and external dependencies. This improves overall efficiency and responsiveness of the video handling feature.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mantequilla-Soft/snapie-io/pull/49)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->