### PR TITLE
fix: Hive node failover, Aioha dynamic node selection, placeholder cleanup

### DIFF
--- a/components/shared/HivePostPreview.tsx
+++ b/components/shared/HivePostPreview.tsx
@@ -185,7 +185,7 @@ export default function HivePostPreview({ author, permlink }: HivePostPreviewPro
               height="80px"
               objectFit="cover"
               borderRadius="md"
-              fallbackSrc="https://via.placeholder.com/80"
+              fallbackSrc="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='80' height='80'%3E%3Crect width='80' height='80' fill='%23e2e8f0'/%3E%3C/svg%3E"
             />
           )}
           <VStack align="start" flex={1} spacing={1}>

--- a/lib/hive/aioha.ts
+++ b/lib/hive/aioha.ts
@@ -1,5 +1,6 @@
 'use client';
 import { Aioha, Asset, KeyTypes, Providers } from '@aioha/aioha';
+import { fetchHealthyNodes } from './hiveclient';
 
 let aiohaInstance: Aioha | null = null;
 
@@ -37,7 +38,9 @@ export function getAioha(): Aioha {
         scope: ['login', 'vote', 'comment', 'follow', 'transfer'],
       });
     }
-    a.setApi('https://api.hive.blog');
+    a.setApi('https://api.openhive.network');
+    // Async: upgrade to the freshest healthy node from the beacon
+    fetchHealthyNodes().then(nodes => { if (nodes.length > 0) a.setApi(nodes[0]) }).catch(() => {});
     // NOTE: loadAuth() is intentionally NOT called here. It reads localStorage
     // synchronously and would populate `user` before hydration, causing a
     // server/client mismatch. The Providers component calls loadAuth() inside

--- a/lib/hive/client-functions.ts
+++ b/lib/hive/client-functions.ts
@@ -44,6 +44,7 @@ async function aiohaBroadcast(
     const out = await broadcastOps(operations, keyType, title);
     return { success: true, result: out.result };
   } catch (err) {
+    console.error('[aiohaBroadcast] broadcast failed:', err);
     return {
       success: false,
       error: err instanceof Error ? err.message : 'Broadcast failed',

--- a/lib/hive/hiveclient.tsx
+++ b/lib/hive/hiveclient.tsx
@@ -1,15 +1,14 @@
 import { Client } from "@hiveio/dhive"
 
 const FALLBACK_NODES = [
+  "https://api.openhive.network",
   "https://api.hive.blog",
   "https://techcoderx.com",
   "https://rpc.mahdiyari.info",
   "https://api.c0ff33a.uk",
 ]
 
-// Nodes to exclude (CORS issues with snapie.io)
 const EXCLUDED_NODE_HOSTS = [
-  "api.openhive.network",
   "api.deathwing.me",
 ]
 
@@ -89,6 +88,8 @@ export async function refreshHiveNodes(): Promise<void> {
   const nodes = await fetchHealthyNodes()
   hive.client = new Client(nodes)
 }
+
+export { fetchHealthyNodes }
 
 // Proxy that delegates all property access to the current hive.client.
 // This lets consumers keep `import HiveClient from './hiveclient'`

--- a/lib/hive/hiveclient.tsx
+++ b/lib/hive/hiveclient.tsx
@@ -72,18 +72,22 @@ async function fetchHealthyNodes(): Promise<string[]> {
   }
 }
 
-// Initialize with healthy nodes on first load (client-side only)
-if (typeof window !== "undefined") {
-  fetchHealthyNodes().then(nodes => {
-    hive.client = new Client(nodes)
-    if (process.env.NODE_ENV === "development") {
-      console.log("🔗 HiveClient initialized with beacon nodes:", nodes)
-    }
-  }).catch(err => {
-    if (process.env.NODE_ENV === "development") {
-      console.error("Failed to initialize HiveClient with beacon nodes:", err)
-    }
-  })
+// Initialize with healthy nodes on first load (client and server)
+fetchHealthyNodes().then(nodes => {
+  hive.client = new Client(nodes)
+  if (process.env.NODE_ENV === "development") {
+    console.log("🔗 HiveClient initialized with beacon nodes:", nodes)
+  }
+}).catch(err => {
+  if (process.env.NODE_ENV === "development") {
+    console.error("Failed to initialize HiveClient with beacon nodes:", err)
+  }
+})
+
+/** Call before a critical broadcast to guarantee fresh, healthy nodes are in use. */
+export async function refreshHiveNodes(): Promise<void> {
+  const nodes = await fetchHealthyNodes()
+  hive.client = new Client(nodes)
 }
 
 // Proxy that delegates all property access to the current hive.client.

--- a/lib/hive/server-functions.ts
+++ b/lib/hive/server-functions.ts
@@ -3,7 +3,7 @@
 
 import { PrivateKey, KeyRole, Operation } from '@hiveio/dhive';
 import { Buffer } from 'buffer';
-import HiveClient from "./hiveclient";
+import HiveClient, { refreshHiveNodes } from "./hiveclient";
 
 import { DefaultRenderer } from "@hiveio/content-renderer";
 
@@ -72,8 +72,9 @@ export async function createAccount(username: string, password: string) {
         },
     ];
 
-    // Broadcast the operation using HiveClient
+    // Broadcast using the freshest healthy nodes
     try {
+        await refreshHiveNodes();
         if (process.env.ACCOUNT_KEY) await HiveClient.broadcast.sendOperations([op], PrivateKey.from(process.env.ACCOUNT_KEY));
         console.log('Account created successfully');
     } catch (error) {


### PR DESCRIPTION
## Summary

- **Server-side node failover**: `hiveclient.tsx` was only fetching healthy nodes from the Peakd beacon on the client. Server actions (e.g. `createAccount`) were stuck on hardcoded fallback nodes with no refresh. Removed the `typeof window` guard so the beacon fetch runs on both client and server. Added `refreshHiveNodes()` export, called before `create_claimed_account` broadcast.

- **Aioha hardcoded to `api.hive.blog`**: All comment/post broadcasts go through Aioha, which had `api.hive.blog` hardcoded with zero failover. Now starts on `api.openhive.network` (confirmed working) and upgrades async to the beacon's best node.

- **`api.openhive.network` unblocked**: Was excluded due to old CORS notes but confirmed working. Removed from `EXCLUDED_NODE_HOSTS`, promoted to first entry in `FALLBACK_NODES`.

- **Broken placeholder image**: `HivePostPreview` was loading `via.placeholder.com/80` as a fallback — that service is down, causing console errors on every comment thread. Replaced with an inline SVG data URI.

- **Broadcast error logging**: `aiohaBroadcast` was silently swallowing errors, making node/broadcast failures invisible in the console.

## Test plan

- [x] Tested locally with HiveAuth — comments/replies broadcast successfully
- [ ] Verify comment posting works on production with Keychain and HiveAuth
- [ ] Confirm no CORS errors from `api.openhive.network` in production browser console
- [ ] Confirm placeholder console errors are gone on post/comment threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced blockchain network reliability through automated runtime node selection and health verification.
  * Improved account creation robustness with periodic node freshness updates.
  * Better error logging for blockchain transaction failures.
  * Optimized image rendering with improved fallback handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mantequilla-Soft/snapie-io/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->