### PR TITLE
chore: bump @snapie/hangouts-react 0.7.5→0.7.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@mantequilla-soft/3speak-player": "^0.3.2",
     "@snapie/composer": "workspace:*",
     "@snapie/hangouts-core": "^0.6.1",
-    "@snapie/hangouts-react": "^0.7.5",
+    "@snapie/hangouts-react": "^0.7.6",
     "@snapie/operations": "workspace:*",
     "@snapie/renderer": "workspace:*",
     "@supabase/supabase-js": "^2.45.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^0.6.1
         version: 0.6.1
       '@snapie/hangouts-react':
-        specifier: ^0.7.5
-        version: 0.7.5(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
+        specifier: ^0.7.6
+        version: 0.7.6(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
       '@snapie/operations':
         specifier: workspace:*
         version: link:packages/operations
@@ -1351,8 +1351,8 @@ packages:
   '@snapie/hangouts-core@0.6.1':
     resolution: {integrity: sha512-ucisCBuVLPQFALc4f4lwkmz2cUwUtSQvakpuEMFXk6ooUWdAyPOnf3WZURrWUiWUAhoIlV8BxMChKQrEHDM3wA==}
 
-  '@snapie/hangouts-react@0.7.5':
-    resolution: {integrity: sha512-Y2/gYFMroLEZWYcIbmpJZ1BmEJrdf0lzZY6nsw+3O5cRFJlttSvyrjrIRCbpTaS0cOsLGWnlnPE3tp0BjDwBNw==}
+  '@snapie/hangouts-react@0.7.6':
+    resolution: {integrity: sha512-jgRcYfkKc5rXVcycqqE5kZExoQokdwkZ2hZECJKKndeyg24B3QmTakS/PfVNzuFj62feYZNkeVyieaNpzWsL9w==}
     peerDependencies:
       '@livekit/components-react': ^2.0.0
       livekit-client: ^2.0.0
@@ -5679,7 +5679,7 @@ snapshots:
 
   '@snapie/hangouts-core@0.6.1': {}
 
-  '@snapie/hangouts-react@0.7.5(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
+  '@snapie/hangouts-react@0.7.6(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
     dependencies:
       '@livekit/components-react': 2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@snapie/hangouts-core': 0.5.1


### PR DESCRIPTION
## Summary

| Package | Before | After |
|---------|--------|-------|
| `@snapie/hangouts-react` | `^0.7.5` | `^0.7.6` |

Diagnostic/fix release — error message will surface the exact failure point in the chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)