### PR TITLE
chore: bump @snapie/hangouts-react 0.7.1→0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@mantequilla-soft/3speak-player": "^0.3.2",
     "@snapie/composer": "workspace:*",
     "@snapie/hangouts-core": "^0.6.1",
-    "@snapie/hangouts-react": "^0.7.1",
+    "@snapie/hangouts-react": "^0.7.2",
     "@snapie/operations": "workspace:*",
     "@snapie/renderer": "workspace:*",
     "@supabase/supabase-js": "^2.45.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^0.6.1
         version: 0.6.1
       '@snapie/hangouts-react':
-        specifier: ^0.7.1
-        version: 0.7.1(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
+        specifier: ^0.7.2
+        version: 0.7.2(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
       '@snapie/operations':
         specifier: workspace:*
         version: link:packages/operations
@@ -1351,8 +1351,8 @@ packages:
   '@snapie/hangouts-core@0.6.1':
     resolution: {integrity: sha512-ucisCBuVLPQFALc4f4lwkmz2cUwUtSQvakpuEMFXk6ooUWdAyPOnf3WZURrWUiWUAhoIlV8BxMChKQrEHDM3wA==}
 
-  '@snapie/hangouts-react@0.7.1':
-    resolution: {integrity: sha512-5NIUT8yPKrXIT+k0onEM+LRlqJJk3VovNr1M6r1YcuN90Cqbp5LOoNBZCLHTVWnHXvVnAieR8cEw5lr3a2JEGg==}
+  '@snapie/hangouts-react@0.7.2':
+    resolution: {integrity: sha512-63U55SPX7KHKALeVpnSRhUf8sfu9GhUsgouB/Eh7Tz/KlEUqcjOnqIjj9Iu9l6oxz+AXCJLo3If6H6MzGm0ATw==}
     peerDependencies:
       '@livekit/components-react': ^2.0.0
       livekit-client: ^2.0.0
@@ -5679,7 +5679,7 @@ snapshots:
 
   '@snapie/hangouts-core@0.6.1': {}
 
-  '@snapie/hangouts-react@0.7.1(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
+  '@snapie/hangouts-react@0.7.2(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
     dependencies:
       '@livekit/components-react': 2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@snapie/hangouts-core': 0.5.1


### PR DESCRIPTION
## Summary

Bug fix patch for `@snapie/hangouts-react`.

| Package | Before | After |
|---------|--------|-------|
| `@snapie/hangouts-react` | `^0.7.1` | `^0.7.2` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)