### PR TITLE
chore: bump @snapie/hangouts-react 0.7.6→0.7.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@mantequilla-soft/3speak-player": "^0.3.2",
     "@snapie/composer": "workspace:*",
     "@snapie/hangouts-core": "^0.6.1",
-    "@snapie/hangouts-react": "^0.7.6",
+    "@snapie/hangouts-react": "^0.7.7",
     "@snapie/operations": "workspace:*",
     "@snapie/renderer": "workspace:*",
     "@supabase/supabase-js": "^2.45.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^0.6.1
         version: 0.6.1
       '@snapie/hangouts-react':
-        specifier: ^0.7.6
-        version: 0.7.6(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
+        specifier: ^0.7.7
+        version: 0.7.7(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
       '@snapie/operations':
         specifier: workspace:*
         version: link:packages/operations
@@ -1351,8 +1351,8 @@ packages:
   '@snapie/hangouts-core@0.6.1':
     resolution: {integrity: sha512-ucisCBuVLPQFALc4f4lwkmz2cUwUtSQvakpuEMFXk6ooUWdAyPOnf3WZURrWUiWUAhoIlV8BxMChKQrEHDM3wA==}
 
-  '@snapie/hangouts-react@0.7.6':
-    resolution: {integrity: sha512-jgRcYfkKc5rXVcycqqE5kZExoQokdwkZ2hZECJKKndeyg24B3QmTakS/PfVNzuFj62feYZNkeVyieaNpzWsL9w==}
+  '@snapie/hangouts-react@0.7.7':
+    resolution: {integrity: sha512-s4iZrpzPMtOXbUZaSbdDVzYw3oYSO42wIoxgMxDnnqTXaJsiqCkWh+jJEjdBG+5GptIFFEKgCKDCID+8yjEBcw==}
     peerDependencies:
       '@livekit/components-react': ^2.0.0
       livekit-client: ^2.0.0
@@ -5679,7 +5679,7 @@ snapshots:
 
   '@snapie/hangouts-core@0.6.1': {}
 
-  '@snapie/hangouts-react@0.7.6(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
+  '@snapie/hangouts-react@0.7.7(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
     dependencies:
       '@livekit/components-react': 2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@snapie/hangouts-core': 0.5.1


### PR DESCRIPTION
## Summary

| Package | Before | After |
|---------|--------|-------|
| `@snapie/hangouts-react` | `^0.7.6` | `^0.7.7` |

**Root cause fixed:** Next.js had bundled `HangoutsApiClient` from `@snapie/hangouts-core@0.6.0` at the last build, so `getBoostConfig` simply didn't exist on the runtime class even after `npm install` updated `node_modules`.

**Fix:** `SendBoostDialog` now calls `fetch(apiBaseUrl + '/boosts/config')` directly — no class method, no version dependency, works with any bundled sdk-core. `apiBaseUrl` is now part of `HangoutsContext` so it flows down cleanly.

The Send button should enable as soon as the dialog opens after this deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)