### PR TITLE
perf: fetch snap container replies in parallel

### DIFF
--- a/hooks/useSnaps.ts
+++ b/hooks/useSnaps.ts
@@ -107,15 +107,18 @@ export const useSnaps = ({ filterType = 'community', username }: UseSnapsProps =
         break;
       }
 
-      for (const resultItem of result) {
-        const comments = (await HiveClient.database.call("get_content_replies", [
-          author,
-          resultItem.permlink,
-        ])) as ExtendedComment[];
+      const allReplies = await Promise.all(
+        result.map((resultItem: any) =>
+          HiveClient.database.call("get_content_replies", [author, resultItem.permlink])
+        )
+      );
+
+      for (let i = 0; i < result.length; i++) {
+        const resultItem = result[i];
+        const comments = allReplies[i] as ExtendedComment[];
 
         let filteredComments: ExtendedComment[] = [];
 
-        // Apply appropriate filter based on filterType
         if (filterType === 'community') {
           filteredComments = filterCommentsByTag(comments, tag);
         } else if (filterType === 'all') {
@@ -124,15 +127,12 @@ export const useSnaps = ({ filterType = 'community', username }: UseSnapsProps =
           filteredComments = filterCommentsByFollowing(comments);
         }
 
-        // Filter out muted accounts (community + user personal list)
         filteredComments = filteredComments.filter(c => !mutedList.has(c.author.toLowerCase()));
 
         allFilteredComments.push(...filteredComments);
 
-        // Add permlink to the fetched set
         fetchedPermlinksRef.current.add(resultItem.permlink);
 
-        // Update the last container info for the next fetch
         permlink = resultItem.permlink;
         date = resultItem.created;
       }


### PR DESCRIPTION
## Summary

- `get_content_replies` was awaited sequentially inside a `for...of` loop, meaning each batch of 3 containers cost 3 back-to-back RPC round trips before any snaps could render
- Replaced with `Promise.all` so all 3 reply fetches fire simultaneously — each loop iteration now costs 1 parallel round trip instead of 3 serial ones
- Confirmed significantly faster feed load locally, especially noticeable for accounts following many users

## Test plan

- [x] Tested locally — feed loads noticeably faster
- [ ] Verify Community, All, and Following tabs all load correctly
- [ ] Confirm scroll/pagination (load more) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)