### PR TITLE
feat: improve reply context in notifications and post view

### DIFF
--- a/components/blog/PostDetails.tsx
+++ b/components/blog/PostDetails.tsx
@@ -49,6 +49,7 @@ export default function PostDetails({ post, isEmbedMode = false }: PostDetailsPr
     const { user } = useAioha();
     const router = useRouter();
     const canEdit = !isEmbedMode && user === author;
+    const hasParent = Boolean(post.depth > 0 && post.parent_author && post.parent_permlink);
 
     const bodySegments = useMemo((): BodySegment[] => {
         let html = markdownRenderer(body, { defaultEmojiOwner: author });
@@ -205,6 +206,20 @@ export default function PostDetails({ post, isEmbedMode = false }: PostDetailsPr
                     </Tooltip>
                 )}
             </Flex>
+            {!isEmbedMode && hasParent && (
+                <Flex mb={3} gap={3} align="center" wrap="wrap">
+                    <Text fontSize="sm" color="secondary">Reply context:</Text>
+                    <Link
+                        as={NextLink}
+                        href={`/@${post.parent_author}/${post.parent_permlink}`}
+                        fontSize="sm"
+                        color="primary"
+                        fontWeight="semibold"
+                    >
+                        View parent
+                    </Link>
+                </Flex>
+            )}
             <Box mt={4} data-blog-post-body sx={bodySx}>
                 {bodySegments.map((seg, i) => {
                     if (seg.type === 'audio') {

--- a/components/notifications/NotificationsComp.tsx
+++ b/components/notifications/NotificationsComp.tsx
@@ -47,6 +47,7 @@ import {
 } from '@/lib/utils/notificationHelpers';
 import { groupNotifications, NotificationGroup } from '@/lib/utils/notificationGrouping';
 import { getHiveAvatarUrl } from '@/lib/utils/avatarUtils';
+import { useNotificationContext } from '@/hooks/useNotificationContext';
 
 interface NotificationCompProps {
   username: string
@@ -229,6 +230,7 @@ export default function NotificationsComp({ username }: NotificationCompProps) {
 
   const grouped = useMemo(() => groupNotifications(filtered), [filtered]);
   const bucketed = useMemo(() => bucketize(grouped), [grouped]);
+  const notificationContext = useNotificationContext(filtered);
 
   const summary = useMemo(() => {
     const now = new Date();
@@ -388,6 +390,7 @@ export default function NotificationsComp({ username }: NotificationCompProps) {
                       group={group}
                       isUnread={isUnread}
                       onClick={handleNotificationClick}
+                      contextById={notificationContext}
                     />
                   ))}
                 </Stack>
@@ -500,10 +503,12 @@ function NotificationRow({
   group,
   isUnread,
   onClick,
+  contextById,
 }: {
   group: NotificationGroup;
   isUnread: (notification: Notifications) => boolean;
   onClick: (notification: Notifications) => void;
+  contextById: Record<string, { label: string; previewText: string; parentRoute: string } | undefined>;
 }) {
   const [expanded, setExpanded] = useState(false);
 
@@ -513,6 +518,7 @@ function NotificationRow({
         notification={group.notification}
         unread={isUnread(group.notification)}
         onClick={() => onClick(group.notification)}
+        contextPreview={contextById[group.notification.id]}
       />
     );
   }
@@ -561,6 +567,7 @@ function NotificationRow({
               unread={isUnread(notification)}
               onClick={() => onClick(notification)}
               nested
+              contextPreview={contextById[notification.id]}
             />
           ))}
         </Stack>
@@ -574,11 +581,13 @@ function SingleNotificationRow({
   unread,
   onClick,
   nested = false,
+  contextPreview,
 }: {
   notification: Notifications;
   unread: boolean;
   onClick: () => void;
   nested?: boolean;
+  contextPreview?: { label: string; previewText: string; parentRoute: string };
 }) {
   const actor = getNotificationActor(notification);
   const postKey = getNotificationPostKey(notification);
@@ -601,6 +610,21 @@ function SingleNotificationRow({
             </>
           )}
         </HStack>
+        {contextPreview && (
+          <Text mt={1} fontSize="sm" opacity={0.86} noOfLines={2}>
+            <Text as="span" fontWeight="semibold">{contextPreview.label}: </Text>
+            <Text
+              as="a"
+              href={contextPreview.parentRoute}
+              onClick={(event) => event.stopPropagation()}
+              color="primary"
+              textDecoration="underline"
+              _hover={{ opacity: 0.9 }}
+            >
+              {`"${contextPreview.previewText}"`}
+            </Text>
+          </Text>
+        )}
       </Box>
     </NotificationShell>
   );

--- a/hooks/useNotificationContext.ts
+++ b/hooks/useNotificationContext.ts
@@ -1,0 +1,147 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Discussion, Notifications } from '@hiveio/dhive';
+import HiveClient from '@/lib/hive/hiveclient';
+import { getNotificationPostKey, truncatePreviewWords } from '@/lib/utils/notificationHelpers';
+
+interface NotificationContextPreview {
+  label: string;
+  previewText: string;
+  parentRoute: string;
+}
+
+type NotificationContextMap = Record<string, NotificationContextPreview | undefined>;
+
+const REPLY_TYPES = new Set(['reply', 'reply_comment']);
+const CONCURRENCY_LIMIT = 5;
+
+const contentCache = new Map<string, Promise<Discussion | null>>();
+const previewCache = new Map<string, NotificationContextPreview | null>();
+
+function makeContentKey(author: string, permlink: string): string {
+  return `${author.toLowerCase()}/${permlink}`;
+}
+
+async function fetchContent(author: string, permlink: string): Promise<Discussion | null> {
+  const key = makeContentKey(author, permlink);
+  const cached = contentCache.get(key);
+  if (cached) return cached;
+
+  const request = HiveClient.database
+    .call('get_content', [author, permlink])
+    .then((result) => {
+      if (!result || !(result as Discussion).author || !(result as Discussion).permlink) return null;
+      return result as Discussion;
+    })
+    .catch(() => null);
+
+  contentCache.set(key, request);
+  return request;
+}
+
+function toRoute(author: string, permlink: string): string {
+  return `/@${author}/${permlink}`;
+}
+
+async function resolveParentPreview(replyAuthor: string, replyPermlink: string): Promise<NotificationContextPreview | null> {
+  const cacheKey = makeContentKey(replyAuthor, replyPermlink);
+  if (previewCache.has(cacheKey)) return previewCache.get(cacheKey) ?? null;
+
+  const reply = await fetchContent(replyAuthor, replyPermlink);
+  if (!reply?.parent_author || !reply?.parent_permlink) {
+    previewCache.set(cacheKey, null);
+    return null;
+  }
+
+  const parent = await fetchContent(reply.parent_author, reply.parent_permlink);
+  if (!parent) {
+    previewCache.set(cacheKey, null);
+    return null;
+  }
+
+  const parentTitle = (parent.title || '').trim();
+  const isParentPost = Number(parent.depth || 0) === 0;
+  const previewText = isParentPost && parentTitle
+    ? parentTitle
+    : truncatePreviewWords(parent.body || '', 12, 16);
+
+  if (!previewText) {
+    previewCache.set(cacheKey, null);
+    return null;
+  }
+
+  const preview: NotificationContextPreview = {
+    label: isParentPost ? 'Replied to your post' : 'Replied to your comment',
+    previewText,
+    parentRoute: toRoute(parent.author, parent.permlink),
+  };
+
+  previewCache.set(cacheKey, preview);
+  return preview;
+}
+
+async function runWithConcurrency<T>(tasks: Array<() => Promise<T>>, limit: number): Promise<T[]> {
+  if (tasks.length === 0) return [];
+
+  const results: T[] = new Array(tasks.length);
+  let index = 0;
+
+  const workers = Array.from({ length: Math.min(limit, tasks.length) }, async () => {
+    while (index < tasks.length) {
+      const current = index;
+      index += 1;
+      results[current] = await tasks[current]();
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+}
+
+export function useNotificationContext(notifications: Notifications[]): NotificationContextMap {
+  const [contextMap, setContextMap] = useState<NotificationContextMap>({});
+
+  const replyItems = useMemo(() => notifications.filter((n) => REPLY_TYPES.has(n.type)), [notifications]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function resolveAll() {
+      if (replyItems.length === 0) {
+        if (!cancelled) setContextMap({});
+        return;
+      }
+
+      const tasks = replyItems.map((notification) => async () => {
+        const key = getNotificationPostKey(notification);
+        if (!key) return { id: notification.id, preview: undefined };
+
+        const [author, permlink] = key.split('/');
+        if (!author || !permlink) return { id: notification.id, preview: undefined };
+
+        const preview = await resolveParentPreview(author, permlink);
+        return { id: notification.id, preview: preview ?? undefined };
+      });
+
+      const resolved = await runWithConcurrency(tasks, CONCURRENCY_LIMIT);
+      if (cancelled) return;
+
+      setContextMap((prev) => {
+        const next: NotificationContextMap = { ...prev };
+        for (const item of resolved) {
+          next[item.id] = item.preview;
+        }
+        return next;
+      });
+    }
+
+    resolveAll();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [replyItems]);
+
+  return contextMap;
+}

--- a/lib/utils/notificationHelpers.ts
+++ b/lib/utils/notificationHelpers.ts
@@ -125,3 +125,35 @@ export function parseHiveDate(dateString?: string): Date {
   if (!dateString) return new Date(0);
   return new Date(dateString + (dateString.endsWith('Z') ? '' : 'Z'));
 }
+
+export function normalizeNotificationPreviewText(text?: string): string {
+  if (!text) return '';
+
+  return text
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/!\[[^\]]*]\(([^)]+)\)/g, ' ')
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1')
+    .replace(/`{1,3}[^`]*`{1,3}/g, ' ')
+    .replace(/[_*~>#-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function truncatePreviewWords(text: string, minWords = 12, maxWords = 16): string {
+  const cleaned = normalizeNotificationPreviewText(text);
+  if (!cleaned) return '';
+
+  const words = cleaned.split(/\s+/);
+  if (words.length <= maxWords) return cleaned;
+
+  let cut = maxWords;
+  for (let i = minWords; i <= maxWords; i += 1) {
+    const word = words[i - 1];
+    if (word && /[.!?]$/.test(word)) {
+      cut = i;
+      break;
+    }
+  }
+
+  return `${words.slice(0, cut).join(' ')}…`;
+}


### PR DESCRIPTION
## Summary
- add reply-context previews to notification rows for `reply` and `reply_comment` events, including clickable parent links
- resolve parent context using a new `useNotificationContext` hook with deduped fetches, in-memory caching, and concurrency limits
- add text normalization + 12-16 word truncation helpers for readable preview snippets
- add a `View parent` context link in `PostDetails` when opening a reply directly

## Test plan
- [x] Run `npm run build`
- [x] Confirm app compiles with notification and post-context changes together
- [ ] Manually verify on `/@<user>/notifications` that reply notifications show parent preview text and clickable parent navigation
- [ ] Manually verify on direct reply URLs that `PostDetails` shows `Reply context: View parent`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Posts now display reply context with links to parent posts when applicable.
  * Notifications include contextual previews showing parent discussion information.
  * Enhanced preview text formatting with intelligent truncation for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->