### PR TITLE
feat: add HiveSense-powered blog search

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,17 +1,23 @@
 'use client';
-import { Box } from '@chakra-ui/react';
+import { Box, Text } from '@chakra-ui/react';
 import { useState, useRef, useEffect } from 'react';
 import { Discussion } from '@hiveio/dhive';
-import { findPosts } from '@/lib/hive/client-functions';
+import { findPosts, searchPosts } from '@/lib/hive/client-functions';
 import { mutedAccountsManager } from '@/lib/hive/muted-accounts';
 import { useHiveUser } from '@/contexts/UserContext';
 import TopBar from '@/components/blog/TopBar';
 import PostInfiniteScroll from '@/components/blog/PostInfiniteScroll';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 export default function Blog() {
     const { hiveUser } = useHiveUser();
+    const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
     const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
-    const [query, setQuery] = useState("created");
+    const [query, setQuery] = useState('created');
+    const [searchTerm, setSearchTerm] = useState(searchParams.get('q') || '');
+    const [activeSearchTerm, setActiveSearchTerm] = useState(searchParams.get('q') || '');
     const [allPosts, setAllPosts] = useState<Discussion[]>([]);
     const [hasMore, setHasMore] = useState(true);
     const [mutedLoaded, setMutedLoaded] = useState(false);
@@ -27,10 +33,57 @@ export default function Blog() {
         start_permlink: '',
     });
 
+    useEffect(() => {
+        const initial = searchParams.get('q') || '';
+        setSearchTerm(initial);
+        setActiveSearchTerm(initial);
+    }, [searchParams]);
+
     async function fetchPosts() {
         if (isFetching.current) return;
         isFetching.current = true;
         try {
+            if (activeSearchTerm) {
+                const results = await searchPosts(activeSearchTerm, {
+                    limit: 20,
+                    truncate: 320,
+                    fullPosts: 10,
+                    observer: hiveUser?.name || '',
+                });
+
+                const seenKeys = new Set<string>();
+                const topLevelResults = results.filter((post: Discussion) => {
+                    const title = typeof post.title === 'string' ? post.title.trim() : '';
+                    const body = typeof post.body === 'string' ? post.body.trim() : '';
+                    const isTopLevel = !post.parent_author;
+                    const isMuted = mutedSetRef.current.has(post.author.toLowerCase());
+                    const author = post.author || '';
+                    const permlink = post.permlink || '';
+                    const dedupeKey = `${author}/${permlink}`;
+                    const hasRenderableContent = Boolean(title && body);
+                    const hasGarbageNaN = /na+a+n/i.test(title) || /na+a+n/i.test(body);
+                    const isDuplicate = seenKeys.has(dedupeKey);
+                    if (!isDuplicate && author && permlink) seenKeys.add(dedupeKey);
+                    return (
+                        isTopLevel &&
+                        !isMuted &&
+                        !isDuplicate &&
+                        Boolean(author && permlink) &&
+                        hasRenderableContent &&
+                        !hasGarbageNaN
+                    );
+                }).sort((a: Discussion, b: Discussion) => {
+                    const aTime = a.created ? new Date(a.created).getTime() : 0;
+                    const bTime = b.created ? new Date(b.created).getTime() : 0;
+                    return bTime - aTime;
+                });
+
+                setAllPosts(topLevelResults);
+                setHasMore(false);
+                isFetching.current = false;
+                return;
+            }
+
             const posts = await findPosts(query, params.current);
 
             if (posts.length === 0) {
@@ -67,6 +120,15 @@ export default function Blog() {
         }
     }
 
+    useEffect(() => {
+        const next = new URLSearchParams(searchParams.toString());
+        if (activeSearchTerm) next.set('q', activeSearchTerm);
+        else next.delete('q');
+
+        const queryString = next.toString();
+        router.replace(queryString ? `${pathname}?${queryString}` : pathname);
+    }, [activeSearchTerm, pathname, router, searchParams]);
+
     // Load muted accounts on mount and when user changes (login/logout)
     useEffect(() => {
         setMutedLoaded(false);
@@ -82,7 +144,7 @@ export default function Blog() {
         if (!mutedLoaded) return; // Wait for muted accounts to load
         
         setAllPosts([]);
-        setHasMore(true);
+        setHasMore(!activeSearchTerm);
         params.current = {
             tag: tag,
             limit: 20,
@@ -91,7 +153,16 @@ export default function Blog() {
         };
         fetchPosts();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [query, mutedLoaded, tag]); // fetchPosts excluded - callback identity changes each render
+    }, [query, mutedLoaded, tag, activeSearchTerm, hiveUser?.name]); // fetchPosts excluded - callback identity changes each render
+
+    const submitSearch = () => {
+        setActiveSearchTerm(searchTerm.trim());
+    };
+
+    const clearSearch = () => {
+        setSearchTerm('');
+        setActiveSearchTerm('');
+    };
 
     return (
         <Box
@@ -107,8 +178,27 @@ export default function Blog() {
                 scrollbarWidth: 'none',
             }}
         >
-            <TopBar viewMode={viewMode} setViewMode={setViewMode} setQuery={setQuery} />
-            <PostInfiniteScroll allPosts={allPosts} fetchPosts={fetchPosts} viewMode={viewMode} hasMore={hasMore} />
+            <TopBar
+                viewMode={viewMode}
+                setViewMode={setViewMode}
+                setQuery={setQuery}
+                searchTerm={searchTerm}
+                setSearchTerm={setSearchTerm}
+                onSearchSubmit={submitSearch}
+                onSearchClear={clearSearch}
+            />
+            {activeSearchTerm && (
+                <Text fontSize="sm" color="text" opacity={0.75} mb={3}>
+                    {`Search results for "${activeSearchTerm}" (${allPosts.length})`}
+                </Text>
+            )}
+            <PostInfiniteScroll
+                allPosts={allPosts}
+                fetchPosts={fetchPosts}
+                viewMode={viewMode}
+                hasMore={hasMore}
+                searchMode={Boolean(activeSearchTerm)}
+            />
         </Box>
     );
 }

--- a/components/blog/PostCard.tsx
+++ b/components/blog/PostCard.tsx
@@ -13,9 +13,10 @@ import InteractionBar from '@/components/shared/InteractionBar';
 
 interface PostCardProps {
     post: Discussion;
+    compact?: boolean;
 }
 
-export default function PostCard({ post }: PostCardProps) {
+export default function PostCard({ post, compact = false }: PostCardProps) {
     const { title, author, body, json_metadata, created } = post;
     const postDate = getPostDate(created);
     const metadata = typeof json_metadata === 'object' && json_metadata !== null
@@ -23,6 +24,13 @@ export default function PostCard({ post }: PostCardProps) {
         : (() => { try { return JSON.parse(json_metadata || '{}'); } catch { return {}; } })();
     const [imageUrls, setImageUrls] = useState<string[]>([]);
     const router = useRouter();
+    const safeBody = typeof body === 'string' ? body : '';
+    const snippet = safeBody
+        .replace(/<[^>]*>/g, ' ')
+        .replace(/!\[[^\]]*]\(([^)]+)\)/g, ' ')
+        .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1')
+        .replace(/\s+/g, ' ')
+        .trim();
 
     // **State to control how many images to show initially**
     const [visibleImages, setVisibleImages] = useState<number>(3); // Start with 3 images
@@ -37,13 +45,15 @@ export default function PostCard({ post }: PostCardProps) {
                 : [];
             if (metaImages.length > 0) setImageUrls(metaImages);
         }
-    }, [body]);
+    }, [body, metadata]);
 
-    function extractImagesFromBody(body: string): string[] {
+    function extractImagesFromBody(rawBody: unknown): string[] {
+        if (typeof rawBody !== 'string' || !rawBody) return [];
+
         const markdownImageRegex = /!\[.*?\]\((.*?)\)/g;
         const htmlImageRegex = /<img\s+[^>]*src="([^"]*)"[^>]*>/g;
-        const markdownMatches = Array.from(body.matchAll(markdownImageRegex)) as RegExpExecArray[];
-        const htmlMatches = Array.from(body.matchAll(htmlImageRegex)) as RegExpExecArray[];
+        const markdownMatches = Array.from(rawBody.matchAll(markdownImageRegex)) as RegExpExecArray[];
+        const htmlMatches = Array.from(rawBody.matchAll(htmlImageRegex)) as RegExpExecArray[];
         const markdownImages = markdownMatches.map(match => match[1]);
         const htmlImages = htmlMatches.map(match => match[1]);
         return [...markdownImages, ...htmlImages];
@@ -93,17 +103,29 @@ export default function PostCard({ post }: PostCardProps) {
 
             {/* Content Section */}
             <Box display="flex" flexDirection="column" flexGrow={1} cursor="pointer">
-            <Text 
-    fontWeight="bold" 
-    fontSize="lg" 
-    textAlign="left" 
-    onClick={viewPost} 
-    mb={2}
-    isTruncated
->
-    {title}
-</Text>
-            {imageUrls.length > 0 && (
+                <Text
+                    fontWeight="bold"
+                    fontSize="lg"
+                    textAlign="left"
+                    onClick={viewPost}
+                    mb={2}
+                    noOfLines={compact ? 2 : 1}
+                >
+                    {title || 'Untitled post'}
+                </Text>
+                {compact && snippet && (
+                    <Text
+                        fontSize="sm"
+                        color="text"
+                        opacity={0.82}
+                        noOfLines={3}
+                        mb={3}
+                        onClick={viewPost}
+                    >
+                        {snippet}
+                    </Text>
+                )}
+            {imageUrls.length > 0 && !compact && (
                 <Box flex="1" display="flex" alignItems="flex-end" justifyContent="center">
                     <Swiper
                         spaceBetween={10}
@@ -134,7 +156,7 @@ export default function PostCard({ post }: PostCardProps) {
         </Box>
 
             {/* Interaction Bar */}
-            <Box mt="auto">
+            <Box mt="auto" opacity={compact ? 0.92 : 1}>
                 <InteractionBar post={post} showShare={false} />
             </Box>
         </Box>

--- a/components/blog/PostGrid.tsx
+++ b/components/blog/PostGrid.tsx
@@ -10,9 +10,10 @@ import { Discussion } from '@hiveio/dhive';
 interface PostGridProps {
     posts: Discussion[];
     columns: 1 | 2 | 3 | 4;
+    searchMode?: boolean;
 }
 
-export default function PostGrid({ posts, columns }: PostGridProps) {
+export default function PostGrid({ posts, columns, searchMode = false }: PostGridProps) {
 
     return (
         <SimpleGrid
@@ -20,7 +21,7 @@ export default function PostGrid({ posts, columns }: PostGridProps) {
             spacing={4}
         >
             {posts.map((post) => (
-                <PostCard key={post.permlink} post={post} />
+                <PostCard key={`${post.author}/${post.permlink}`} post={post} compact={searchMode} />
             ))}
         </SimpleGrid>
     );

--- a/components/blog/PostInfiniteScroll.tsx
+++ b/components/blog/PostInfiniteScroll.tsx
@@ -9,9 +9,16 @@ interface PostsInfiniteScrollProps {
     fetchPosts: () => Promise<void>;
     viewMode: 'grid' | 'list';
     hasMore?: boolean;
+    searchMode?: boolean;
 }
 
-export default function PostsInfiniteScroll({ allPosts, fetchPosts, viewMode, hasMore = true }: PostsInfiniteScrollProps) {
+export default function PostsInfiniteScroll({
+    allPosts,
+    fetchPosts,
+    viewMode,
+    hasMore = true,
+    searchMode = false,
+}: PostsInfiniteScrollProps) {
 
     return (
         <InfiniteScroll
@@ -25,7 +32,13 @@ export default function PostsInfiniteScroll({ allPosts, fetchPosts, viewMode, ha
                 )}
             scrollableTarget="scrollableDiv"
         >
-            {allPosts && (<PostGrid posts={allPosts ?? []} columns={viewMode === 'grid' ? 3 : 1} />)}
+            {allPosts && (
+                <PostGrid
+                    posts={allPosts ?? []}
+                    columns={viewMode === 'grid' ? 3 : 1}
+                    searchMode={searchMode}
+                />
+            )}
         </InfiniteScroll>
     );
 }

--- a/components/blog/TopBar.tsx
+++ b/components/blog/TopBar.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Flex, IconButton, Menu, MenuButton, MenuList, MenuItem, Button } from '@chakra-ui/react';
+import { Flex, IconButton, Menu, MenuButton, MenuList, MenuItem, Button, Input, InputGroup, InputRightElement, CloseButton } from '@chakra-ui/react';
 import { FaTh, FaBars, FaPen, FaSort } from 'react-icons/fa'; 
 import { useRouter } from 'next/navigation';
 
@@ -7,19 +7,56 @@ interface TopBarProps {
     viewMode: 'grid' | 'list';
     setViewMode: (mode: 'grid' | 'list') => void;
     setQuery: (query: string) => void;
+    searchTerm: string;
+    setSearchTerm: (value: string) => void;
+    onSearchSubmit: () => void;
+    onSearchClear: () => void;
 }
 
-export default function TopBar({ viewMode, setViewMode, setQuery }: TopBarProps) {
+export default function TopBar({
+    viewMode,
+    setViewMode,
+    setQuery,
+    searchTerm,
+    setSearchTerm,
+    onSearchSubmit,
+    onSearchClear,
+}: TopBarProps) {
     const router = useRouter(); 
 
     return (
-        <Flex justifyContent="space-between" mb={4}>
-            <IconButton
-                aria-label="Compose"
-                icon={<FaPen />}  
-                onClick={() => router.push('/compose')}  
-                variant="outline"  
-            />
+        <Flex justifyContent="space-between" mb={4} gap={4} align="center" flexWrap="wrap">
+            <Flex gap={3} align="center" flex="1" minW={{ base: '100%', md: '360px' }}>
+                <IconButton
+                    aria-label="Compose"
+                    icon={<FaPen />}
+                    onClick={() => router.push('/compose')}
+                    variant="outline"
+                />
+                <InputGroup maxW={{ base: 'full', md: '480px' }}>
+                    <Input
+                        placeholder="Search posts, titles, authors..."
+                        value={searchTerm}
+                        onChange={(event) => setSearchTerm(event.target.value)}
+                        onKeyDown={(event) => {
+                            if (event.key === 'Enter') onSearchSubmit();
+                        }}
+                        bg="muted"
+                    />
+                    {searchTerm && (
+                        <InputRightElement>
+                            <CloseButton
+                                size="sm"
+                                onClick={onSearchClear}
+                                aria-label="Clear search"
+                            />
+                        </InputRightElement>
+                    )}
+                </InputGroup>
+                <Button onClick={onSearchSubmit} size="sm" colorScheme="blue">
+                    Go
+                </Button>
+            </Flex>
             <Flex justifyContent="flex-end">
                 <IconButton
                     aria-label="Grid View"

--- a/lib/hive/client-functions.ts
+++ b/lib/hive/client-functions.ts
@@ -781,6 +781,38 @@ export async function getSimilarPosts(author: string, permlink: string, limit = 
   return res.json();
 }
 
+interface SearchPostsOptions {
+  limit?: number;
+  truncate?: number;
+  fullPosts?: number;
+  observer?: string;
+}
+
+export async function searchPosts(query: string, options: SearchPostsOptions = {}): Promise<Discussion[]> {
+  const trimmedQuery = query.trim();
+  if (!trimmedQuery) return [];
+
+  const {
+    limit = 20,
+    truncate = 0,
+    fullPosts = 10,
+    observer = process.env.NEXT_PUBLIC_HIVE_USER || '',
+  } = options;
+
+  const url = new URL('https://api.hive.blog/hivesense-api/posts/search');
+  url.searchParams.set('q', trimmedQuery);
+  url.searchParams.set('truncate', String(truncate));
+  url.searchParams.set('result_limit', String(limit));
+  url.searchParams.set('full_posts', String(fullPosts));
+  url.searchParams.set('observer', observer);
+
+  const res = await fetch(url.toString());
+  if (!res.ok) return [];
+
+  const data = await res.json();
+  return Array.isArray(data) ? (data as Discussion[]) : [];
+}
+
 export async function getCommunityInfo(username: string) {
   const profile = await HiveClient.call('bridge', 'get_community', { name: username });
   return profile;


### PR DESCRIPTION
## Summary
- add blog search in the top bar using HiveSense `/hivesense-api/posts/search` with explicit submit (Enter/Go) and URL query sync
- improve result quality with top-level-only filtering, dedupe by `author/permlink`, malformed/garbage content filtering, and newest-first sort
- render search results in a compact post-card mode (title + snippet, no carousel) and pass search mode through infinite scroll/grid

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] manually verified branch compiles cleanly after search updates

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a search feature to the blog with input field, submit, and clear buttons.
  * Search results display in a compact format with content snippets.
  * Search queries appear in the page URL for easy sharing and bookmarking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->