### PR TITLE
fix: improve navigation links and deploy PM2 user handling

### DIFF
--- a/components/blog/PostCard.tsx
+++ b/components/blog/PostCard.tsx
@@ -7,7 +7,6 @@ import 'swiper/css';
 import 'swiper/css/navigation';
 import 'swiper/css/pagination';
 import { getPostDate } from '@/lib/utils/GetPostDate';
-import { useRouter } from 'next/navigation';
 import NextLink from 'next/link';
 import InteractionBar from '@/components/shared/InteractionBar';
 
@@ -23,8 +22,8 @@ export default function PostCard({ post, compact = false }: PostCardProps) {
         ? json_metadata
         : (() => { try { return JSON.parse(json_metadata || '{}'); } catch { return {}; } })();
     const [imageUrls, setImageUrls] = useState<string[]>([]);
-    const router = useRouter();
     const safeBody = typeof body === 'string' ? body : '';
+    const postHref = `/@${encodeURIComponent(author || '')}/${encodeURIComponent(post.permlink || '')}`;
     const snippet = safeBody
         .replace(/<[^>]*>/g, ' ')
         .replace(/!\[[^\]]*]\(([^)]+)\)/g, ' ')
@@ -57,10 +56,6 @@ export default function PostCard({ post, compact = false }: PostCardProps) {
         const markdownImages = markdownMatches.map(match => match[1]);
         const htmlImages = htmlMatches.map(match => match[1]);
         return [...markdownImages, ...htmlImages];
-    }
-
-    function viewPost() {
-        router.push('/@' + author + '/' + post.permlink);
     }
 
     // **Function to load more slides**
@@ -104,23 +99,27 @@ export default function PostCard({ post, compact = false }: PostCardProps) {
             {/* Content Section */}
             <Box display="flex" flexDirection="column" flexGrow={1} cursor="pointer">
                 <Text
+                    as={NextLink}
+                    href={postHref}
                     fontWeight="bold"
                     fontSize="lg"
                     textAlign="left"
-                    onClick={viewPost}
                     mb={2}
                     noOfLines={compact ? 2 : 1}
+                    _hover={{ textDecoration: 'underline', textUnderlineOffset: '3px' }}
                 >
                     {title || 'Untitled post'}
                 </Text>
                 {compact && snippet && (
                     <Text
+                        as={NextLink}
+                        href={postHref}
                         fontSize="sm"
                         color="text"
                         opacity={0.82}
                         noOfLines={3}
                         mb={3}
-                        onClick={viewPost}
+                        _hover={{ opacity: 1 }}
                     >
                         {snippet}
                     </Text>
@@ -137,7 +136,7 @@ export default function PostCard({ post, compact = false }: PostCardProps) {
                     >
                         {imageUrls.slice(0, visibleImages).map((url, index) => (
                             <SwiperSlide key={index}>
-                                <Box h="200px" w="100%">
+                                <Box as={NextLink} href={postHref} h="200px" w="100%" cursor="pointer">
                                     <Image
                                         src={url}
                                         alt={title}

--- a/components/layout/FooterNavigation.tsx
+++ b/components/layout/FooterNavigation.tsx
@@ -2,7 +2,7 @@ import { useAioha } from '@aioha/react-ui';
 import { useLoginModal } from '@/contexts/LoginModalContext';
 import { Box, Button, HStack, Icon, Tooltip, useColorMode } from '@chakra-ui/react';
 import { CountBadge } from '@/components/ui/CountBadge';
-import { useRouter } from 'next/navigation';
+import NextLink from 'next/link';
 import { FiBell, FiBook, FiCreditCard, FiHome, FiUser, FiLogIn, FiLogOut, FiMessageSquare, FiChevronLeft, FiChevronRight, FiRadio, FiUserPlus } from 'react-icons/fi';
 import { useState, useRef, useEffect } from 'react';
 import { useOpenPodsCount } from '@/hooks/useOpenPodsCount';
@@ -19,7 +19,6 @@ export default function FooterNavigation({ isChatOpen = false, setIsChatOpen, ch
     const { user, aioha } = useAioha();
     const { openLoginModal } = useLoginModal();
     const logout = () => aioha.logout();
-    const router = useRouter();
     const { colorMode } = useColorMode();
     const scrollRef = useRef<HTMLDivElement>(null);
     const [showLeftFade, setShowLeftFade] = useState(false);
@@ -27,12 +26,6 @@ export default function FooterNavigation({ isChatOpen = false, setIsChatOpen, ch
     const openPodsCount = useOpenPodsCount();
     const { unreadCount } = useHiveNotifications(user, { limit: 1, poll: false });
     
-    const handleNavigation = (path: string) => {
-        if (router) {
-            router.push(path);
-        }
-    };
-
     // Check scroll position to show/hide fade indicators
     const checkScroll = () => {
         if (scrollRef.current) {
@@ -116,7 +109,8 @@ export default function FooterNavigation({ isChatOpen = false, setIsChatOpen, ch
             <HStack spacing={1} minW="max-content" justify="center" px={2}>
                 <Tooltip label="Home" aria-label="Home tooltip">
                     <Button
-                        onClick={() => handleNavigation("/")}
+                        as={NextLink}
+                        href="/"
                         variant="ghost"
                         color="white"
                         size="sm"
@@ -129,7 +123,8 @@ export default function FooterNavigation({ isChatOpen = false, setIsChatOpen, ch
 
                 <Tooltip label="Blog" aria-label="Blog tooltip">
                     <Button
-                        onClick={() => handleNavigation("/blog")}
+                        as={NextLink}
+                        href="/blog"
                         variant="ghost"
                         color="white"
                         size="sm"
@@ -143,7 +138,8 @@ export default function FooterNavigation({ isChatOpen = false, setIsChatOpen, ch
                 <Tooltip label="OpenPods" aria-label="OpenPods tooltip">
                     <Box position="relative">
                         <Button
-                            onClick={() => handleNavigation("/hangouts")}
+                            as={NextLink}
+                            href="/hangouts"
                             variant="ghost"
                             color="white"
                             size="sm"
@@ -161,7 +157,8 @@ export default function FooterNavigation({ isChatOpen = false, setIsChatOpen, ch
                         <Tooltip label="Notifications" aria-label="Notifications tooltip">
                             <Box position="relative">
                                 <Button
-                                    onClick={() => handleNavigation("/@" + user + "/notifications")}
+                                    as={NextLink}
+                                    href={`/@${user}/notifications`}
                                     variant="ghost"
                                     color="white"
                                     size="sm"
@@ -176,7 +173,8 @@ export default function FooterNavigation({ isChatOpen = false, setIsChatOpen, ch
 
                         <Tooltip label="Wallet" aria-label="Wallet tooltip">
                             <Button
-                                onClick={() => handleNavigation("/@" + user + '/wallet')}
+                                as={NextLink}
+                                href={`/@${user}/wallet`}
                                 variant="ghost"
                                 color="white"
                                 size="sm"
@@ -206,7 +204,8 @@ export default function FooterNavigation({ isChatOpen = false, setIsChatOpen, ch
 
                         <Tooltip label="Profile" aria-label="Profile tooltip">
                             <Button
-                                onClick={() => handleNavigation("/@" + user)}
+                                as={NextLink}
+                                href={`/@${user}`}
                                 variant="ghost"
                                 color="white"
                                 size="sm"
@@ -246,7 +245,8 @@ export default function FooterNavigation({ isChatOpen = false, setIsChatOpen, ch
                         </Tooltip>
                         <Tooltip label="Create account" aria-label="Create account tooltip">
                             <Button
-                                onClick={() => handleNavigation('/join')}
+                                as={NextLink}
+                                href="/join"
                                 variant="ghost"
                                 color="white"
                                 size="sm"

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -2,7 +2,8 @@
 import React, { useEffect, useState } from 'react';
 import { Box, VStack, Button, Icon, Image, Spinner, Flex, Text, useColorMode, transition, Tooltip, useBreakpointValue, useToast } from '@chakra-ui/react';
 import { CountBadge } from '@/components/ui/CountBadge';
-import { useRouter, usePathname } from 'next/navigation';
+import { usePathname } from 'next/navigation';
+import NextLink from 'next/link';
 import { useAioha } from '@aioha/react-ui';
 import { useLoginModal } from '@/contexts/LoginModalContext';
 import { FiHome, FiBell, FiUser, FiShoppingCart, FiBook, FiCreditCard, FiLogIn, FiLogOut, FiMessageSquare, FiRadio, FiInfo, FiUserPlus } from 'react-icons/fi';
@@ -39,7 +40,6 @@ export default function Sidebar({ isChatOpen = false, setIsChatOpen, chatUnreadC
     const { openLoginModal } = useLoginModal();
     const isLoggedIn = !!user;
     const logout = () => aioha.logout();
-    const router = useRouter();
     const pathname = usePathname();
     const [communityInfo, setCommunityInfo] = useState<CommunityInfo | null>(null); // State to hold community info
     const [profileInfo, setProfileInfo] = useState<ProfileInfo | null>(null); // State to hold profile info
@@ -84,12 +84,6 @@ export default function Sidebar({ isChatOpen = false, setIsChatOpen, chatUnreadC
 
         fetchData();
     }, []);
-
-    const handleNavigation = (path: string) => {
-        if (router) {
-            router.push(path);
-        }
-    };
 
     return (
         <Box
@@ -153,7 +147,8 @@ export default function Sidebar({ isChatOpen = false, setIsChatOpen, chatUnreadC
                     <Tooltip label="Home" placement="right" hasArrow isDisabled={!isCompactMode}>
                         <Box w="full">
                             <Button
-                                onClick={() => handleNavigation("/")}
+                                as={NextLink}
+                                href="/"
                                 variant="ghost"
                                 w="full"
                                 justifyContent={iconJustify}
@@ -170,7 +165,8 @@ export default function Sidebar({ isChatOpen = false, setIsChatOpen, chatUnreadC
                     <Tooltip label="Blog" placement="right" hasArrow isDisabled={!isCompactMode}>
                         <Box w="full">
                             <Button
-                                onClick={() => handleNavigation("/blog")}
+                                as={NextLink}
+                                href="/blog"
                                 variant="ghost"
                                 w="full"
                                 justifyContent={iconJustify}
@@ -186,7 +182,8 @@ export default function Sidebar({ isChatOpen = false, setIsChatOpen, chatUnreadC
                     <Tooltip label="OpenPods" placement="right" hasArrow isDisabled={!isCompactMode}>
                         <Box w="full" position="relative">
                             <Button
-                                onClick={() => handleNavigation("/hangouts")}
+                                as={NextLink}
+                                href="/hangouts"
                                 variant="ghost"
                                 w="full"
                                 justifyContent={iconJustify}
@@ -205,7 +202,8 @@ export default function Sidebar({ isChatOpen = false, setIsChatOpen, chatUnreadC
                             <Tooltip label="Notifications" placement="right" hasArrow isDisabled={!isCompactMode}>
                                 <Box w="full" position="relative">
                                     <Button
-                                        onClick={() => handleNavigation("/@" + user + "/notifications")}
+                                        as={NextLink}
+                                        href={`/@${user}/notifications`}
                                         variant="ghost"
                                         w="full"
                                         justifyContent={iconJustify}
@@ -233,7 +231,8 @@ export default function Sidebar({ isChatOpen = false, setIsChatOpen, chatUnreadC
                             <Tooltip label="Profile" placement="right" hasArrow isDisabled={!isCompactMode}>
                                 <Box w="full">
                                     <Button
-                                        onClick={() => handleNavigation("/@" + user)}
+                                        as={NextLink}
+                                        href={`/@${user}`}
                                         variant="ghost"
                                         w="full"
                                         justifyContent={iconJustify}
@@ -260,7 +259,8 @@ export default function Sidebar({ isChatOpen = false, setIsChatOpen, chatUnreadC
                             <Tooltip label="Wallet" placement="right" hasArrow isDisabled={!isCompactMode}>
                                 <Box w="full">
                                     <Button
-                                        onClick={() => handleNavigation("/@" + user + '/wallet')}
+                                        as={NextLink}
+                                        href={`/@${user}/wallet`}
                                         variant="ghost"
                                         w="full"
                                         justifyContent={iconJustify}
@@ -316,7 +316,8 @@ export default function Sidebar({ isChatOpen = false, setIsChatOpen, chatUnreadC
                         <Tooltip label="Create account" placement="right" hasArrow isDisabled={!isCompactMode}>
                             <Box w="full">
                                 <Button
-                                    onClick={() => router.push('/join')}
+                                    as={NextLink}
+                                    href="/join"
                                     variant="ghost"
                                     w="full"
                                     justifyContent={iconJustify}

--- a/components/wallet/WalletPage.tsx
+++ b/components/wallet/WalletPage.tsx
@@ -468,19 +468,16 @@ export default function WalletPage({ username }: WalletPageProps) {
                 <Button size="sm" leftIcon={<FaExchangeAlt />} onClick={() => handleModalOpen({ title: 'Convert HIVE', description: 'Convert HIVE to HBD (3.5 day settlement)' })} variant="outline" colorScheme="orange">Convert</Button>
                 <Button size="sm" leftIcon={<FaExchangeAlt />} onClick={() => handleModalOpen({ title: 'Swap HIVE', description: 'Fast market swap HIVE -> HBD (immediate-or-cancel)', swapDirection: 'HIVE_TO_HBD' })} variant="outline" colorScheme="yellow">Swap</Button>
                 <Button size="sm" leftIcon={<FaPiggyBank />} onClick={() => handleModalOpen({ title: 'HIVE Savings', description: 'Transfer to HIVE savings' })} variant="outline" colorScheme="teal">To Savings</Button>
-                <Button size="sm" leftIcon={<FaShoppingCart />} onClick={() => {
-                    const params = new URLSearchParams({
-                      apiKey: '771c8ab6-b3ba-4450-b69d-ca35e4b25eb8',
-                      redirectURL: window.location.href,
-                      cryptoCurrencyCode: 'HIVE',
-                      defaultCryptoAmount: '200',
-                      exchangeScreenTitle: 'Buy HIVE',
-                      isFeeCalculationHidden: 'false',
-                      defaultPaymentMethod: 'credit_debit_card',
-                      walletAddress: user ?? '',
-                    });
-                    router.push(`https://global.transak.com/?${params.toString()}`);
-                  }} variant="outline" colorScheme="green">Buy HIVE</Button>
+                <Button
+                  size="sm"
+                  leftIcon={<FaShoppingCart />}
+                  variant="outline"
+                  colorScheme="green"
+                  isDisabled
+                  title="Coming soon"
+                >
+                  Buy HIVE (Coming soon)
+                </Button>
               </Flex>
             )}
           </Box>

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 git pull
 pnpm install
 pnpm build
-pm2 restart snapie-io
+
+# PM2 process ownership is tied to user session; when deploy runs with sudo,
+# restart PM2 as the app user so it targets the correct process list.
+if [ "${EUID}" -eq 0 ]; then
+  sudo -u meno -H env PM2_HOME=/home/meno/.pm2 pm2 restart snapie-io
+else
+  pm2 restart snapie-io
+fi


### PR DESCRIPTION
## Summary
- convert sidebar/footer navigational buttons to real links so middle-click and browser open-in-new-tab behavior work natively
- harden post-card navigation reliability by using explicit link targets for post title/snippet/media click-through
- disable broken Buy HIVE action behind a clear coming-soon state and update deploy script so PM2 restart runs under `meno` when deploy is executed via sudo

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] manual sanity: menu links open correctly and support native browser tab behavior

Made with [Cursor](https://cursor.com)