### PR TITLE
fix: correct ChatPanel edit key handler typing

### DIFF
--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -123,7 +123,7 @@ function MessageBubble({
       onReplySelect(msg);
     }
   };
-  const handleEditKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+  const handleEditKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
     if (!onEditSelect) return;
     if (e.key === 'e' || e.key === 'E') {
       e.preventDefault();


### PR DESCRIPTION
## Summary
- fix keyboard event typing in `ChatPanel` edit action handler
- align the handler type with Chakra `Button` `onKeyDown` expectations
- unblock Next.js production build/type-check on deploy

## Test plan
- [x] Run `npm run build`
- [x] Confirm no TypeScript errors in `components/chat/ChatPanel.tsx`

Made with [Cursor](https://cursor.com)