### PR TITLE
fix: interruptible navigation + hide top-snap parent links

### DIFF
--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,14 @@
+import { Box, Spinner } from '@chakra-ui/react';
+
+// Root loading boundary. Without a loading.tsx, App Router navigations block on
+// the destination route's server work (e.g. generateMetadata's Hive call) and are
+// NOT interruptible — clicking a post freezes the app until the render resolves,
+// and queued link clicks only flush on the next discrete state update. This Suspense
+// fallback makes every navigation show instant feedback and stay interruptible.
+export default function Loading() {
+  return (
+    <Box display="flex" justifyContent="center" alignItems="center" height="100vh">
+      <Spinner size="xl" color="primary" />
+    </Box>
+  );
+}

--- a/components/blog/PostDetails.tsx
+++ b/components/blog/PostDetails.tsx
@@ -13,6 +13,7 @@ import InteractionBar from '@/components/shared/InteractionBar';
 import SnapieSpeakAudio from '@/components/shared/SnapieSpeakAudio';
 import ThreeSpeakVideoPlayer from '@/components/shared/ThreeSpeakVideoPlayer';
 import TwitterEmbed from '@/components/shared/TwitterEmbed';
+import { isSnapContainer } from '@/lib/utils/snapUtils';
 
 type BodySegment =
     | { type: 'html'; html: string }
@@ -49,7 +50,14 @@ export default function PostDetails({ post, isEmbedMode = false }: PostDetailsPr
     const { user } = useAioha();
     const router = useRouter();
     const canEdit = !isEmbedMode && user === author;
-    const hasParent = Boolean(post.depth > 0 && post.parent_author && post.parent_permlink);
+    // Suppress the parent link for "top snaps" (direct replies to the snap container):
+    // navigating there would load the entire container thread (hundreds of snaps).
+    const hasParent = Boolean(
+        post.depth > 0 &&
+        post.parent_author &&
+        post.parent_permlink &&
+        !isSnapContainer(post.parent_author, post.parent_permlink)
+    );
 
     const bodySegments = useMemo((): BodySegment[] => {
         let html = markdownRenderer(body, { defaultEmojiOwner: author });

--- a/components/homepage/Conversation.tsx
+++ b/components/homepage/Conversation.tsx
@@ -6,6 +6,7 @@ import { ArrowBackIcon, ArrowUpIcon } from "@chakra-ui/icons";
 import Snap from './Snap';
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { isSnapContainer } from '@/lib/utils/snapUtils';
 
 interface ConversationProps {
     comment: Comment;
@@ -19,7 +20,9 @@ const Conversation = ({ comment, setConversation, onOpen, setReply, refreshTrigg
     const { hiveUser } = useHiveUser();
     const router = useRouter();
     const { comments, isLoading, error, updateComments } = useComments(comment.author, comment.permlink, true, hiveUser?.name);
-    const isTopLevel = !comment.parent_author || comment.parent_author === 'peak.snaps';
+    // A "top snap" replies directly to the snap container; hide its parent link so users
+    // can't open the container and load hundreds of snaps at once.
+    const isTopLevel = !comment.parent_author || isSnapContainer(comment.parent_author, comment.parent_permlink);
 
     useEffect(() => {
         if (refreshTrigger && refreshTrigger > 0) updateComments();

--- a/lib/utils/snapUtils.ts
+++ b/lib/utils/snapUtils.ts
@@ -1,5 +1,26 @@
 import { Discussion } from "@hiveio/dhive";
 
+/**
+ * The snap "container" post that all top-level snaps reply to. Top snaps have this
+ * post as their direct parent. Navigating to it loads every snap reply at once
+ * (hundreds of them), so parent links must never point here.
+ */
+export const SNAP_CONTAINER_AUTHOR = "peak.snaps";
+export const SNAP_CONTAINER_PERMLINK = "snaps";
+
+/**
+ * True when (author, permlink) refers to the snap container post. A reply whose
+ * parent is the container is a "top snap" — we hide its parent link to avoid
+ * dumping the entire container thread on the user.
+ */
+export function isSnapContainer(author?: string | null, permlink?: string | null): boolean {
+  if (!author) return false;
+  // Permlink may be unknown in some call sites; author match alone is a safe signal
+  // since the container account only hosts the snaps thread.
+  if (author !== SNAP_CONTAINER_AUTHOR) return false;
+  return !permlink || permlink === SNAP_CONTAINER_PERMLINK;
+}
+
 /** Wrapper aspect for iframe/video embeds (avoids forcing vertical content into 16/9). */
 export type EmbedAspect = "16/9" | "9/16" | "4/5" | "3/4";
 


### PR DESCRIPTION
## Summary

Two fixes on a fresh branch off `main`:

### 1. Profile navigation lock (the real root cause)
The previous attempt (PR #99) swapped `router.push` for `NextLink` in `PostCard`, but the freeze persisted. The actual cause is that the app had **no `loading.tsx` anywhere**, so App Router navigations were **blocking and non-interruptible**.

The `[...slug]` route's `generateMetadata` runs a synchronous Hive `get_content` call. Without a Suspense/`loading` boundary, the client navigation transition waits for that full server render before committing. While it's pending:
- Clicking a post on a profile appears to do nothing.
- Other link clicks (menu, OpenPods, notifications) queue up behind the blocked transition and seem dead.
- Clicking the **Snaps tab** (a non-transition `setState`) forces React to flush, which "teleports" you to the previously clicked post.

Adding a root `app/loading.tsx` gives instant navigation feedback and makes navigation interruptible — the layout/sidebar stay live while the content area shows a spinner.

### 2. Top-snap parent link (memory killer)
A "top snap" is a direct reply to the `peak.snaps/snaps` container. The "View parent" link (in `PostDetails`) pointed at that container, which loads hundreds of snaps in one go.

- New shared helper `isSnapContainer()` + container constants in `snapUtils`.
- `PostDetails` no longer renders the parent link when the parent is the container.
- `Conversation` now uses the same helper for its "Replying to @…" link (previously a partial author-only check).

## Test plan
- [ ] On a profile, switch to Posts/Blog, click a post → navigates immediately, app stays usable.
- [ ] Menu items (OpenPods, Notifications, Wallet) respond while a navigation is in flight.
- [ ] Open a top snap → no "View parent" / "Replying to" link to the container.
- [ ] Open a nested reply → parent link still shows and works.
- [x] `pnpm build` passes.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading spinner that displays during page transitions for better user feedback.

* **Bug Fixes**
  * Improved display logic for parent reply links in conversations and blog post details, ensuring they appear correctly in all contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->