### PR TITLE
fix: bump hangouts-core to 0.5.1 to unblock guest join

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@livekit/components-react": "^2.9.20",
     "@mantequilla-soft/3speak-player": "^0.3.2",
     "@snapie/composer": "workspace:*",
-    "@snapie/hangouts-core": "^0.5.0",
+    "@snapie/hangouts-core": "^0.5.1",
     "@snapie/hangouts-react": "^0.6.1",
     "@snapie/operations": "workspace:*",
     "@snapie/renderer": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: workspace:*
         version: link:packages/composer
       '@snapie/hangouts-core':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.5.1
+        version: 0.5.1
       '@snapie/hangouts-react':
         specifier: ^0.6.1
         version: 0.6.1(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
@@ -1345,8 +1345,8 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
-  '@snapie/hangouts-core@0.5.0':
-    resolution: {integrity: sha512-bGjp+2j3n44cY7+DSiNwr/f0eHJ/rRAnCq5CC5lkGBksXSofRrW0SB8q6iPqz7ZjJhPY8X2sxz0QuluYv6/uWA==}
+  '@snapie/hangouts-core@0.5.1':
+    resolution: {integrity: sha512-KZdWZfrzB07UA4+16kTSfylhYdJIcpyOuLhgFNbJkneuxCrSp6d7GIzrdDdTUw/1tf5vk0TjO1TWF0p+n+oiiA==}
 
   '@snapie/hangouts-react@0.6.1':
     resolution: {integrity: sha512-uNs0lU48vHOnAJhQp5ctaG7wlThfy7MqepolysPzg8wmMrDdypC5TF86iGlSWxv8UmkHep5WEMh77xUwhhKWqQ==}
@@ -5671,12 +5671,12 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@snapie/hangouts-core@0.5.0': {}
+  '@snapie/hangouts-core@0.5.1': {}
 
   '@snapie/hangouts-react@0.6.1(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
     dependencies:
       '@livekit/components-react': 2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
-      '@snapie/hangouts-core': 0.5.0
+      '@snapie/hangouts-core': 0.5.1
       livekit-client: 2.18.0(@types/dom-mediacapture-record@1.0.22)
       react: 18.3.1
 


### PR DESCRIPTION
## Summary

- Bumps `@snapie/hangouts-core` from `0.5.0` → `0.5.1`

## Root cause

`0.5.0` called `listenAsGuest(roomName)` with no body when no `displayName` was provided. The server's `/listen` route has a Fastify AJV schema of `type: object`, which rejects `null` — returning `400 body must be object`. Guests got stuck on "Connecting..." indefinitely.

`0.5.1` sends `{}` as the body when there is no display name, satisfying the schema. The server has also been patched (`deploy.sh`) to accept `null` for backwards compatibility.

## Test plan

- [ ] Merge and redeploy frontend
- [ ] Confirm server `deploy.sh` has been run
- [ ] Share a hangout link with a non-Hive user and verify they can join as a guest

🤖 Generated with [Claude Code](https://claude.com/claude-code)