### PR TITLE
feat: add typing indicator and mention autocomplete in chat

### DIFF
--- a/app/api/chat/typing/route.ts
+++ b/app/api/chat/typing/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withChatAuth } from '@/lib/chat/auth';
+import { ChatUser } from '@/lib/db/models/ChatUser';
+import { Channel } from '@/lib/db/models/Channel';
+import { isDmParticipant } from '@/lib/chat/conversations';
+
+const TYPING_TTL_MS = 6000;
+const TYPING_CLEANUP_MS = 5 * 60 * 1000;
+
+function isConversationIdValid(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export const POST = withChatAuth(async (req: NextRequest, { username }) => {
+  const { conversationId, isTyping } = await req.json().catch(() => ({}));
+  if (!isConversationIdValid(conversationId)) {
+    return NextResponse.json({ error: 'conversationId required' }, { status: 400 });
+  }
+  const convId = conversationId.trim();
+  if (typeof isTyping !== 'boolean') {
+    return NextResponse.json({ error: 'isTyping boolean required' }, { status: 400 });
+  }
+
+  if (convId.startsWith('dm:')) {
+    if (!isDmParticipant(convId, username)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+    }
+  } else {
+    const channel = await Channel.findById(convId).lean();
+    if (!channel) return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+    const memberList = Array.isArray(channel.members) ? channel.members : [];
+    if (!channel.isPublic && !memberList.includes(username)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+    }
+  }
+
+  if (isTyping) {
+    await ChatUser.findOneAndUpdate(
+      { _id: username },
+      { $set: { [`typingAt.${convId}`]: new Date() } },
+      { upsert: true, returnDocument: 'after' }
+    );
+  } else {
+    await ChatUser.findOneAndUpdate(
+      { _id: username },
+      { $unset: { [`typingAt.${convId}`]: 1 } },
+      { upsert: true, returnDocument: 'after' }
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+});
+
+export const GET = withChatAuth(async (req: NextRequest, { username }) => {
+  const { searchParams } = new URL(req.url);
+  const conversationId = searchParams.get('conversationId');
+  if (!isConversationIdValid(conversationId)) {
+    return NextResponse.json({ error: 'conversationId required' }, { status: 400 });
+  }
+  const convId = conversationId.trim();
+
+  if (convId.startsWith('dm:')) {
+    if (!isDmParticipant(convId, username)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+    }
+  } else {
+    const channel = await Channel.findById(convId).lean();
+    if (!channel) return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+    const memberList = Array.isArray(channel.members) ? channel.members : [];
+    if (!channel.isPublic && !memberList.includes(username)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+    }
+  }
+
+  const users = await ChatUser.find(
+    { _id: { $ne: username }, [`typingAt.${convId}`]: { $exists: true } },
+    { _id: 1, typingAt: 1 }
+  ).lean();
+
+  const now = Date.now();
+  const typingUsers: string[] = [];
+  const staleUsers: string[] = [];
+
+  for (const u of users) {
+    const rawMap = u.typingAt as unknown as Record<string, string | Date> | undefined;
+    const ts = rawMap?.[convId];
+    if (!ts) continue;
+    const age = now - new Date(ts).getTime();
+    if (age <= TYPING_TTL_MS) typingUsers.push(String(u._id));
+    if (age > TYPING_CLEANUP_MS) staleUsers.push(String(u._id));
+  }
+
+  if (staleUsers.length > 0) {
+    await ChatUser.updateMany(
+      { _id: { $in: staleUsers } },
+      { $unset: { [`typingAt.${convId}`]: 1 } }
+    );
+  }
+
+  return NextResponse.json({ users: typingUsers, ttlMs: TYPING_TTL_MS });
+});

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -467,6 +467,7 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
   const [isResizing, setIsResizing] = useState(false);
   const [showResizeHint, setShowResizeHint] = useState(false);
   const [uploadingImage, setUploadingImage] = useState(false);
+  const [typingUsers, setTypingUsers] = useState<string[]>([]);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
@@ -476,9 +477,17 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
   const shouldAutoScrollRef = useRef(true);
   const resizeStartRef = useRef<{ x: number; y: number; width: number; height: number } | null>(null);
   const imageInputRef = useRef<HTMLInputElement>(null);
+  const typingPingAtRef = useRef(0);
+  const typingPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const isAuthed = chatService.isAuthenticated();
   const activeConversation = conversations.find(c => c._id === activeConversationId);
+  const typingLabel = useMemo(() => {
+    if (!typingUsers.length) return '';
+    if (typingUsers.length === 1) return `@${typingUsers[0]} is typing...`;
+    if (typingUsers.length === 2) return `@${typingUsers[0]} and @${typingUsers[1]} are typing...`;
+    return `${typingUsers.length} people are typing...`;
+  }, [typingUsers]);
   const sortedMentions = useMemo(
     () => messages
       .map((msg, idx) => ({ msg, idx }))
@@ -633,8 +642,26 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
     setReplyingTo(null);
     setEditingMessage(null);
     setMessageCache({});
+    setTypingUsers([]);
     loadMessages(activeConversationId, activeConversation?.type);
   }, [isOpen, isMinimized, activeConversationId, activeConversation?.type, loadMessages]);
+
+  useEffect(() => {
+    if (!isOpen || isMinimized || !isAuthed || !activeConversationId) return;
+
+    const loadTyping = async () => {
+      try {
+        const out = await chatService.getTyping(activeConversationId);
+        setTypingUsers(out.users || []);
+      } catch {}
+    };
+    loadTyping();
+    typingPollRef.current = setInterval(loadTyping, 3000);
+    return () => {
+      if (typingPollRef.current) clearInterval(typingPollRef.current);
+      typingPollRef.current = null;
+    };
+  }, [isOpen, isMinimized, isAuthed, activeConversationId]);
 
   useEffect(() => {
     if (!messages.length) return;
@@ -979,6 +1006,7 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
       setMessages(prev => [...prev, msg]);
       setMessageCache(prev => ({ ...prev, [msg._id]: msg }));
       setReplyingTo(null);
+      try { await chatService.setTyping(activeConversation._id, false); } catch {}
       if (activeConversation.type === 'dm' && dmDelivery?.memoSuggested && activeConversation.peer && user) {
         setShowMemoFallbackPrompt({ conversationId: activeConversation._id, peer: activeConversation.peer });
       }
@@ -991,6 +1019,13 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
   }
 
   function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (isAuthed && activeConversation && !sending) {
+      const now = Date.now();
+      if (now - typingPingAtRef.current > 1500) {
+        typingPingAtRef.current = now;
+        chatService.setTyping(activeConversation._id, true).catch(() => {});
+      }
+    }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSend();
@@ -1482,6 +1517,11 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
                   </VStack>
                 )}
                 <div ref={messagesEndRef} />
+                {!!typingLabel && (
+                  <Text fontSize="11px" color="whiteAlpha.600" mt={1}>
+                    {typingLabel}
+                  </Text>
+                )}
                 {shouldShowJumpToMention && (
                   <IconButton
                     aria-label="Jump to latest mention"

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -52,6 +52,7 @@ const DESKTOP_PANEL_MIN = { width: 400, height: 520 };
 const CHAT_IMAGE_MAX_BYTES = 8 * 1024 * 1024;
 const CHAT_IMAGE_ACCEPT = ['image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/avif'];
 const MENTION_REGEX = /@[a-z0-9.-]+/gi;
+const MENTION_INPUT_REGEX = /(?:^|\s)@([a-z0-9.-]{0,32})$/i;
 
 function isImageUrl(url: string): boolean {
   const trimmed = url.trim();
@@ -80,6 +81,26 @@ function messageMentionsUser(content: string, username?: string | null): boolean
   const target = normalizeMentionToken(username);
   const matches = content.match(MENTION_REGEX) || [];
   return matches.some(token => normalizeMentionToken(token) === target);
+}
+
+type ActiveMentionDraft = {
+  start: number;
+  end: number;
+  query: string;
+};
+
+function getActiveMentionDraft(content: string, cursorPos: number): ActiveMentionDraft | null {
+  if (!content || cursorPos < 0 || cursorPos > content.length) return null;
+  const beforeCursor = content.slice(0, cursorPos);
+  const match = beforeCursor.match(MENTION_INPUT_REGEX);
+  if (!match) return null;
+  const atIdx = beforeCursor.lastIndexOf('@');
+  if (atIdx < 0) return null;
+  return {
+    start: atIdx,
+    end: cursorPos,
+    query: (match[1] || '').toLowerCase(),
+  };
 }
 
 function contentWithMentions(content: string, activeUsername?: string | null): Array<{ text: string; highlighted: boolean }> {
@@ -468,6 +489,10 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
   const [showResizeHint, setShowResizeHint] = useState(false);
   const [uploadingImage, setUploadingImage] = useState(false);
   const [typingUsers, setTypingUsers] = useState<string[]>([]);
+  const [mentionQuery, setMentionQuery] = useState('');
+  const [mentionSuggestions, setMentionSuggestions] = useState<string[]>([]);
+  const [activeMentionIdx, setActiveMentionIdx] = useState(0);
+  const [hasValidMentionInDraft, setHasValidMentionInDraft] = useState(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
@@ -477,6 +502,7 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
   const shouldAutoScrollRef = useRef(true);
   const resizeStartRef = useRef<{ x: number; y: number; width: number; height: number } | null>(null);
   const imageInputRef = useRef<HTMLInputElement>(null);
+  const composerInputRef = useRef<HTMLInputElement>(null);
   const typingPingAtRef = useRef(0);
   const typingPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -498,6 +524,19 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
   const shouldShowJumpToMention =
     !!latestMention &&
     latestMention.idx < Math.max(messages.length - 3, 0);
+  const mentionCandidates = useMemo(() => {
+    if (!activeConversation) return [] as string[];
+    const set = new Set<string>();
+    if (user) set.add(normalizeMentionToken(user));
+    if (activeConversation.members?.length) {
+      for (const member of activeConversation.members) set.add(normalizeMentionToken(member));
+    }
+    if (activeConversation.peer) set.add(normalizeMentionToken(activeConversation.peer));
+    if (messages.length) {
+      for (const msg of messages) set.add(normalizeMentionToken(msg.sender));
+    }
+    return Array.from(set).filter(Boolean);
+  }, [activeConversation, messages, user]);
 
   const mergeConversations = useCallback((baseConversations: Conversation[], publicChannels: Channel[]): Conversation[] => {
     const byId = new Map(baseConversations.map(c => [c._id, c]));
@@ -643,8 +682,32 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
     setEditingMessage(null);
     setMessageCache({});
     setTypingUsers([]);
+    setMentionQuery('');
+    setMentionSuggestions([]);
+    setHasValidMentionInDraft(false);
     loadMessages(activeConversationId, activeConversation?.type);
   }, [isOpen, isMinimized, activeConversationId, activeConversation?.type, loadMessages]);
+
+  useEffect(() => {
+    const maybeMention = getActiveMentionDraft(draft, draft.length);
+    if (!maybeMention) {
+      setMentionQuery('');
+      setMentionSuggestions([]);
+      setActiveMentionIdx(0);
+      const hasValid = !!(user && draft.match(MENTION_REGEX)?.some(m => normalizeMentionToken(m) === normalizeMentionToken(user)));
+      setHasValidMentionInDraft(hasValid);
+      return;
+    }
+    const q = maybeMention.query;
+    const options = mentionCandidates
+      .filter(candidate => candidate.includes(q))
+      .slice(0, 6);
+    setMentionQuery(q);
+    setMentionSuggestions(options);
+    setActiveMentionIdx(prev => Math.min(prev, Math.max(options.length - 1, 0)));
+    const hasValid = !!(user && draft.match(MENTION_REGEX)?.some(m => normalizeMentionToken(m) === normalizeMentionToken(user)));
+    setHasValidMentionInDraft(hasValid);
+  }, [draft, mentionCandidates, user]);
 
   useEffect(() => {
     if (!isOpen || isMinimized || !isAuthed || !activeConversationId) return;
@@ -1018,7 +1081,48 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
     setSending(false);
   }
 
+  function applyMentionSuggestion(username: string) {
+    const input = composerInputRef.current;
+    const cursorPos = input?.selectionStart ?? draft.length;
+    const active = getActiveMentionDraft(draft, cursorPos);
+    if (!active) return;
+    const next = `${draft.slice(0, active.start)}@${username} ${draft.slice(active.end)}`;
+    setDraft(next);
+    setMentionSuggestions([]);
+    setMentionQuery('');
+    setActiveMentionIdx(0);
+    const nextCursor = active.start + username.length + 2;
+    requestAnimationFrame(() => {
+      if (!composerInputRef.current) return;
+      composerInputRef.current.focus();
+      composerInputRef.current.setSelectionRange(nextCursor, nextCursor);
+    });
+  }
+
   function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (mentionSuggestions.length > 0) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setActiveMentionIdx(prev => (prev + 1) % mentionSuggestions.length);
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setActiveMentionIdx(prev => (prev - 1 + mentionSuggestions.length) % mentionSuggestions.length);
+        return;
+      }
+      if (e.key === 'Tab' || e.key === 'Enter') {
+        e.preventDefault();
+        applyMentionSuggestion(mentionSuggestions[activeMentionIdx] || mentionSuggestions[0]);
+        return;
+      }
+      if (e.key === 'Escape') {
+        setMentionSuggestions([]);
+        setMentionQuery('');
+        return;
+      }
+    }
+
     if (isAuthed && activeConversation && !sending) {
       const now = Date.now();
       if (now - typingPingAtRef.current > 1500) {
@@ -1770,15 +1874,16 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
                     flexShrink={0}
                   />
                   <Input
+                    ref={composerInputRef}
                     value={draft}
                     onChange={e => setDraft(e.target.value)}
                     onKeyDown={handleKeyDown}
                     placeholder="Message…"
                     size="sm"
                     borderRadius="full"
-                    bg="whiteAlpha.50"
+                    bg={hasValidMentionInDraft ? 'yellow.900' : 'whiteAlpha.50'}
                     border="1px solid"
-                    borderColor="whiteAlpha.100"
+                    borderColor={hasValidMentionInDraft ? 'yellow.400' : 'whiteAlpha.100'}
                     color="white"
                     _placeholder={{ color: 'whiteAlpha.400' }}
                     _focus={{ borderColor: 'blue.400', boxShadow: '0 0 0 1px var(--chakra-colors-blue-400)', bg: 'whiteAlpha.100' }}
@@ -1798,6 +1903,36 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
                     flexShrink={0}
                   />
                 </HStack>
+                {mentionSuggestions.length > 0 && (
+                  <Box
+                    w="100%"
+                    border="1px solid"
+                    borderColor="whiteAlpha.200"
+                    borderRadius="10px"
+                    bg="gray.800"
+                    overflow="hidden"
+                  >
+                    <Text fontSize="10px" color="whiteAlpha.600" px={2} pt={2}>
+                      Mention suggestions {mentionQuery ? `for "${mentionQuery}"` : ''}
+                    </Text>
+                    <VStack align="stretch" spacing={0} p={1}>
+                      {mentionSuggestions.map((name, idx) => (
+                        <Button
+                          key={name}
+                          size="sm"
+                          justifyContent="flex-start"
+                          variant="ghost"
+                          borderRadius="8px"
+                          bg={idx === activeMentionIdx ? 'whiteAlpha.200' : 'transparent'}
+                          onClick={() => applyMentionSuggestion(name)}
+                          onMouseEnter={() => setActiveMentionIdx(idx)}
+                        >
+                          @{name}
+                        </Button>
+                      ))}
+                    </VStack>
+                  </Box>
+                )}
                 </Flex>
               )}
             </Flex>

--- a/lib/chat/ChatService.ts
+++ b/lib/chat/ChatService.ts
@@ -34,6 +34,11 @@ export interface DmStatusInfo {
   peerOnline: boolean;
 }
 
+export interface TypingStatusInfo {
+  users: string[];
+  ttlMs: number;
+}
+
 export interface Conversation {
   _id: string;
   name: string;
@@ -274,6 +279,15 @@ class ChatService {
     } catch {
       return 0;
     }
+  }
+
+  async setTyping(conversationId: string, isTyping: boolean): Promise<void> {
+    await this.post(`${BASE}/typing`, { conversationId, isTyping }, true);
+  }
+
+  async getTyping(conversationId: string): Promise<TypingStatusInfo> {
+    const qs = new URLSearchParams({ conversationId }).toString();
+    return this.get<TypingStatusInfo>(`${BASE}/typing?${qs}`, true);
   }
 
   private async get<T>(url: string, auth: boolean): Promise<T> {

--- a/lib/db/models/ChatUser.ts
+++ b/lib/db/models/ChatUser.ts
@@ -9,6 +9,7 @@ export interface IChatUser extends Document<string> {
   lastSeen: Date;
   conversationSeen: Map<string, Date>;
   memoNotifyAt: Map<string, Date>;
+  typingAt: Map<string, Date>;
 }
 
 const ChatUserSchema = new Schema<IChatUser>(
@@ -21,6 +22,7 @@ const ChatUserSchema = new Schema<IChatUser>(
     lastSeen: { type: Date, default: Date.now },
     conversationSeen: { type: Map, of: Date, default: {} },
     memoNotifyAt: { type: Map, of: Date, default: {} },
+    typingAt: { type: Map, of: Date, default: {} },
   },
   { timestamps: false }
 );


### PR DESCRIPTION
## Summary
- add transient typing indicator API and chat panel typing status UI
- add mention autocomplete in chat composer based on participants/recent senders
- add visual valid-mention feedback in composer when a resolvable mention is present

## Test plan
- [x] Run `npm run lint -- --file components/chat/ChatPanel.tsx --file app/api/chat/typing/route.ts --file lib/chat/ChatService.ts --file lib/db/models/ChatUser.ts`
- [x] Run `npm run build`
- [ ] In channel and DM, type `@` and verify suggestions + keyboard select (Up/Down, Enter/Tab)
- [ ] Verify input highlight appears when a valid mention exists in draft
- [ ] Verify `is typing...` appears for other participant(s) and clears after stop/send

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Real-time typing indicators now display which participants are actively typing in your conversations, helping you stay aware of ongoing discussions.
* `@mention` autocomplete suggestions in the message composer allow you to quickly tag other users, with intelligent filtering and visual highlighting when you're mentioned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->