### PR TITLE
feat: blog post 3-column sidebar and profile page enhancement

### DIFF
--- a/components/blog/PostPage.tsx
+++ b/components/blog/PostPage.tsx
@@ -1,7 +1,8 @@
 // app/page.tsx
 'use client';
 
-import { Box, Spinner } from '@chakra-ui/react';
+import { Box, Flex, Spinner } from '@chakra-ui/react';
+import PostSidebar from '@/components/blog/PostSidebar';
 import SnapList from '../homepage/SnapList';
 import SnapComposer from '../homepage/SnapComposer';
 import { useEffect, useState } from 'react';
@@ -98,23 +99,41 @@ export default function PostPage({ author, permlink }: PostPageProps) {
 
   return (
     <Box bg="background" color="text" minH="100vh" p={isEmbedMode ? 2 : 4}>
-      <PostDetails post={post} isEmbedMode={isEmbedMode} />
-      {!isEmbedMode && !conversation ? (
-        <>
-          <SnapComposer pa={author} pp={permlink} onNewComment={handleTopLevelComment} post={true} onClose={() => {}} />
-          <SnapList
-            author={author}
-            permlink={permlink}
-            setConversation={setConversation}
-            onOpen={onOpen}
-            setReply={setReply}
-            post={true}
-            data={commentsData}
-          />
-        </>
-      ) : !isEmbedMode && conversation ? (
-        <Conversation comment={conversation} setConversation={setConversation} onOpen={onOpen} setReply={setReply} refreshTrigger={conversationRefreshTrigger} />
-      ) : null}
+      <Flex gap={6} align="flex-start">
+        <Box flex="1" minW={0}>
+          <PostDetails post={post} isEmbedMode={isEmbedMode} />
+          {!isEmbedMode && !conversation ? (
+            <>
+              <SnapComposer pa={author} pp={permlink} onNewComment={handleTopLevelComment} post={true} onClose={() => {}} />
+              <SnapList
+                author={author}
+                permlink={permlink}
+                setConversation={setConversation}
+                onOpen={onOpen}
+                setReply={setReply}
+                post={true}
+                data={commentsData}
+              />
+            </>
+          ) : !isEmbedMode && conversation ? (
+            <Conversation comment={conversation} setConversation={setConversation} onOpen={onOpen} setReply={setReply} refreshTrigger={conversationRefreshTrigger} />
+          ) : null}
+        </Box>
+
+        {!isEmbedMode && (
+          <Box
+            display={{ base: 'none', lg: 'flex' }}
+            flexDir="column"
+            w="300px"
+            flexShrink={0}
+            position="sticky"
+            top={4}
+            alignSelf="flex-start"
+          >
+            <PostSidebar author={author} permlink={permlink} />
+          </Box>
+        )}
+      </Flex>
       {!isEmbedMode && isOpen && <SnapReplyModal isOpen={isOpen} onClose={onClose} comment={reply} onNewReply={handleReply} />}
     </Box>
   );

--- a/components/blog/PostSidebar.tsx
+++ b/components/blog/PostSidebar.tsx
@@ -1,0 +1,263 @@
+'use client';
+import React, { useEffect, useState } from 'react';
+import {
+  Box, Avatar, Text, Heading, HStack, VStack, Flex, Link, Spinner,
+  Image, Icon,
+} from '@chakra-ui/react';
+import { FaGlobe, FaMapMarkerAlt } from 'react-icons/fa';
+import { useAioha } from '@aioha/react-ui';
+import { getProfile, getAccountPosts, getSimilarPosts } from '@/lib/hive/client-functions';
+import { getHiveAvatarUrl } from '@/lib/utils/avatarUtils';
+import UserActionButtons from '@/components/profile/UserActionButtons';
+
+interface PostSidebarProps {
+  author: string;
+  permlink: string;
+}
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function MiniPostCard({ title, author, permlink, image, date }: {
+  title: string; author: string; permlink: string; image?: string; date?: string;
+}) {
+  return (
+    <Link href={`/@${author}/${permlink}`} _hover={{ textDecoration: 'none' }}>
+      <Flex gap={2} align="flex-start" _hover={{ opacity: 0.8 }} transition="opacity 0.15s">
+        {image && (
+          <Image
+            src={image}
+            alt={title}
+            boxSize="52px"
+            objectFit="cover"
+            borderRadius="md"
+            flexShrink={0}
+            fallback={<Box boxSize="52px" borderRadius="md" bg="muted" flexShrink={0} />}
+          />
+        )}
+        <Box minW={0}>
+          <Text fontSize="sm" fontWeight="semibold" color="text" noOfLines={2} lineHeight="1.3">
+            {title}
+          </Text>
+          {date && (
+            <Text fontSize="xs" color="gray.500" mt={0.5}>{formatDate(date)}</Text>
+          )}
+          {author && (
+            <Text fontSize="xs" color="primary">@{author}</Text>
+          )}
+        </Box>
+      </Flex>
+    </Link>
+  );
+}
+
+function SidebarBlock({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <Box border="1px solid" borderColor="muted" borderRadius="lg" p={4}>
+      <Text fontSize="xs" fontWeight="bold" textTransform="uppercase" letterSpacing="wider" color="gray.500" mb={3}>
+        {title}
+      </Text>
+      {children}
+    </Box>
+  );
+}
+
+export default function PostSidebar({ author, permlink }: PostSidebarProps) {
+  const { user } = useAioha();
+  const [profile, setProfile] = useState<any>(null);
+  const [recentPosts, setRecentPosts] = useState<any[]>([]);
+  const [similarPosts, setSimilarPosts] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function fetchAll() {
+      setLoading(true);
+      const [profileData, accountPosts, similar] = await Promise.all([
+        getProfile(author, user || '').catch(() => null),
+        getAccountPosts(author, 8, user || '').catch(() => []),
+        getSimilarPosts(author, permlink, 3).catch(() => []),
+      ]);
+
+      setProfile(profileData);
+
+      const own = (accountPosts || [])
+        .filter((p: any) => p.author === author && p.permlink !== permlink)
+        .slice(0, 3);
+      setRecentPosts(own);
+
+      setSimilarPosts((similar || []).slice(0, 3));
+      setLoading(false);
+    }
+    fetchAll();
+  }, [author, permlink, user]);
+
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="center" py={8}>
+        <Spinner size="md" color="primary" />
+      </Box>
+    );
+  }
+
+  const meta = profile?.metadata?.profile || {};
+  const stats = profile?.stats || {};
+  const memberYear = profile?.created ? new Date(profile.created).getFullYear() : null;
+
+  return (
+    <VStack spacing={4} align="stretch">
+      {/* Block 1 — Author Info */}
+      <SidebarBlock title="About the author">
+        <Link href={`/@${author}`} _hover={{ textDecoration: 'none' }}>
+          <Flex align="center" gap={3} mb={3} _hover={{ opacity: 0.85 }} transition="opacity 0.15s">
+            <Avatar
+              src={getHiveAvatarUrl(author, 'large')}
+              name={author}
+              boxSize="52px"
+              flexShrink={0}
+            />
+            <Box minW={0}>
+              <Flex align="center" gap={1}>
+                <Heading as="h3" size="sm" color="primary" isTruncated>
+                  {meta.name || author}
+                </Heading>
+                {profile?.reputation != null && (
+                  <Box
+                    display="inline-flex"
+                    alignItems="center"
+                    justifyContent="center"
+                    minW="18px"
+                    h="18px"
+                    px={1}
+                    bg="gray.200"
+                    borderRadius="sm"
+                    fontSize="10px"
+                    fontWeight="bold"
+                    color="gray.700"
+                    flexShrink={0}
+                  >
+                    {Math.round(profile.reputation)}
+                  </Box>
+                )}
+              </Flex>
+              <Text fontSize="xs" color="gray.500">@{author}</Text>
+            </Box>
+          </Flex>
+        </Link>
+
+        {meta.about && (
+          <Text fontSize="sm" color="text" noOfLines={3} mb={3} lineHeight="1.5">
+            {meta.about}
+          </Text>
+        )}
+
+        <HStack spacing={4} mb={2} flexWrap="wrap">
+          <Box textAlign="center">
+            <Text fontSize="sm" fontWeight="bold" color="text">{stats.followers?.toLocaleString() ?? 0}</Text>
+            <Text fontSize="xs" color="gray.500">Followers</Text>
+          </Box>
+          <Box textAlign="center">
+            <Text fontSize="sm" fontWeight="bold" color="text">{stats.following?.toLocaleString() ?? 0}</Text>
+            <Text fontSize="xs" color="gray.500">Following</Text>
+          </Box>
+          {profile?.post_count != null && (
+            <Box textAlign="center">
+              <Text fontSize="sm" fontWeight="bold" color="text">{profile.post_count.toLocaleString()}</Text>
+              <Text fontSize="xs" color="gray.500">Posts</Text>
+            </Box>
+          )}
+        </HStack>
+
+        {(meta.location || meta.website || memberYear) && (
+          <VStack align="flex-start" spacing={1} mb={3}>
+            {meta.location && (
+              <Flex align="center" gap={1}>
+                <Icon as={FaMapMarkerAlt} w={3} h={3} color="gray.500" />
+                <Text fontSize="xs" color="gray.500">{meta.location}</Text>
+              </Flex>
+            )}
+            {meta.website && (
+              <Flex align="center" gap={1}>
+                <Icon as={FaGlobe} w={3} h={3} color="gray.500" />
+                <Text
+                  fontSize="xs"
+                  color="primary"
+                  cursor="pointer"
+                  onClick={() => window.open(meta.website, '_blank')}
+                  _hover={{ textDecoration: 'underline' }}
+                  isTruncated
+                  maxW="200px"
+                >
+                  {meta.website.replace(/^https?:\/\//, '')}
+                </Text>
+              </Flex>
+            )}
+            {memberYear && (
+              <Text fontSize="xs" color="gray.500">Member since {memberYear}</Text>
+            )}
+          </VStack>
+        )}
+
+        <UserActionButtons
+          targetUsername={author}
+          currentUsername={user || null}
+          showBlacklist={false}
+        />
+      </SidebarBlock>
+
+      {/* Block 2 — Recent Posts */}
+      {recentPosts.length > 0 && (
+        <SidebarBlock title="More from this author">
+          <VStack spacing={3} align="stretch">
+            {recentPosts.map((post) => {
+              let image: string | undefined;
+              try {
+                const jm = typeof post.json_metadata === 'string'
+                  ? JSON.parse(post.json_metadata)
+                  : post.json_metadata;
+                image = jm?.image?.[0];
+              } catch { /* no image */ }
+              return (
+                <MiniPostCard
+                  key={post.permlink}
+                  title={post.title}
+                  author={post.author}
+                  permlink={post.permlink}
+                  image={image}
+                  date={post.created}
+                />
+              );
+            })}
+          </VStack>
+        </SidebarBlock>
+      )}
+
+      {/* Block 3 — Similar Posts */}
+      {similarPosts.length > 0 && (
+        <SidebarBlock title="Similar posts">
+          <VStack spacing={3} align="stretch">
+            {similarPosts.map((post: any) => {
+              let image: string | undefined;
+              try {
+                const jm = typeof post.json_metadata === 'string'
+                  ? JSON.parse(post.json_metadata)
+                  : post.json_metadata;
+                image = jm?.image?.[0];
+              } catch { /* no image */ }
+              return (
+                <MiniPostCard
+                  key={`${post.author}-${post.permlink}`}
+                  title={post.title}
+                  author={post.author}
+                  permlink={post.permlink}
+                  image={image}
+                  date={post.created}
+                />
+              );
+            })}
+          </VStack>
+        </SidebarBlock>
+      )}
+    </VStack>
+  );
+}

--- a/components/profile/ProfilePage.tsx
+++ b/components/profile/ProfilePage.tsx
@@ -27,11 +27,6 @@ interface ProfilePageProps {
 export default function ProfilePage({ username }: ProfilePageProps) {
   const { user } = useAioha();
   const { hiveAccount, isLoading, error } = useHiveAccount(username);
-  const [profileMetadata, setProfileMetadata] = useState<{ profileImage: string; coverImage: string; website: string }>({
-    profileImage: '',
-    coverImage: '',
-    website: '',
-  });
   const [profileInfo, setProfileInfo] = useState<any>(null);
 
   // Posts tab state
@@ -103,37 +98,26 @@ export default function ProfilePage({ username }: ProfilePageProps) {
   }, [username]);
 
   useEffect(() => {
-    if (hiveAccount?.json_metadata) {
-      try {
-        const parsedMetadata = JSON.parse(hiveAccount.posting_json_metadata);
-        const profile = parsedMetadata?.profile || {};
-        setProfileMetadata({
-          profileImage: profile.profile_image || '',
-          coverImage: profile.cover_image || '',
-          website: profile.website || '',
-        });
-      } catch (err) {
-        console.error('Failed to parse profile metadata', err);
-      }
-    }
-  }, [hiveAccount]);
-
-  useEffect(() => {
     const fetchProfileInfo = async () => {
       try {
-        const profileData = await getProfile(username);
+        const profileData = await getProfile(username, user || '');
         setProfileInfo(profileData);
       } catch (err) {
         console.error('Failed to fetch profile info', err);
       }
     };
     if (username) fetchProfileInfo();
-  }, [username]);
+  }, [username, user]);
 
+  const profileMeta = profileInfo?.metadata?.profile || {};
   const followers = profileInfo?.stats?.followers || 0;
   const following = profileInfo?.stats?.following || 0;
-  const location = profileInfo?.metadata?.profile?.location || '';
-  const about = profileInfo?.metadata?.profile?.about || '';
+  const postCount = profileInfo?.post_count ?? null;
+  const memberSince = profileInfo?.created ? new Date(profileInfo.created).getFullYear() : null;
+  const location = profileMeta.location || '';
+  const about = profileMeta.about || '';
+  const coverImage = profileMeta.cover_image || '';
+  const website = profileMeta.website || '';
 
   const handleSnapReply = () => {
     setTimeout(() => {
@@ -167,13 +151,18 @@ export default function ProfilePage({ username }: ProfilePageProps) {
       <Box position="relative" height="200px">
         <Container id="cover" maxW="container.lg" p={0} overflow="hidden" position="relative" height="100%">
           <Image
-            src={profileMetadata.coverImage}
+            src={coverImage}
             alt={`${hiveAccount?.name} cover`}
             width="100%"
             height="100%"
             objectFit="cover"
-            mb={4}
-            fallback={<div></div>}
+            fallback={
+              <Box
+                width="100%"
+                height="100%"
+                bgGradient="linear(to-br, blue.700, purple.600, teal.500)"
+              />
+            }
           />
         </Container>
       </Box>
@@ -193,7 +182,7 @@ export default function ProfilePage({ username }: ProfilePageProps) {
           <Box>
             <Flex alignItems="center">
               <Heading as="h2" size="lg" color="primary" mr={2}>
-                {profileInfo?.metadata?.profile?.name || username}
+                {profileMeta.name || username}
               </Heading>
               <Box display="flex" alignItems="center" justifyContent="center" width="15px" height="15px" bg="gray.200" fontWeight="bold" fontSize="xs">
                 {profileInfo?.reputation ? Math.round(profileInfo.reputation) : 0}
@@ -218,16 +207,18 @@ export default function ProfilePage({ username }: ProfilePageProps) {
               >
                 Followers: {followers}
               </Text>
-              {' | '}
-              Location: {location}
-              <br />
-              {about}
+              {postCount != null && (
+                <>{' | '}Posts: {postCount.toLocaleString()}</>
+              )}
+              {location && <>{' | '}Location: {location}</>}
+              {memberSince && <>{' | '}Member since {memberSince}</>}
+              {about && <><br />{about}</>}
             </Text>
 
-            {profileMetadata.website && (
+            {website && (
               <Flex alignItems="center">
-                <Icon as={FaGlobe} w={2} h={2} onClick={() => window.open(profileMetadata.website, '_blank')} style={{ cursor: 'pointer' }} />
-                <Text ml={2} fontSize="xs" color="primary">{profileMetadata.website}</Text>
+                <Icon as={FaGlobe} w={2} h={2} onClick={() => window.open(website, '_blank')} style={{ cursor: 'pointer' }} />
+                <Text ml={2} fontSize="xs" color="primary">{website}</Text>
               </Flex>
             )}
           </Box>

--- a/components/profile/UserActionButtons.tsx
+++ b/components/profile/UserActionButtons.tsx
@@ -7,9 +7,10 @@ import { useAioha } from '@aioha/react-ui';
 interface UserActionButtonsProps {
   targetUsername: string;
   currentUsername: string | null;
+  showBlacklist?: boolean;
 }
 
-export default function UserActionButtons({ targetUsername, currentUsername }: UserActionButtonsProps) {
+export default function UserActionButtons({ targetUsername, currentUsername, showBlacklist = true }: UserActionButtonsProps) {
   const { user } = useAioha();
   const toast = useToast();
   const [isFollowing, setIsFollowing] = useState(false);
@@ -213,16 +214,18 @@ export default function UserActionButtons({ targetUsername, currentUsername }: U
       >
         {isMuted ? 'Unmute' : 'Mute'}
       </Button>
-      <Button
-        size="sm"
-        colorScheme={isBlacklisted ? 'red' : 'gray'}
-        variant={isBlacklisted ? 'solid' : 'outline'}
-        onClick={handleBlacklist}
-        isDisabled={isProcessing}
-        isLoading={isProcessing}
-      >
-        {isBlacklisted ? 'Unblacklist' : 'Blacklist'}
-      </Button>
+      {showBlacklist && (
+        <Button
+          size="sm"
+          colorScheme={isBlacklisted ? 'red' : 'gray'}
+          variant={isBlacklisted ? 'solid' : 'outline'}
+          onClick={handleBlacklist}
+          isDisabled={isProcessing}
+          isLoading={isProcessing}
+        >
+          {isBlacklisted ? 'Unblacklist' : 'Blacklist'}
+        </Button>
+      )}
     </HStack>
   );
 }

--- a/lib/hive/client-functions.ts
+++ b/lib/hive/client-functions.ts
@@ -757,9 +757,28 @@ export async function convertVestToHive(amount: number) {
   return vestHive;
 }
 
-export async function getProfile(username: string) {
-  const profile = await HiveClient.call('bridge', 'get_profile', { account: username });
+export async function getProfile(username: string, observer?: string) {
+  const profile = await HiveClient.call('bridge', 'get_profile', { account: username, observer: observer || '' });
   return profile;
+}
+
+export async function getAccountPosts(account: string, limit: number, observer: string) {
+  return HiveClient.call('bridge', 'get_account_posts', {
+    sort: 'blog',
+    account,
+    start_author: '',
+    start_permlink: '',
+    limit,
+    observer,
+  });
+}
+
+export async function getSimilarPosts(author: string, permlink: string, limit = 3) {
+  const observer = process.env.NEXT_PUBLIC_HIVE_USER || '';
+  const url = `https://api.hive.blog/hivesense-api/posts/${author}/${permlink}/similar?truncate=20&result_limit=${limit}&full_posts=10&observer=${observer}`;
+  const res = await fetch(url);
+  if (!res.ok) return [];
+  return res.json();
 }
 
 export async function getCommunityInfo(username: string) {


### PR DESCRIPTION
## Summary

- **Blog post sidebar (desktop only)**: Adds a sticky 300px right column on `lg+` screens with three blocks:
  - **About the author** — avatar, display name, reputation, bio, followers/following/posts stats, location, website, member-since year, Follow + Mute buttons
  - **More from this author** — last 2–3 posts via `bridge.get_account_posts` (reblogs and the current post filtered out), with thumbnails
  - **Similar posts** — HiveSense API results with thumbnails, titles, and author handles
- **Profile page improvements**: removes the fragile `posting_json_metadata` parse and reads all profile data directly from `bridge.get_profile`. Adds post count and member-since year to the header. Replaces the blank cover image fallback with a blue→purple→teal gradient.
- **`UserActionButtons`**: adds a `showBlacklist?: boolean` prop (default `true`) so the sidebar can show only Follow + Mute.
- **`client-functions.ts`**: adds `getAccountPosts()`, `getSimilarPosts()`, and updates `getProfile()` to accept an optional `observer` parameter.

## Test plan

- [ ] Open a blog post at `/@author/permlink` on a desktop viewport — sidebar renders with all 3 blocks
- [ ] Resize to mobile — sidebar is hidden, post reads full-width
- [ ] Click Follow/Mute in the sidebar — toast fires and state updates correctly
- [ ] Visit `/@username` — cover image loads (or gradient fallback shows), post count and member since visible
- [ ] Check a post with no HiveSense results — Similar Posts block is hidden gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)