### PR TITLE
feat: use 3speak SDK in snaps, center media, fix heart color

### DIFF
--- a/components/homepage/VoteSlider.tsx
+++ b/components/homepage/VoteSlider.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Slider, SliderTrack, SliderFilledTrack, SliderThumb, HStack, Text, useToast } from '@chakra-ui/react';
+import { Box, Button, Flex, Icon, Slider, SliderTrack, SliderFilledTrack, SliderThumb, HStack, Text, useToast } from '@chakra-ui/react';
 import { memo, useState } from 'react';
 import { FaHeart, FaRegHeart } from 'react-icons/fa';
 
@@ -91,7 +91,8 @@ const VoteControls = memo(({ initialVoted, initialVoteCount, onVote, onVoteOptim
     }
 
     return (
-        <Button leftIcon={voted ? (<FaHeart />) : (<FaRegHeart />)} variant="ghost" onClick={toggleSlider}>
+        <Button variant="ghost" onClick={toggleSlider}>
+            <Icon as={voted ? FaHeart : FaRegHeart} mr={1} color={voted ? "red.400" : undefined} />
             {voteCount}
         </Button>
     );

--- a/components/shared/InteractionBar.tsx
+++ b/components/shared/InteractionBar.tsx
@@ -143,11 +143,12 @@ export default function InteractionBar({
             ) : (
                 <Flex justifyContent="space-between" alignItems="center" className="post-actions">
                     <Flex alignItems="center">
-                        {voted ? (
-                            <Icon as={FaHeart} onClick={handleHeartClick} cursor="pointer" />
-                        ) : (
-                            <Icon as={FaRegHeart} onClick={handleHeartClick} cursor="pointer" />
-                        )}
+                        <Icon
+                            as={voted ? FaHeart : FaRegHeart}
+                            onClick={handleHeartClick}
+                            cursor="pointer"
+                            color={voted ? "red.400" : undefined}
+                        />
                         <Text ml={2} fontSize="sm">{voteCount}</Text>
                         
                         <Icon 

--- a/components/shared/MediaRenderer.tsx
+++ b/components/shared/MediaRenderer.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/utils/snapUtils";
 import SnapieSpeakAudio from "@/components/shared/SnapieSpeakAudio";
 import TwitterEmbed from "@/components/shared/TwitterEmbed";
+import ThreeSpeakVideoPlayer from "@/components/shared/ThreeSpeakVideoPlayer";
 import DOMPurify from "isomorphic-dompurify";
 
 interface MediaRendererProps {
@@ -63,11 +64,7 @@ const IframeEmbedBox = memo(function IframeEmbedBox({
       ? "min(420px, 100%)"
       : boxAspect === "4/5"
         ? "540px"
-        : "100%";
-  const centerEmbed =
-    boxAspect === "9/16" ||
-    boxAspect === "3/4" ||
-    boxAspect === "4/5";
+        : { base: "100%", md: "640px", lg: "800px" };
 
   return (
     <Box
@@ -75,7 +72,7 @@ const IframeEmbedBox = memo(function IframeEmbedBox({
       position="relative"
       aspectRatio={boxAspect}
       maxW={maxW}
-      mx={centerEmbed ? "auto" : undefined}
+      mx="auto"
       dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
       sx={{
         iframe: {
@@ -159,12 +156,11 @@ const MediaRenderer = ({ mediaContent }: MediaRendererProps) => {
 
           if (imageUrl) {
             return (
-              <Box key={index} mb={2}>
+              <Box key={index} mb={2} maxW="540px" mx="auto">
                 <Image
                   src={imageUrl}
                   alt="Post media"
                   width="100%"
-                  maxWidth="540px"
                   height="auto"
                   objectFit="contain"
                   borderRadius="md"
@@ -192,6 +188,14 @@ const MediaRenderer = ({ mediaContent }: MediaRendererProps) => {
             const idMatch = item.src.match(/[?&]id=(\d+)/i);
             if (idMatch) {
               return <TwitterEmbed key={`twitter-${idMatch[1]}`} tweetId={idMatch[1]} />;
+            }
+          }
+
+          if (item.src.includes("play.3speak.tv")) {
+            const key = speakVideoKeyFromUrl(item.src);
+            if (key) {
+              const [author, permlink] = key.split("/");
+              return <ThreeSpeakVideoPlayer key={key} author={author} permlink={permlink} />;
             }
           }
 

--- a/components/shared/ThreeSpeakVideoPlayer.tsx
+++ b/components/shared/ThreeSpeakVideoPlayer.tsx
@@ -28,7 +28,7 @@ export default function ThreeSpeakVideoPlayer({ author, permlink }: ThreeSpeakVi
 
     const isVertical = state.isVertical === true;
     const aspectRatio = isVertical ? '3/4' : '16/9';
-    const maxW = isVertical ? 'min(420px, 100%)' : '800px';
+    const maxW = isVertical ? 'min(420px, 100%)' : { base: '100%', md: '640px', lg: '800px' };
     const showSpinner = !state.ready && !fatalError;
 
     return (
@@ -41,7 +41,7 @@ export default function ThreeSpeakVideoPlayer({ author, permlink }: ThreeSpeakVi
             overflow="hidden"
             bg="black"
             my={4}
-            mx={isVertical ? 'auto' : undefined}
+            mx="auto"
         >
             {showSpinner && (
                 <Center position="absolute" inset="0" zIndex={1} bg="blackAlpha.600">


### PR DESCRIPTION
## Summary

- **3speak SDK in snaps**: replaced iframe embeds with `ThreeSpeakVideoPlayer` — gives snaps the same HLS streaming, poster image, and automatic vertical/landscape detection that blog posts already had
- **Centered media**: videos (3speak + YouTube) and images in snaps now center with responsive max-widths (100% on mobile, 640px on tablet, 800px on desktop)
- **Heart color fix**: voted heart was turning blue in snaps due to Chakra UI's `leftIcon` slot coloring; switched to inline `Icon` with `color="red.400"` when voted — consistent across snaps and the right-column post feed

## Test plan

- [ ] Open a snap with a 3speak video — confirm SDK player renders (spinner → HLS video with controls) instead of a bare iframe
- [ ] Open a snap with a YouTube link — confirm video is centered and capped responsively
- [ ] Vote on a snap — confirm heart fills red, not blue
- [ ] Vote on a post in the right column — confirm heart fills red consistently
- [ ] Confirm audio.3speak.tv and Twitter embeds in snaps still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native support for 3Speak video embeds with optimized rendering across all screen sizes.

* **Style**
  * Updated vote button heart icon styling with conditional color changes based on vote state.
  * Enhanced responsive layout and centering for embedded videos and images across different breakpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mantequilla-Soft/snapie-io/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->