### PR TITLE
feat: add message reply interactions in chat

### DIFF
--- a/app/api/chat/channels/[id]/messages/route.ts
+++ b/app/api/chat/channels/[id]/messages/route.ts
@@ -86,3 +86,33 @@ export const POST = withChatAuth(async (req, { username, params }) => {
 
   return NextResponse.json({ message }, { status: 201 });
 });
+
+export const PATCH = withChatAuth(async (req, { username, params }) => {
+  const channelId = params?.id;
+  if (!channelId) return NextResponse.json({ error: 'Channel id missing' }, { status: 400 });
+
+  const { messageId, content } = await req.json();
+  if (!messageId || typeof messageId !== 'string' || !mongoose.isValidObjectId(messageId)) {
+    return NextResponse.json({ error: 'Valid messageId required' }, { status: 400 });
+  }
+
+  const validated = validateMessageBody(content);
+  if (!validated.ok) return validated.response;
+
+  const channel = await Channel.findById(channelId);
+  if (!channel) return NextResponse.json({ error: 'Channel not found' }, { status: 404 });
+  const memberList = Array.isArray(channel.members) ? channel.members : [];
+  const isMember = memberList.includes(username);
+  if (!channel.isPublic && !isMember) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+  }
+
+  const message = await Message.findOneAndUpdate(
+    { _id: messageId, type: 'channel', target: channelId, sender: username },
+    { $set: { content: validated.value, editedAt: new Date() } },
+    { returnDocument: 'after' }
+  );
+
+  if (!message) return NextResponse.json({ error: 'Message not found or not editable' }, { status: 404 });
+  return NextResponse.json({ message });
+});

--- a/app/api/chat/dm/[id]/messages/route.ts
+++ b/app/api/chat/dm/[id]/messages/route.ts
@@ -131,3 +131,25 @@ export const POST = withChatAuth(async (req, { username, params }) => {
   );
 });
 
+export const PATCH = withChatAuth(async (req, { username, params }) => {
+  const id = params?.id;
+  if (!id) return NextResponse.json({ error: 'DM id missing' }, { status: 400 });
+  if (!isDmParticipant(id, username)) return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+
+  const { messageId, content } = await req.json();
+  if (!messageId || typeof messageId !== 'string') {
+    return NextResponse.json({ error: 'messageId required' }, { status: 400 });
+  }
+  const validated = validateMessageBody(content);
+  if (!validated.ok) return validated.response;
+
+  const message = await Message.findOneAndUpdate(
+    { _id: messageId, type: 'dm', target: id, sender: username },
+    { $set: { content: validated.value, editedAt: new Date() } },
+    { returnDocument: 'after' }
+  );
+  if (!message) return NextResponse.json({ error: 'Message not found or not editable' }, { status: 404 });
+
+  return NextResponse.json({ message });
+});
+

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -19,6 +19,7 @@ import {
   Switch,
   Spinner,
   Text,
+  Tooltip,
   VStack,
   useBreakpointValue,
 } from '@chakra-ui/react';
@@ -44,6 +45,7 @@ const POLL_INTERVAL = 15000;
 const QUICK_EMOJIS = ['😀', '😂', '❤️', '🔥', '👏', '👍', '🙏', '🎉', '😮', '😢'];
 const fadeIn = keyframes`from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: translateY(0); }`;
 const CHAT_PANEL_SIZE_KEY = 'snapie-chat-panel-size';
+const CHAT_PANEL_RESIZE_HINT_KEY = 'snapie-chat-resize-hint-dismissed';
 const DESKTOP_PANEL_DEFAULT = { width: 460, height: 680 };
 const DESKTOP_PANEL_MIN = { width: 400, height: 520 };
 
@@ -140,43 +142,44 @@ function MessageBubble({
       alignSelf="flex-start"
       maxW="88%"
     >
-      <HStack align="flex-end" spacing={2}>
-        <VStack spacing={1} align="center" minW="52px">
+      <HStack align="flex-start" spacing={2}>
+        <Box
+          onDoubleClick={() => onOpenDm?.(msg.sender)}
+          cursor={canOpenDm ? 'pointer' : 'default'}
+          title={canOpenDm ? 'Double-click to open DM' : undefined}
+          pt="2px"
+        >
+          <Avatar size="2xs" name={msg.sender} src={getHiveAvatarUrl(msg.sender, 'small')} />
+        </Box>
+        <Box minW={0}>
           <Text
             fontSize="10px"
             color="blue.300"
             fontWeight="600"
             letterSpacing="0.03em"
+            mb="2px"
             onDoubleClick={() => onOpenDm?.(msg.sender)}
             cursor={canOpenDm ? 'pointer' : 'default'}
             title={canOpenDm ? 'Double-click to open DM' : undefined}
             noOfLines={1}
-            maxW="52px"
           >
             @{msg.sender}
           </Text>
           <Box
-            onDoubleClick={() => onOpenDm?.(msg.sender)}
-            cursor={canOpenDm ? 'pointer' : 'default'}
-            title={canOpenDm ? 'Double-click to open DM' : undefined}
+            bg="whiteAlpha.100"
+            px={3}
+            py={2}
+            borderRadius="16px 16px 16px 4px"
+            border="1px solid"
+            borderColor="whiteAlpha.100"
           >
-            <Avatar size="2xs" name={msg.sender} src={getHiveAvatarUrl(msg.sender, 'small')} />
+            <Text fontSize="sm" color="white" lineHeight="1.5" whiteSpace="pre-wrap" wordBreak="break-word">
+              {msg.content}
+            </Text>
+            <Text fontSize="9px" color="whiteAlpha.400" mt="4px" textAlign="right">
+              {formatTime(msg.createdAt)}
+            </Text>
           </Box>
-        </VStack>
-        <Box
-          bg="whiteAlpha.100"
-          px={3}
-          py={2}
-          borderRadius="16px 16px 16px 4px"
-          border="1px solid"
-          borderColor="whiteAlpha.100"
-        >
-          <Text fontSize="sm" color="white" lineHeight="1.5" whiteSpace="pre-wrap" wordBreak="break-word">
-            {msg.content}
-          </Text>
-          <Text fontSize="9px" color="whiteAlpha.400" mt="4px" textAlign="right">
-            {formatTime(msg.createdAt)}
-          </Text>
         </Box>
       </HStack>
     </Box>
@@ -247,6 +250,7 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
   const [loadingMessages, setLoadingMessages] = useState(false);
   const [panelSize, setPanelSize] = useState(DESKTOP_PANEL_DEFAULT);
   const [isResizing, setIsResizing] = useState(false);
+  const [showResizeHint, setShowResizeHint] = useState(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
@@ -347,6 +351,16 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
     if (isMobile) return;
     localStorage.setItem(CHAT_PANEL_SIZE_KEY, JSON.stringify(panelSize));
   }, [panelSize, isMobile]);
+
+  useEffect(() => {
+    if (isMobile) return;
+    try {
+      const dismissed = localStorage.getItem(CHAT_PANEL_RESIZE_HINT_KEY) === '1';
+      setShowResizeHint(!dismissed);
+    } catch {
+      setShowResizeHint(true);
+    }
+  }, [isMobile]);
 
   const fetchMessagesForConversation = useCallback(async (
     convId: string,
@@ -575,6 +589,8 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
     if (isMobile) return;
     e.preventDefault();
     e.stopPropagation();
+    setShowResizeHint(false);
+    localStorage.setItem(CHAT_PANEL_RESIZE_HINT_KEY, '1');
     resizeStartRef.current = {
       x: e.clientX,
       y: e.clientY,
@@ -770,20 +786,30 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
         }}
       >
         {!isMobile && (
-          <Box
-            position="absolute"
-            left="0"
-            bottom="0"
-            w="16px"
-            h="16px"
-            cursor="nwse-resize"
-            zIndex={1500}
-            onMouseDown={handleResizeStart}
-            title="Resize chat panel"
-            sx={{
-              background: 'linear-gradient(135deg, transparent 48%, rgba(255,255,255,0.35) 49%, rgba(255,255,255,0.35) 51%, transparent 52%)',
-            }}
-          />
+          <Tooltip label="Drag to resize" hasArrow placement="top" isOpen={showResizeHint ? undefined : false}>
+            <Box
+              position="absolute"
+              left="0"
+              bottom="0"
+              w="22px"
+              h="22px"
+              cursor="nwse-resize"
+              zIndex={1500}
+              onMouseDown={handleResizeStart}
+              title="Drag to resize"
+              bg="whiteAlpha.100"
+              borderTop="1px solid"
+              borderRight="1px solid"
+              borderColor="whiteAlpha.200"
+              borderTopRightRadius="8px"
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              _hover={{ bg: 'whiteAlpha.200' }}
+            >
+              <Icon as={FiMaximize2} boxSize={3} color="whiteAlpha.700" />
+            </Box>
+          </Tooltip>
         )}
 
         {/* Header */}

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -106,12 +106,14 @@ function MessageBubble({
   onOpenDm,
   onReplySelect,
   replyPreview,
+  onEditSelect,
 }: {
   msg: Message;
   isOwn: boolean;
   onOpenDm?: (username: string) => void;
   onReplySelect?: (message: Message) => void;
   replyPreview?: Message | null;
+  onEditSelect?: (message: Message) => void;
 }) {
   const canOpenDm = !isOwn && !!onOpenDm;
   const handleReplyKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
@@ -119,6 +121,13 @@ function MessageBubble({
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       onReplySelect(msg);
+    }
+  };
+  const handleEditKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (!onEditSelect) return;
+    if (e.key === 'e' || e.key === 'E') {
+      e.preventDefault();
+      onEditSelect(msg);
     }
   };
   if (isOwn) {
@@ -158,9 +167,22 @@ function MessageBubble({
             {msg.content}
           </Text>
           <Text fontSize="9px" color="whiteAlpha.400" mt="4px" textAlign="right">
-            {formatTime(msg.createdAt)}
+            {msg.editedAt ? `edited • ${formatTime(msg.createdAt)}` : formatTime(msg.createdAt)}
           </Text>
         </Box>
+        {onEditSelect && (
+          <HStack justify="flex-end" mt={1}>
+            <Button
+              size="2xs"
+              variant="ghost"
+              colorScheme="whiteAlpha"
+              onClick={() => onEditSelect(msg)}
+              onKeyDown={handleEditKeyDown}
+            >
+              Edit
+            </Button>
+          </HStack>
+        )}
       </Box>
     );
   }
@@ -224,7 +246,7 @@ function MessageBubble({
               {msg.content}
             </Text>
             <Text fontSize="9px" color="whiteAlpha.400" mt="4px" textAlign="right">
-              {formatTime(msg.createdAt)}
+              {msg.editedAt ? `edited • ${formatTime(msg.createdAt)}` : formatTime(msg.createdAt)}
             </Text>
           </Box>
         </Box>
@@ -294,6 +316,7 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
   const [messageCache, setMessageCache] = useState<Record<string, Message>>({});
   const [dmStatus, setDmStatus] = useState<DmStatusInfo | null>(null);
   const [replyingTo, setReplyingTo] = useState<Message | null>(null);
+  const [editingMessage, setEditingMessage] = useState<Message | null>(null);
   const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
   const [loadingMessages, setLoadingMessages] = useState(false);
@@ -452,6 +475,7 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
     shouldAutoScrollRef.current = true;
     setDmStatus(null);
     setReplyingTo(null);
+    setEditingMessage(null);
     setMessageCache({});
     loadMessages(activeConversationId, activeConversation?.type);
   }, [isOpen, isMinimized, activeConversationId, activeConversation?.type, loadMessages]);
@@ -728,6 +752,20 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
     const replyTo = replyingTo?._id;
     try {
       setPanelError('');
+      if (editingMessage) {
+        let edited: Message;
+        if (activeConversation.type === 'dm') {
+          edited = await chatService.editDmMessage(activeConversation._id, editingMessage._id, content);
+        } else {
+          edited = await chatService.editMessage(activeConversation._id, editingMessage._id, content);
+        }
+        setMessages(prev => prev.map(m => (m._id === edited._id ? edited : m)));
+        setMessageCache(prev => ({ ...prev, [edited._id]: edited }));
+        setEditingMessage(null);
+        setReplyingTo(null);
+        setSending(false);
+        return;
+      }
       let msg: Message;
       let dmDelivery: { hasFcm: boolean; memoSuggested: boolean; cooldownMs: number } | undefined;
       if (activeConversation.type === 'dm') {
@@ -738,6 +776,7 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
         msg = await chatService.sendMessage(activeConversation._id, content, replyTo);
       }
       setMessages(prev => [...prev, msg]);
+      setMessageCache(prev => ({ ...prev, [msg._id]: msg }));
       setReplyingTo(null);
       if (activeConversation.type === 'dm' && dmDelivery?.memoSuggested && activeConversation.peer && user) {
         setShowMemoFallbackPrompt({ conversationId: activeConversation._id, peer: activeConversation.peer });
@@ -1210,6 +1249,11 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
                       onOpenDm={openDmByUsername}
                       onReplySelect={setReplyingTo}
                       replyPreview={msg.replyTo ? messageCache[msg.replyTo] || null : null}
+                      onEditSelect={msg.sender === user ? (m) => {
+                        setEditingMessage(m);
+                        setReplyingTo(null);
+                        setDraft(m.content);
+                      } : undefined}
                     />
                     ))}
                     {activeConversation?.type === 'dm' && (() => {
@@ -1364,6 +1408,35 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
                     </HStack>
                     <Text fontSize="11px" color="whiteAlpha.800" noOfLines={2}>
                       {replyingTo.content}
+                    </Text>
+                  </Box>
+                )}
+                {editingMessage && (
+                  <Box
+                    w="100%"
+                    border="1px solid"
+                    borderColor="orange.300"
+                    bg="orange.900"
+                    borderRadius="10px"
+                    p={2}
+                  >
+                    <HStack justify="space-between" mb={1}>
+                      <Text fontSize="11px" color="orange.100" fontWeight="600">
+                        Editing your message
+                      </Text>
+                      <IconButton
+                        aria-label="Cancel edit"
+                        icon={<FiX />}
+                        size="2xs"
+                        variant="ghost"
+                        onClick={() => {
+                          setEditingMessage(null);
+                          setDraft('');
+                        }}
+                      />
+                    </HStack>
+                    <Text fontSize="11px" color="whiteAlpha.800" noOfLines={2}>
+                      {editingMessage.content}
                     </Text>
                   </Box>
                 )}

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -24,7 +24,7 @@ import {
   useBreakpointValue,
 } from '@chakra-ui/react';
 import { keyframes } from '@emotion/react';
-import { useState, useEffect, useRef, useCallback, KeyboardEvent, MouseEvent as ReactMouseEvent, useMemo } from 'react';
+import { useState, useEffect, useRef, useCallback, KeyboardEvent, MouseEvent as ReactMouseEvent } from 'react';
 import { useAioha } from '@aioha/react-ui';
 import { FiArrowLeft, FiChevronDown, FiCornerUpLeft, FiHash, FiMaximize2, FiMessageSquare, FiMinus, FiPlus, FiSend, FiUsers, FiX } from 'react-icons/fi';
 import { KeyTypes } from '@aioha/aioha';
@@ -114,6 +114,13 @@ function MessageBubble({
   replyPreview?: Message | null;
 }) {
   const canOpenDm = !isOwn && !!onOpenDm;
+  const handleReplyKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (!onReplySelect) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onReplySelect(msg);
+    }
+  };
   if (isOwn) {
     return (
       <Box
@@ -130,6 +137,9 @@ function MessageBubble({
           borderColor="blue.500"
           onClick={() => onReplySelect?.(msg)}
           cursor={onReplySelect ? 'pointer' : 'default'}
+          role={onReplySelect ? 'button' : undefined}
+          tabIndex={onReplySelect ? 0 : undefined}
+          onKeyDown={handleReplyKeyDown}
         >
           {msg.replyTo && (
             <Box mb={2} px={2} py={1} borderRadius="8px" bg="blackAlpha.300" border="1px solid" borderColor="whiteAlpha.200">
@@ -193,6 +203,9 @@ function MessageBubble({
             borderColor="whiteAlpha.100"
             onClick={() => onReplySelect?.(msg)}
             cursor={onReplySelect ? 'pointer' : 'default'}
+            role={onReplySelect ? 'button' : undefined}
+            tabIndex={onReplySelect ? 0 : undefined}
+            onKeyDown={handleReplyKeyDown}
           >
             {msg.replyTo && (
               <Box mb={2} px={2} py={1} borderRadius="8px" bg="blackAlpha.300" border="1px solid" borderColor="whiteAlpha.200">
@@ -278,6 +291,7 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
   const [mutedUsers, setMutedUsers] = useState<string[]>([]);
   const [blockedUsers, setBlockedUsers] = useState<string[]>([]);
   const [messages, setMessages] = useState<Message[]>([]);
+  const [messageCache, setMessageCache] = useState<Record<string, Message>>({});
   const [dmStatus, setDmStatus] = useState<DmStatusInfo | null>(null);
   const [replyingTo, setReplyingTo] = useState<Message | null>(null);
   const [draft, setDraft] = useState('');
@@ -296,7 +310,6 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
 
   const isAuthed = chatService.isAuthenticated();
   const activeConversation = conversations.find(c => c._id === activeConversationId);
-  const messageById = useMemo(() => new Map(messages.map(m => [m._id, m])), [messages]);
 
   const mergeConversations = useCallback((baseConversations: Conversation[], publicChannels: Channel[]): Conversation[] => {
     const byId = new Map(baseConversations.map(c => [c._id, c]));
@@ -439,8 +452,18 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
     shouldAutoScrollRef.current = true;
     setDmStatus(null);
     setReplyingTo(null);
+    setMessageCache({});
     loadMessages(activeConversationId, activeConversation?.type);
   }, [isOpen, isMinimized, activeConversationId, activeConversation?.type, loadMessages]);
+
+  useEffect(() => {
+    if (!messages.length) return;
+    setMessageCache(prev => {
+      const next = { ...prev };
+      for (const msg of messages) next[msg._id] = msg;
+      return next;
+    });
+  }, [messages]);
 
   async function handleOpenConversation(conv: Conversation) {
     setPanelError('');
@@ -626,8 +649,6 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
     if (isMobile) return;
     e.preventDefault();
     e.stopPropagation();
-    setShowResizeHint(false);
-    localStorage.setItem(CHAT_PANEL_RESIZE_HINT_KEY, '1');
     resizeStartRef.current = {
       x: e.clientX,
       y: e.clientY,
@@ -635,6 +656,10 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
       height: panelSize.height,
     };
     setIsResizing(true);
+    setShowResizeHint(false);
+    try {
+      localStorage.setItem(CHAT_PANEL_RESIZE_HINT_KEY, '1');
+    } catch {}
   }
 
   useEffect(() => {
@@ -1184,7 +1209,7 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
                       isOwn={msg.sender === user}
                       onOpenDm={openDmByUsername}
                       onReplySelect={setReplyingTo}
-                      replyPreview={msg.replyTo ? messageById.get(msg.replyTo) || null : null}
+                      replyPreview={msg.replyTo ? messageCache[msg.replyTo] || null : null}
                     />
                     ))}
                     {activeConversation?.type === 'dm' && (() => {

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -24,9 +24,9 @@ import {
   useBreakpointValue,
 } from '@chakra-ui/react';
 import { keyframes } from '@emotion/react';
-import { useState, useEffect, useRef, useCallback, KeyboardEvent, MouseEvent as ReactMouseEvent } from 'react';
+import { useState, useEffect, useRef, useCallback, KeyboardEvent, MouseEvent as ReactMouseEvent, useMemo } from 'react';
 import { useAioha } from '@aioha/react-ui';
-import { FiArrowLeft, FiChevronDown, FiHash, FiMaximize2, FiMessageSquare, FiMinus, FiPlus, FiSend, FiUsers, FiX } from 'react-icons/fi';
+import { FiArrowLeft, FiChevronDown, FiCornerUpLeft, FiHash, FiMaximize2, FiMessageSquare, FiMinus, FiPlus, FiSend, FiUsers, FiX } from 'react-icons/fi';
 import { KeyTypes } from '@aioha/aioha';
 import { chatService, Channel, Conversation, DmStatusInfo, Message } from '@/lib/chat/ChatService';
 import { getFCMToken, onForegroundMessage } from '@/lib/chat/fcmClient';
@@ -104,10 +104,14 @@ function MessageBubble({
   msg,
   isOwn,
   onOpenDm,
+  onReplySelect,
+  replyPreview,
 }: {
   msg: Message;
   isOwn: boolean;
   onOpenDm?: (username: string) => void;
+  onReplySelect?: (message: Message) => void;
+  replyPreview?: Message | null;
 }) {
   const canOpenDm = !isOwn && !!onOpenDm;
   if (isOwn) {
@@ -124,7 +128,22 @@ function MessageBubble({
           borderRadius="16px 16px 4px 16px"
           border="1px solid"
           borderColor="blue.500"
+          onClick={() => onReplySelect?.(msg)}
+          cursor={onReplySelect ? 'pointer' : 'default'}
         >
+          {msg.replyTo && (
+            <Box mb={2} px={2} py={1} borderRadius="8px" bg="blackAlpha.300" border="1px solid" borderColor="whiteAlpha.200">
+              <HStack spacing={1} mb="2px">
+                <Icon as={FiCornerUpLeft} boxSize={3} color="whiteAlpha.700" />
+                <Text fontSize="10px" color="whiteAlpha.700" fontWeight="600">
+                  @{replyPreview?.sender || 'message'}
+                </Text>
+              </HStack>
+              <Text fontSize="11px" color="whiteAlpha.800" noOfLines={2}>
+                {replyPreview?.content || 'Original message unavailable'}
+              </Text>
+            </Box>
+          )}
           <Text fontSize="sm" color="white" lineHeight="1.5" whiteSpace="pre-wrap" wordBreak="break-word">
             {msg.content}
           </Text>
@@ -172,7 +191,22 @@ function MessageBubble({
             borderRadius="16px 16px 16px 4px"
             border="1px solid"
             borderColor="whiteAlpha.100"
+            onClick={() => onReplySelect?.(msg)}
+            cursor={onReplySelect ? 'pointer' : 'default'}
           >
+            {msg.replyTo && (
+              <Box mb={2} px={2} py={1} borderRadius="8px" bg="blackAlpha.300" border="1px solid" borderColor="whiteAlpha.200">
+                <HStack spacing={1} mb="2px">
+                  <Icon as={FiCornerUpLeft} boxSize={3} color="whiteAlpha.700" />
+                  <Text fontSize="10px" color="whiteAlpha.700" fontWeight="600">
+                    @{replyPreview?.sender || 'message'}
+                  </Text>
+                </HStack>
+                <Text fontSize="11px" color="whiteAlpha.800" noOfLines={2}>
+                  {replyPreview?.content || 'Original message unavailable'}
+                </Text>
+              </Box>
+            )}
             <Text fontSize="sm" color="white" lineHeight="1.5" whiteSpace="pre-wrap" wordBreak="break-word">
               {msg.content}
             </Text>
@@ -245,6 +279,7 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
   const [blockedUsers, setBlockedUsers] = useState<string[]>([]);
   const [messages, setMessages] = useState<Message[]>([]);
   const [dmStatus, setDmStatus] = useState<DmStatusInfo | null>(null);
+  const [replyingTo, setReplyingTo] = useState<Message | null>(null);
   const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
   const [loadingMessages, setLoadingMessages] = useState(false);
@@ -261,6 +296,7 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
 
   const isAuthed = chatService.isAuthenticated();
   const activeConversation = conversations.find(c => c._id === activeConversationId);
+  const messageById = useMemo(() => new Map(messages.map(m => [m._id, m])), [messages]);
 
   const mergeConversations = useCallback((baseConversations: Conversation[], publicChannels: Channel[]): Conversation[] => {
     const byId = new Map(baseConversations.map(c => [c._id, c]));
@@ -402,6 +438,7 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
     oldestIdRef.current = undefined;
     shouldAutoScrollRef.current = true;
     setDmStatus(null);
+    setReplyingTo(null);
     loadMessages(activeConversationId, activeConversation?.type);
   }, [isOpen, isMinimized, activeConversationId, activeConversation?.type, loadMessages]);
 
@@ -663,18 +700,20 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
     if (!content || sending || !activeConversation) return;
     setSending(true);
     setDraft('');
+    const replyTo = replyingTo?._id;
     try {
       setPanelError('');
       let msg: Message;
       let dmDelivery: { hasFcm: boolean; memoSuggested: boolean; cooldownMs: number } | undefined;
       if (activeConversation.type === 'dm') {
-        const out = await chatService.sendDmMessageWithDelivery(activeConversation._id, content);
+        const out = await chatService.sendDmMessageWithDelivery(activeConversation._id, content, replyTo);
         msg = out.message;
         dmDelivery = out.delivery;
       } else {
-        msg = await chatService.sendMessage(activeConversation._id, content);
+        msg = await chatService.sendMessage(activeConversation._id, content, replyTo);
       }
       setMessages(prev => [...prev, msg]);
+      setReplyingTo(null);
       if (activeConversation.type === 'dm' && dmDelivery?.memoSuggested && activeConversation.peer && user) {
         setShowMemoFallbackPrompt({ conversationId: activeConversation._id, peer: activeConversation.peer });
       }
@@ -1144,6 +1183,8 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
                       msg={msg}
                       isOwn={msg.sender === user}
                       onOpenDm={openDmByUsername}
+                      onReplySelect={setReplyingTo}
+                      replyPreview={msg.replyTo ? messageById.get(msg.replyTo) || null : null}
                     />
                     ))}
                     {activeConversation?.type === 'dm' && (() => {
@@ -1270,6 +1311,35 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
                         Send 0.001 {memoAssetChoice}
                       </Button>
                     </HStack>
+                  </Box>
+                )}
+                {replyingTo && (
+                  <Box
+                    w="100%"
+                    border="1px solid"
+                    borderColor="blue.300"
+                    bg="blue.900"
+                    borderRadius="10px"
+                    p={2}
+                  >
+                    <HStack justify="space-between" mb={1}>
+                      <HStack spacing={1}>
+                        <Icon as={FiCornerUpLeft} boxSize={3} color="blue.200" />
+                        <Text fontSize="11px" color="blue.100" fontWeight="600">
+                          Replying to @{replyingTo.sender}
+                        </Text>
+                      </HStack>
+                      <IconButton
+                        aria-label="Cancel reply"
+                        icon={<FiX />}
+                        size="2xs"
+                        variant="ghost"
+                        onClick={() => setReplyingTo(null)}
+                      />
+                    </HStack>
+                    <Text fontSize="11px" color="whiteAlpha.800" noOfLines={2}>
+                      {replyingTo.content}
+                    </Text>
                   </Box>
                 )}
                 <HStack spacing={1} w="100%" justify="space-between">

--- a/lib/chat/ChatService.ts
+++ b/lib/chat/ChatService.ts
@@ -17,6 +17,7 @@ export interface Message {
   sender: string;
   content: string;
   replyTo?: string | null;
+  editedAt?: string | null;
   createdAt: string;
 }
 
@@ -138,6 +139,19 @@ class ChatService {
     );
   }
 
+  async editDmMessage(conversationId: string, messageId: string, content: string): Promise<Message> {
+    const { message } = await this.request<{ message: Message }>(
+      `${BASE}/dm/${conversationId}/messages`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messageId, content }),
+      },
+      true
+    );
+    return message;
+  }
+
   async openDm(targetUser: string): Promise<Conversation> {
     const { conversation } = await this.post<{ conversation: Conversation }>(
       `${BASE}/dm`,
@@ -222,6 +236,19 @@ class ChatService {
     const { message } = await this.post<{ message: Message }>(
       `${BASE}/channels/${channelId}/messages`,
       { content, replyTo: replyTo || null },
+      true
+    );
+    return message;
+  }
+
+  async editMessage(channelId: string, messageId: string, content: string): Promise<Message> {
+    const { message } = await this.request<{ message: Message }>(
+      `${BASE}/channels/${channelId}/messages`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messageId, content }),
+      },
       true
     );
     return message;

--- a/lib/db/models/Message.ts
+++ b/lib/db/models/Message.ts
@@ -7,6 +7,7 @@ export interface IMessage extends Document {
   sender: string;
   content: string;
   replyTo?: Types.ObjectId | null;
+  editedAt?: Date | null;
   createdAt: Date;
 }
 
@@ -17,6 +18,7 @@ const MessageSchema = new Schema<IMessage>(
     sender: { type: String, required: true },
     content: { type: String, required: true, maxlength: 2000 },
     replyTo: { type: Schema.Types.ObjectId, ref: 'Message', default: null },
+    editedAt: { type: Date, default: null },
   },
   { timestamps: { createdAt: true, updatedAt: false } }
 );


### PR DESCRIPTION
## Summary
- add tap/click-to-reply interactions for chat messages
- show reply context above composer with cancel action
- include `replyTo` when sending channel and DM messages
- render quoted preview blocks in replied messages

## Test plan
- [ ] click any message bubble and verify reply context appears above composer
- [ ] send in a crowded channel and verify posted message references the selected message
- [ ] repeat in DM and verify `replyTo` works the same way
- [ ] verify cancel reply clears context and sends normal messages
- [ ] verify existing DM double-click open behavior still works

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- **Message reply support**: Click any message to reply to it; reply context is displayed in a preview panel above the compose bar and included when sending
- **Persistent resize hint dismissal**: Dismiss the resize hint once and your preference is remembered across sessions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mantequilla-Soft/snapie-io/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->