### PR TITLE
fix: include video thumbnail in post metadata and feed preview

### DIFF
--- a/app/compose/Editor.tsx
+++ b/app/compose/Editor.tsx
@@ -211,9 +211,10 @@ interface EditorProps {
   isSubmitting?: boolean;
   onVideoEmbedUrlChange?: (url: string | null) => void;
   onAudioEmbedUrlChange?: (url: string | null) => void;
+  onVideoThumbnailChange?: (url: string | null) => void;
 }
 
-const Editor: FC<EditorProps> = ({ markdown, setMarkdown, title, setTitle, hashtagInput, setHashtagInput, hashtags, setHashtags, beneficiaries, setBeneficiaries, lockedAccounts, onSubmit, isSubmitting = false, onVideoEmbedUrlChange, onAudioEmbedUrlChange }) => {
+const Editor: FC<EditorProps> = ({ markdown, setMarkdown, title, setTitle, hashtagInput, setHashtagInput, hashtags, setHashtags, beneficiaries, setBeneficiaries, lockedAccounts, onSubmit, isSubmitting = false, onVideoEmbedUrlChange, onAudioEmbedUrlChange, onVideoThumbnailChange }) => {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const toast = useToast();
     const isMobile = useBreakpointValue({ base: true, sm: false }, { ssr: false });
@@ -417,6 +418,7 @@ const Editor: FC<EditorProps> = ({ markdown, setMarkdown, title, setTitle, hasht
                 setVideoEmbedUrl(result.embedUrl);
                 setVideoId(result.videoId);
                 setVideoThumbnailUrl(result.thumbnailUrl ?? null);
+                onVideoThumbnailChange?.(result.thumbnailUrl ?? null);
                 onVideoEmbedUrlChange?.(result.embedUrl);
                 toast({ title: 'Video Uploaded', description: 'Video will be embedded in your post.', status: 'success', duration: 3000, isClosable: true });
             } catch (error) {
@@ -434,6 +436,7 @@ const Editor: FC<EditorProps> = ({ markdown, setMarkdown, title, setTitle, hasht
         setVideoEmbedUrl(null);
         setVideoId(null);
         setVideoThumbnailUrl(null);
+        onVideoThumbnailChange?.(null);
         setVideoUploadProgress(0);
         onVideoEmbedUrlChange?.(null);
     };
@@ -458,6 +461,7 @@ const Editor: FC<EditorProps> = ({ markdown, setMarkdown, title, setTitle, hasht
                 }
                 await set3SpeakThumbnail(videoId, thumbUrl, apiKey);
                 setVideoThumbnailUrl(thumbUrl);
+                onVideoThumbnailChange?.(thumbUrl);
                 toast({ title: 'Thumbnail updated', status: 'success', duration: 2000, isClosable: true });
             } catch (error) {
                 toast({ title: 'Thumbnail update failed', description: error instanceof Error ? error.message : 'Please try again.', status: 'error', duration: 3000, isClosable: true });

--- a/app/compose/page.tsx
+++ b/app/compose/page.tsx
@@ -220,6 +220,7 @@ export default function Home() {
         setBeneficiaries([{ account: 'snapie', weight: 300 }]) // Reset to default
         setVideoEmbedUrl(null)
         setAudioEmbedUrl(null)
+        setVideoThumbnailUrl(null)
 
         // Redirect to post after delay (allow Hive node propagation)
         setTimeout(() => {

--- a/app/compose/page.tsx
+++ b/app/compose/page.tsx
@@ -53,6 +53,7 @@ export default function Home() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [videoEmbedUrl, setVideoEmbedUrl] = useState<string | null>(null)
   const [audioEmbedUrl, setAudioEmbedUrl] = useState<string | null>(null)
+  const [videoThumbnailUrl, setVideoThumbnailUrl] = useState<string | null>(null)
 
   // Sync state when search params change (e.g., same-route navigation from recording upload)
   useEffect(() => {
@@ -170,8 +171,10 @@ export default function Home() {
       if (videoEmbedUrl) postBody = `${postBody}\n\n${videoEmbedUrl}`
       if (audioEmbedUrl) postBody = `${postBody}\n\n${audioEmbedUrl}`
 
-      // Prepare image array for metadata (first image becomes thumbnail)
-      const imageArray = prepareImageArray(postBody)
+      // Prepare image array for metadata (first image becomes thumbnail).
+      // For video posts the body has no image markdown, so pass the video
+      // thumbnail explicitly so it lands in json_metadata.image[0].
+      const imageArray = prepareImageArray(postBody, videoThumbnailUrl)
 
       // Use SDK to build operations
       const composerResult = blogComposer.build({
@@ -293,6 +296,7 @@ export default function Home() {
           isSubmitting={isSubmitting}
           onVideoEmbedUrlChange={handleVideoEmbedUrlChange}
           onAudioEmbedUrlChange={setAudioEmbedUrl}
+          onVideoThumbnailChange={setVideoThumbnailUrl}
         />
       </Flex>
     </Flex>

--- a/components/blog/PostCard.tsx
+++ b/components/blog/PostCard.tsx
@@ -29,6 +29,9 @@ export default function PostCard({ post }: PostCardProps) {
         const images = extractImagesFromBody(body);
         if (images && images.length > 0) {
             setImageUrls(images);
+        } else if (metadata?.image?.length > 0) {
+            // Video posts have no inline images — fall back to json_metadata.image
+            setImageUrls(metadata.image);
         }
     }, [body]);
 

--- a/components/blog/PostCard.tsx
+++ b/components/blog/PostCard.tsx
@@ -29,9 +29,11 @@ export default function PostCard({ post }: PostCardProps) {
         const images = extractImagesFromBody(body);
         if (images && images.length > 0) {
             setImageUrls(images);
-        } else if (metadata?.image?.length > 0) {
-            // Video posts have no inline images — fall back to json_metadata.image
-            setImageUrls(metadata.image);
+        } else {
+            const metaImages = Array.isArray(metadata?.image)
+                ? metadata.image.filter((u: unknown): u is string => typeof u === 'string' && u.length > 0)
+                : [];
+            if (metaImages.length > 0) setImageUrls(metaImages);
         }
     }, [body]);
 


### PR DESCRIPTION
## Summary
- Bubbles the video thumbnail URL from `Editor` up to `compose/page.tsx` via a new optional `onVideoThumbnailChange` callback prop
- Passes the thumbnail as `selectedThumbnail` to `prepareImageArray()` so it lands in `json_metadata.image[0]` on publish
- `PostCard` now falls back to `json_metadata.image` when no inline images are found in the post body, so video posts show their thumbnail in the blogs feed

## Test plan
- [ ] Upload a video in the composer, publish the post, and confirm the thumbnail appears in the blogs feed
- [ ] Verify normal image-only posts still show their first inline image as the preview (no regression)
- [ ] Change the thumbnail after upload and confirm the updated one is used in metadata on publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video posts now automatically capture and display thumbnails in the feed and post previews.
  * Enhanced thumbnail selection and management in the video editor.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mantequilla-Soft/snapie-io/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->