### PR TITLE
chore: bump @snapie/hangouts-react 0.8.7→0.8.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@mantequilla-soft/3speak-player": "^0.3.2",
     "@snapie/composer": "workspace:*",
     "@snapie/hangouts-core": "^0.6.3",
-    "@snapie/hangouts-react": "^0.8.7",
+    "@snapie/hangouts-react": "^0.8.8",
     "@snapie/operations": "workspace:*",
     "@snapie/renderer": "workspace:*",
     "@supabase/supabase-js": "^2.45.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^0.6.3
         version: 0.6.3
       '@snapie/hangouts-react':
-        specifier: ^0.8.7
-        version: 0.8.7(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
+        specifier: ^0.8.8
+        version: 0.8.8(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)
       '@snapie/operations':
         specifier: workspace:*
         version: link:packages/operations
@@ -1351,8 +1351,8 @@ packages:
   '@snapie/hangouts-core@0.6.3':
     resolution: {integrity: sha512-YIzB/NnRrTKGJgJIYOyjck0vCDKTGSOEz6LzEppJobh22Fww//RCJmuN0KBWf3zDBWqnnxfIhuXDl76VOJyX+Q==}
 
-  '@snapie/hangouts-react@0.8.7':
-    resolution: {integrity: sha512-SPJyk9hQDADlimaMSslXi5JLhBtqYqMNgyVPLyjATi9N1RSMIyx2nejG/wDPjoSXwEgezyHhTEN8F25QpRfmzQ==}
+  '@snapie/hangouts-react@0.8.8':
+    resolution: {integrity: sha512-cPazePFIM1Y6sjCMafaJ1tZIFLgJd1q7sTkOaQhLEQ71x4SuMNTOerggyKdrBP8KaulOA2NeoOvI5TGB0i/ZEQ==}
     peerDependencies:
       '@livekit/components-react': ^2.0.0
       livekit-client: ^2.0.0
@@ -5679,7 +5679,7 @@ snapshots:
 
   '@snapie/hangouts-core@0.6.3': {}
 
-  '@snapie/hangouts-react@0.8.7(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
+  '@snapie/hangouts-react@0.8.8(@livekit/components-react@2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1))(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react@18.3.1)':
     dependencies:
       '@livekit/components-react': 2.9.20(livekit-client@2.18.0(@types/dom-mediacapture-record@1.0.22))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tslib@2.8.1)
       '@snapie/hangouts-core': 0.5.1


### PR DESCRIPTION
## Summary
- bump `@snapie/hangouts-react` from `0.8.7` to `0.8.8` in app dependencies
- update `pnpm-lock.yaml` resolution/integrity entries for `0.8.8`

## Test plan
- [x] Run `npm run build`
- [x] Confirm Next.js production build completes successfully
- [ ] Redeploy on VPS with `sudo ./deploy.sh`

Made with [Cursor](https://cursor.com)