### PR TITLE
feat: notifications context, conversation parent link, profile snaps clickable

### DIFF
--- a/components/homepage/Conversation.tsx
+++ b/components/homepage/Conversation.tsx
@@ -2,9 +2,10 @@ import { Box, Text, HStack, Button, Avatar, Divider, VStack, Spinner } from '@ch
 import { Comment } from '@hiveio/dhive';
 import { useComments } from '@/hooks/useComments';
 import { useHiveUser } from '@/contexts/UserContext';
-import { ArrowBackIcon } from "@chakra-ui/icons";
+import { ArrowBackIcon, ArrowUpIcon } from "@chakra-ui/icons";
 import Snap from './Snap';
 import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
 interface ConversationProps {
     comment: Comment;
@@ -16,7 +17,9 @@ interface ConversationProps {
 
 const Conversation = ({ comment, setConversation, onOpen, setReply, refreshTrigger }: ConversationProps) => {
     const { hiveUser } = useHiveUser();
+    const router = useRouter();
     const { comments, isLoading, error, updateComments } = useComments(comment.author, comment.permlink, true, hiveUser?.name);
+    const isTopLevel = !comment.parent_author || comment.parent_author === 'peak.snaps';
 
     useEffect(() => {
         if (refreshTrigger && refreshTrigger > 0) updateComments();
@@ -47,6 +50,21 @@ const Conversation = ({ comment, setConversation, onOpen, setReply, refreshTrigg
                 <Button onClick={onBackClick} variant="ghost" leftIcon={<ArrowBackIcon />}></Button>
                 <Text fontSize="lg" fontWeight="bold">Conversation</Text>
             </HStack>
+            {!isTopLevel && (
+                <HStack
+                    mb={2}
+                    px={1}
+                    spacing={1}
+                    fontSize="sm"
+                    color="gray.500"
+                    cursor="pointer"
+                    _hover={{ color: 'primary' }}
+                    onClick={() => router.push(`/@${comment.parent_author}/${comment.parent_permlink}`)}
+                >
+                    <ArrowUpIcon boxSize={3} />
+                    <Text>Replying to @{comment.parent_author}</Text>
+                </HStack>
+            )}
             <Snap comment={comment} onOpen={onOpen} setReply={setReply} />
             <Divider my={4} />
             <HStack justify="space-between" mt={3} onClick={handleReplyModal}>

--- a/components/notifications/NotificationsComp.tsx
+++ b/components/notifications/NotificationsComp.tsx
@@ -38,6 +38,7 @@ import { useHiveNotifications } from '@/hooks/useHiveNotifications';
 import {
   formatNotificationTime,
   getNotificationActor,
+  getNotificationPostKey,
   getNotificationRoute,
   getNotificationTypeLabel,
   NOTIFICATION_CATEGORIES,
@@ -580,16 +581,25 @@ function SingleNotificationRow({
   nested?: boolean;
 }) {
   const actor = getNotificationActor(notification);
+  const postKey = getNotificationPostKey(notification);
+  const permlink = postKey ? postKey.split('/')[1] : null;
+  const readableTitle = permlink ? permlink.replace(/-/g, ' ') : null;
 
   return (
     <NotificationShell unread={unread} onClick={onClick} nested={nested}>
       <Avatar size="sm" src={actor ? getHiveAvatarUrl(actor, 'small') : undefined} name={actor || undefined} />
       <Box flex="1" minW={0}>
         <Text fontWeight="semibold">{notification.msg || getNotificationTypeLabel(notification.type)}</Text>
-        <HStack fontSize="sm" opacity={0.72} spacing={2}>
+        <HStack fontSize="sm" opacity={0.72} spacing={2} flexWrap="wrap">
           <Text>{getNotificationTypeLabel(notification.type)}</Text>
           <Text>·</Text>
           <Text>{formatNotificationTime(notification.date)}</Text>
+          {readableTitle && (
+            <>
+              <Text>·</Text>
+              <Text isTruncated maxW="160px" opacity={0.8} fontStyle="italic">{readableTitle}</Text>
+            </>
+          )}
         </HStack>
       </Box>
     </NotificationShell>

--- a/components/profile/ProfilePage.tsx
+++ b/components/profile/ProfilePage.tsx
@@ -255,7 +255,6 @@ export default function ProfilePage({ username }: ProfilePageProps) {
                   setConversation={setConversation}
                   onOpen={() => setIsReplyOpen(true)}
                   setReply={(c) => setReply(c as ExtendedComment)}
-                  post={true}
                   data={profileSnaps}
                 />
               )}


### PR DESCRIPTION
## Summary

Three UX gaps addressed in one PR:

### 1. Notifications — which post/snap triggered this?
Each notification row now shows the post permlink as a readable italic subtitle (e.g. `· quiet fixes loud progress`). Derived from the existing `getNotificationPostKey()` helper — suppresses automatically for `follow` and `transfer` notifications which have no post URL.

### 2. Conversation view — "Replying to @author" parent link
When viewing a snap/comment that is itself a reply (i.e. `parent_author` is not `peak.snaps`), a small `↑ Replying to @author` link appears above the snap. Clicking it navigates to `/@parent_author/parent_permlink`. Top-level snaps (direct replies to the peak.snaps container) show nothing.

### 3. Profile page — snaps are now clickable
Removed `post={true}` from the Snaps tab `SnapList`. The profile page already had full conversation state management (`conversation` state, `setConversation` callback, `<Conversation>` conditional rendering) — that single flag was the only thing suppressing clickability. Clicking a snap now opens the inline conversation view; the back button returns to the snap list.

## Test plan
- [ ] Notifications page: reply/vote/mention rows show a subtitle with the post name; follow rows show nothing extra
- [ ] Click a reply notification → navigate to post → open conversation on a reply snap → "Replying to @author" link visible → clicking navigates to parent
- [ ] Go to any user profile Snaps tab → click a snap → conversation view opens inline → back button returns to list
- [ ] Top-level snaps on the Snaps tab (parent is peak.snaps) → no "Replying to" banner in their conversation view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reply headers now include clickable navigation to parent comments, with visual indicators helping users easily follow nested conversations.

* **Improvements**
  * Notifications now display readable post identifiers alongside notification types and timestamps for enhanced context and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->