### PR TITLE
feat: add chat popout mode and jump-to-now button

### DIFF
--- a/app/LayoutContent.tsx
+++ b/app/LayoutContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { Box, Flex } from '@chakra-ui/react';
 import { usePathname, useSearchParams } from 'next/navigation';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import Sidebar from '@/components/layout/Sidebar';
 import FooterNavigation from '@/components/layout/FooterNavigation';
@@ -16,11 +16,13 @@ export default function LayoutContent({ children }: { children: React.ReactNode 
   const searchParams = useSearchParams();
   const isComposePage = pathname === '/compose';
   const isEmbedMode = searchParams.get('embed') === 'true';
+  const isChatPopoutMode = searchParams.get('chat_popout') === '1';
   const { activeRoom, closeRoom } = useHangout();
 
   const [isChatOpen, setIsChatOpen] = useState(false);
   const [isChatMinimized, setIsChatMinimized] = useState(false);
   const [chatUnreadCount, setChatUnreadCount] = useState(0);
+  const popoutRef = useRef<Window | null>(null);
 
   useEffect(() => {
     if (isEmbedMode) {
@@ -42,6 +44,38 @@ export default function LayoutContent({ children }: { children: React.ReactNode 
 
   useEffect(() => { if (isChatOpen) setChatUnreadCount(0); }, [isChatOpen]);
 
+  useEffect(() => {
+    if (!isChatPopoutMode) return;
+    setIsChatOpen(true);
+    setIsChatMinimized(false);
+  }, [isChatPopoutMode]);
+
+  const handlePopoutChat = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    const width = 520;
+    const height = 760;
+    const left = window.screenX + Math.max(0, window.outerWidth - width - 40);
+    const top = window.screenY + 40;
+
+    if (popoutRef.current && !popoutRef.current.closed) {
+      popoutRef.current.focus();
+      return;
+    }
+
+    const popup = window.open(
+      '/?embed=true&chat_popout=1',
+      'snapie-chat-popout',
+      `popup=yes,width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=no`
+    );
+    if (!popup) return;
+    popoutRef.current = popup;
+    setIsChatOpen(false);
+    setIsChatMinimized(false);
+    popup.addEventListener('beforeunload', () => {
+      popoutRef.current = null;
+    });
+  }, []);
+
   return (
     <Box
       bg="background"
@@ -50,7 +84,7 @@ export default function LayoutContent({ children }: { children: React.ReactNode 
       bgGradient="radial(circle at 18% 8%, rgba(24, 168, 255, 0.16), transparent 34%), radial(circle at 78% 0%, rgba(102, 228, 255, 0.10), transparent 30%), linear(to-br, #06111f, #071827 48%, #04101d)"
     >
       <Flex direction={{ base: 'column', sm: 'row' }} h="100vh">
-        {!isEmbedMode && (
+        {!isEmbedMode && !isChatPopoutMode && (
           <Sidebar isChatOpen={isChatOpen} setIsChatOpen={setIsChatOpen} chatUnreadCount={chatUnreadCount} />
         )}
         <Box
@@ -60,10 +94,10 @@ export default function LayoutContent({ children }: { children: React.ReactNode 
           overflowY="auto"
           transition="margin-left 0.3s ease"
         >
-          {children}
+          {!isChatPopoutMode && children}
         </Box>
       </Flex>
-      {!isEmbedMode && (
+      {!isEmbedMode && !isChatPopoutMode && (
         <>
           <FooterNavigation isChatOpen={isChatOpen} setIsChatOpen={setIsChatOpen} chatUnreadCount={chatUnreadCount} />
           <ChatPanel
@@ -72,8 +106,20 @@ export default function LayoutContent({ children }: { children: React.ReactNode 
             isMinimized={isChatMinimized}
             onMinimize={() => setIsChatMinimized(true)}
             onRestore={() => { setIsChatMinimized(false); setIsChatOpen(true); }}
+            onPopout={handlePopoutChat}
           />
         </>
+      )}
+      {isChatPopoutMode && (
+        <ChatPanel
+          isOpen={isChatOpen}
+          onClose={() => {
+            setIsChatOpen(false);
+            if (typeof window !== 'undefined') window.close();
+          }}
+          isMinimized={false}
+          isPopoutWindow
+        />
       )}
       {!isEmbedMode && activeRoom && (
         <HangoutModal isOpen onClose={closeRoom} roomName={activeRoom} />

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -27,7 +27,7 @@ import {
 import { keyframes } from '@emotion/react';
 import { useState, useEffect, useRef, useCallback, useMemo, KeyboardEvent, MouseEvent as ReactMouseEvent } from 'react';
 import { useAioha } from '@aioha/react-ui';
-import { FiArrowLeft, FiArrowUp, FiChevronDown, FiCornerUpLeft, FiHash, FiImage, FiMaximize2, FiMessageSquare, FiMinus, FiPlus, FiSend, FiUsers, FiX } from 'react-icons/fi';
+import { FiArrowDown, FiArrowLeft, FiArrowUp, FiChevronDown, FiCornerUpLeft, FiExternalLink, FiHash, FiImage, FiMaximize2, FiMessageSquare, FiMinus, FiPlus, FiSend, FiUsers, FiX } from 'react-icons/fi';
 import { KeyTypes } from '@aioha/aioha';
 import { chatService, Channel, Conversation, DmStatusInfo, Message } from '@/lib/chat/ChatService';
 import { getFCMToken, onForegroundMessage } from '@/lib/chat/fcmClient';
@@ -40,6 +40,8 @@ interface ChatPanelProps {
   isMinimized?: boolean;
   onMinimize?: () => void;
   onRestore?: () => void;
+  onPopout?: () => void;
+  isPopoutWindow?: boolean;
 }
 
 const POLL_INTERVAL = 15000;
@@ -450,7 +452,15 @@ function ConversationRow({ conv, isActive, onClick }: { conv: Conversation; isAc
   );
 }
 
-export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, onRestore }: ChatPanelProps) {
+export default function ChatPanel({
+  isOpen,
+  onClose,
+  isMinimized,
+  onMinimize,
+  onRestore,
+  onPopout,
+  isPopoutWindow,
+}: ChatPanelProps) {
   const { user, aioha } = useAioha();
   const isMobile = useBreakpointValue({ base: true, md: false });
 
@@ -493,6 +503,7 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
   const [mentionSuggestions, setMentionSuggestions] = useState<string[]>([]);
   const [activeMentionIdx, setActiveMentionIdx] = useState(0);
   const [hasValidMentionInDraft, setHasValidMentionInDraft] = useState(false);
+  const [showJumpToNow, setShowJumpToNow] = useState(false);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
@@ -946,11 +957,17 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
+  useEffect(() => {
+    if (!messages.length) return;
+    if (!shouldAutoScrollRef.current) setShowJumpToNow(true);
+  }, [messages]);
+
   function handleMessagesScroll() {
     const el = messagesContainerRef.current;
     if (!el) return;
     const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
     shouldAutoScrollRef.current = distanceFromBottom < 80;
+    setShowJumpToNow(distanceFromBottom > 160);
   }
 
   function jumpToLatestMention() {
@@ -958,6 +975,12 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
     const el = messageNodeRefs.current[latestMention.msg._id];
     if (!el) return;
     el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }
+
+  function jumpToNow() {
+    shouldAutoScrollRef.current = true;
+    setShowJumpToNow(false);
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
   }
 
   function handleResizeStart(e: ReactMouseEvent<HTMLDivElement>) {
@@ -1375,6 +1398,20 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
                 onClick={onMinimize}
               />
             )}
+            {!isMobile && !!onPopout && !isPopoutWindow && (
+              <Tooltip label="Open chat in a separate window" hasArrow>
+                <Button
+                  size="xs"
+                  leftIcon={<FiExternalLink />}
+                  variant="ghost"
+                  color="whiteAlpha.500"
+                  _hover={{ color: 'white', bg: 'whiteAlpha.100' }}
+                  onClick={onPopout}
+                >
+                  Pop out
+                </Button>
+              </Tooltip>
+            )}
             <IconButton
               aria-label="Close chat"
               icon={<FiX />}
@@ -1626,6 +1663,21 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
                     {typingLabel}
                   </Text>
                 )}
+                {showJumpToNow && (
+                  <IconButton
+                    aria-label="Jump to current messages"
+                    icon={<FiArrowDown />}
+                    size="sm"
+                    colorScheme="blue"
+                    variant="solid"
+                    position="absolute"
+                    bottom="82px"
+                    right="14px"
+                    borderRadius="full"
+                    onClick={jumpToNow}
+                    title="Jump to current messages"
+                  />
+                )}
                 {shouldShowJumpToMention && (
                   <IconButton
                     aria-label="Jump to latest mention"
@@ -1634,7 +1686,7 @@ export default function ChatPanel({ isOpen, onClose, isMinimized, onMinimize, on
                     colorScheme="yellow"
                     variant="solid"
                     position="absolute"
-                    bottom="82px"
+                    bottom={showJumpToNow ? '124px' : '82px'}
                     right="14px"
                     borderRadius="full"
                     onClick={jumpToLatestMention}

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -516,6 +516,9 @@ export default function ChatPanel({
   const composerInputRef = useRef<HTMLInputElement>(null);
   const typingPingAtRef = useRef(0);
   const typingPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const hasInteractedRef = useRef(false);
+  const prevMessageIdsRef = useRef<Set<string>>(new Set());
+  const didPrimeMessageSetRef = useRef(false);
 
   const isAuthed = chatService.isAuthenticated();
   const activeConversation = conversations.find(c => c._id === activeConversationId);
@@ -696,8 +699,22 @@ export default function ChatPanel({
     setMentionQuery('');
     setMentionSuggestions([]);
     setHasValidMentionInDraft(false);
+    prevMessageIdsRef.current = new Set();
+    didPrimeMessageSetRef.current = false;
     loadMessages(activeConversationId, activeConversation?.type);
   }, [isOpen, isMinimized, activeConversationId, activeConversation?.type, loadMessages]);
+
+  useEffect(() => {
+    const markInteracted = () => {
+      hasInteractedRef.current = true;
+    };
+    window.addEventListener('pointerdown', markInteracted, { passive: true });
+    window.addEventListener('keydown', markInteracted);
+    return () => {
+      window.removeEventListener('pointerdown', markInteracted);
+      window.removeEventListener('keydown', markInteracted);
+    };
+  }, []);
 
   useEffect(() => {
     const maybeMention = getActiveMentionDraft(draft, draft.length);
@@ -745,6 +762,50 @@ export default function ChatPanel({
       return next;
     });
   }, [messages]);
+
+  const playNotificationChime = useCallback(() => {
+    if (!hasInteractedRef.current) return;
+    try {
+      const AudioCtx = window.AudioContext || (window as any).webkitAudioContext;
+      if (!AudioCtx) return;
+      const ctx = new AudioCtx();
+      const now = ctx.currentTime;
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'sine';
+      osc.frequency.setValueAtTime(920, now);
+      osc.frequency.exponentialRampToValueAtTime(720, now + 0.14);
+      gain.gain.setValueAtTime(0.0001, now);
+      gain.gain.exponentialRampToValueAtTime(0.055, now + 0.02);
+      gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.20);
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.start(now);
+      osc.stop(now + 0.22);
+      setTimeout(() => ctx.close().catch(() => {}), 280);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    const nextIds = new Set(messages.map(m => m._id));
+    if (!didPrimeMessageSetRef.current) {
+      prevMessageIdsRef.current = nextIds;
+      didPrimeMessageSetRef.current = true;
+      return;
+    }
+    const prevIds = prevMessageIdsRef.current;
+    const incoming = messages.filter(m => !prevIds.has(m._id) && m.sender !== user);
+    prevMessageIdsRef.current = nextIds;
+    if (!incoming.length || !activeConversation) return;
+
+    const shouldChime = incoming.some(m => {
+      if (activeConversation.type === 'dm') return true;
+      const mention = messageMentionsUser(m.content, user);
+      const replyToMine = !!(m.replyTo && messageCache[m.replyTo]?.sender === user);
+      return mention || replyToMine;
+    });
+    if (shouldChime) playNotificationChime();
+  }, [messages, activeConversation, user, messageCache, playNotificationChime]);
 
   async function handleOpenConversation(conv: Conversation) {
     setPanelError('');


### PR DESCRIPTION
## Summary
- add optional desktop chat popout window via header action
- support chat-only popout rendering mode through URL params
- add floating jump-to-now control when user is not at latest messages

## Test plan
- [x] Run `npm run lint -- --file app/LayoutContent.tsx --file components/chat/ChatPanel.tsx`
- [x] Run `npm run build`
- [ ] Open chat on desktop and click `Pop out`, verify separate window opens with chat
- [ ] Scroll up in active conversation and verify `jump to current` button appears and scrolls to latest
- [ ] Verify mention jump button still works when both controls are visible

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to pop out chat into a separate window via new "Pop out" button.
  * Improved chat scrolling with "Jump to current messages" control to quickly navigate to the latest messages.
  * Enhanced message notifications with sound chimes for incoming direct messages, mentions, and replies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->