### PR TITLE
chore: bump @snapie/hangouts-react 0.6.1→0.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@mantequilla-soft/3speak-player": "^0.3.2",
     "@snapie/composer": "workspace:*",
     "@snapie/hangouts-core": "^0.5.1",
-    "@snapie/hangouts-react": "^0.6.1",
+    "@snapie/hangouts-react": "^0.6.3",
     "@snapie/operations": "workspace:*",
     "@snapie/renderer": "workspace:*",
     "@supabase/supabase-js": "^2.45.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       '@snapie/hangouts-react':
-        specifier: ^0.6.1
-        version: 0.6.1(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
+        specifier: ^0.6.3
+        version: 0.6.3(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
       '@snapie/operations':
         specifier: workspace:*
         version: link:packages/operations
@@ -1348,8 +1348,8 @@ packages:
   '@snapie/hangouts-core@0.5.1':
     resolution: {integrity: sha512-KZdWZfrzB07UA4+16kTSfylhYdJIcpyOuLhgFNbJkneuxCrSp6d7GIzrdDdTUw/1tf5vk0TjO1TWF0p+n+oiiA==}
 
-  '@snapie/hangouts-react@0.6.1':
-    resolution: {integrity: sha512-uNs0lU48vHOnAJhQp5ctaG7wlThfy7MqepolysPzg8wmMrDdypC5TF86iGlSWxv8UmkHep5WEMh77xUwhhKWqQ==}
+  '@snapie/hangouts-react@0.6.3':
+    resolution: {integrity: sha512-/LjNNZJqxCzInLBCASvkLZLocIPUa7RRejhb7QWCSZCE2meWRVM6qt+8M8avSdkI0iIOZS0mZ35y2WGxR30ErQ==}
     peerDependencies:
       '@livekit/components-react': ^2.0.0
       livekit-client: ^2.0.0
@@ -5673,7 +5673,7 @@ snapshots:
 
   '@snapie/hangouts-core@0.5.1': {}
 
-  '@snapie/hangouts-react@0.6.1(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
+  '@snapie/hangouts-react@0.6.3(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
     dependencies:
       '@livekit/components-react': 2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@snapie/hangouts-core': 0.5.1


### PR DESCRIPTION
## Summary
- Bumps `@snapie/hangouts-react` from `^0.6.1` to `^0.6.3` to pick up the latest npm release

## Test plan
- [ ] Deploy and confirm hangouts functionality works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to a newer compatible version, which may include performance improvements and bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->