### PR TITLE
feat: optimize chat timeline performance and sync

### DIFF
--- a/app/api/chat/channels/[id]/messages/route.ts
+++ b/app/api/chat/channels/[id]/messages/route.ts
@@ -10,6 +10,7 @@ import mongoose from 'mongoose';
 export const GET = withChatAuth(async (req: NextRequest, { username, params }) => {
   const { searchParams } = new URL(req.url);
   const before = searchParams.get('before');
+  const after = searchParams.get('after');
   const limit = Math.min(parseInt(searchParams.get('limit') || '50', 10), 100);
   const channelId = params?.id;
   if (!channelId) return NextResponse.json({ error: 'Channel id missing' }, { status: 400 });
@@ -36,6 +37,11 @@ export const GET = withChatAuth(async (req: NextRequest, { username, params }) =
       return NextResponse.json({ error: 'Invalid before cursor' }, { status: 400 });
     }
     query._id = { $lt: before };
+  } else if (after) {
+    if (!mongoose.isValidObjectId(after)) {
+      return NextResponse.json({ error: 'Invalid after cursor' }, { status: 400 });
+    }
+    query._id = { $gt: after };
   }
 
   const me = await ChatUser.findById(username);
@@ -43,8 +49,12 @@ export const GET = withChatAuth(async (req: NextRequest, { username, params }) =
     ...(me?.blockedUsers || []),
     ...(me?.mutedUsers || []),
   ]);
-  const messages = await Message.find(query).sort({ _id: -1 }).limit(limit);
+  const sortDirection = after ? 1 : -1;
+  const messages = await Message.find(query).sort({ _id: sortDirection }).limit(limit);
   const visible = messages.filter(m => !blocked.has(m.sender));
+  if (after) {
+    return NextResponse.json({ messages: visible });
+  }
   return NextResponse.json({ messages: visible.reverse() });
 });
 

--- a/app/api/chat/dm/[id]/messages/route.ts
+++ b/app/api/chat/dm/[id]/messages/route.ts
@@ -5,6 +5,7 @@ import { ChatUser } from '@/lib/db/models/ChatUser';
 import { getDmPeer, isDmParticipant } from '@/lib/chat/conversations';
 import { isRateLimited, validateMessageBody } from '@/lib/chat/messages';
 import { sendDirectMessageToTokens } from '@/lib/chat/fcm';
+import mongoose from 'mongoose';
 
 export const GET = withChatAuth(async (req: NextRequest, { username, params }) => {
   const id = params?.id;
@@ -13,6 +14,7 @@ export const GET = withChatAuth(async (req: NextRequest, { username, params }) =
 
   const { searchParams } = new URL(req.url);
   const before = searchParams.get('before');
+  const after = searchParams.get('after');
   const limit = Math.min(parseInt(searchParams.get('limit') || '50', 10), 100);
 
   const me = await ChatUser.findById(username);
@@ -21,8 +23,19 @@ export const GET = withChatAuth(async (req: NextRequest, { username, params }) =
     ...(me?.mutedUsers || []),
   ]);
   const query: Record<string, unknown> = { target: id, type: 'dm' };
-  if (before) query._id = { $lt: before };
-  const messages = await Message.find(query).sort({ _id: -1 }).limit(limit);
+  if (before) {
+    if (!mongoose.isValidObjectId(before)) {
+      return NextResponse.json({ error: 'Invalid before cursor' }, { status: 400 });
+    }
+    query._id = { $lt: before };
+  } else if (after) {
+    if (!mongoose.isValidObjectId(after)) {
+      return NextResponse.json({ error: 'Invalid after cursor' }, { status: 400 });
+    }
+    query._id = { $gt: after };
+  }
+  const sortDirection = after ? 1 : -1;
+  const messages = await Message.find(query).sort({ _id: sortDirection }).limit(limit);
   const visible = messages.filter(m => !blocked.has(m.sender));
 
   const now = Date.now();
@@ -58,6 +71,9 @@ export const GET = withChatAuth(async (req: NextRequest, { username, params }) =
     };
   }
 
+  if (after) {
+    return NextResponse.json({ messages: visible, status });
+  }
   return NextResponse.json({ messages: visible.reverse(), status });
 });
 

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -26,6 +26,7 @@ import {
 } from '@chakra-ui/react';
 import { keyframes } from '@emotion/react';
 import { useState, useEffect, useRef, useCallback, useMemo, KeyboardEvent, MouseEvent as ReactMouseEvent } from 'react';
+import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 import { useAioha } from '@aioha/react-ui';
 import { FiArrowDown, FiArrowLeft, FiArrowUp, FiChevronDown, FiCornerUpLeft, FiExternalLink, FiHash, FiImage, FiMaximize2, FiMessageSquare, FiMinus, FiPlus, FiSend, FiUsers, FiX } from 'react-icons/fi';
 import { KeyTypes } from '@aioha/aioha';
@@ -55,6 +56,9 @@ const CHAT_IMAGE_MAX_BYTES = 8 * 1024 * 1024;
 const CHAT_IMAGE_ACCEPT = ['image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/avif'];
 const MENTION_REGEX = /@[a-z0-9.-]+/gi;
 const MENTION_INPUT_REGEX = /(?:^|\s)@([a-z0-9.-]{0,32})$/i;
+const INITIAL_MESSAGE_LIMIT = 50;
+const DELTA_MESSAGE_LIMIT = 50;
+const MAX_ACTIVE_MESSAGES = 600;
 
 function isImageUrl(url: string): boolean {
   const trimmed = url.trim();
@@ -174,6 +178,25 @@ function formatLastSeen(iso: string): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
+}
+
+function sortMessagesAsc(messages: Message[]): Message[] {
+  return [...messages].sort((a, b) => a._id.localeCompare(b._id));
+}
+
+function mergeMessagesById(existing: Message[], incoming: Message[], cap = MAX_ACTIVE_MESSAGES): Message[] {
+  if (!incoming.length) return existing;
+  const merged = new Map<string, Message>();
+  for (const msg of existing) merged.set(msg._id, msg);
+  for (const msg of incoming) merged.set(msg._id, msg);
+  const ordered = sortMessagesAsc(Array.from(merged.values()));
+  if (ordered.length <= cap) return ordered;
+  return ordered.slice(ordered.length - cap);
+}
+
+function trimMessagesTail(messages: Message[], cap = MAX_ACTIVE_MESSAGES): Message[] {
+  if (messages.length <= cap) return messages;
+  return messages.slice(messages.length - cap);
 }
 
 function avatarNameForConversation(conv: Conversation): string {
@@ -504,6 +527,7 @@ export default function ChatPanel({
   const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
   const [loadingMessages, setLoadingMessages] = useState(false);
+  const [loadingOlder, setLoadingOlder] = useState(false);
   const [panelSize, setPanelSize] = useState(DESKTOP_PANEL_DEFAULT);
   const [isResizing, setIsResizing] = useState(false);
   const [showResizeHint, setShowResizeHint] = useState(false);
@@ -515,12 +539,13 @@ export default function ChatPanel({
   const [hasValidMentionInDraft, setHasValidMentionInDraft] = useState(false);
   const [showJumpToNow, setShowJumpToNow] = useState(false);
 
-  const messagesEndRef = useRef<HTMLDivElement>(null);
-  const messagesContainerRef = useRef<HTMLDivElement>(null);
+  const virtuosoRef = useRef<VirtuosoHandle | null>(null);
   const messageNodeRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const oldestIdRef = useRef<string | undefined>(undefined);
+  const latestIdRef = useRef<string | undefined>(undefined);
   const shouldAutoScrollRef = useRef(true);
+  const loadingOlderRef = useRef(false);
   const resizeStartRef = useRef<{ x: number; y: number; width: number; height: number } | null>(null);
   const imageInputRef = useRef<HTMLInputElement>(null);
   const composerInputRef = useRef<HTMLInputElement>(null);
@@ -665,7 +690,7 @@ export default function ChatPanel({
   const fetchMessagesForConversation = useCallback(async (
     convId: string,
     convType: Conversation['type'] | undefined,
-    opts: { before?: string; limit?: number } = {}
+    opts: { before?: string; after?: string; limit?: number } = {}
   ): Promise<Message[]> => {
     if (!convId) return [];
     if (convType === 'dm') {
@@ -683,23 +708,56 @@ export default function ChatPanel({
     convType: Conversation['type'] | undefined,
     append = false
   ) => {
-    setLoadingMessages(!append);
+    if (append) {
+      if (loadingOlderRef.current) return;
+      loadingOlderRef.current = true;
+      setLoadingOlder(true);
+    } else {
+      setLoadingMessages(true);
+    }
     try {
       const msgs = await fetchMessagesForConversation(convId, convType, {
         before: append ? oldestIdRef.current : undefined,
-        limit: 50,
+        limit: INITIAL_MESSAGE_LIMIT,
       });
-      if (msgs.length > 0) oldestIdRef.current = msgs[0]._id;
-      setMessages(prev => append ? [...msgs, ...prev] : msgs);
+      if (append) {
+        if (!msgs.length) {
+          oldestIdRef.current = undefined;
+        } else {
+          oldestIdRef.current = msgs[0]._id;
+          setMessages(prev => mergeMessagesById(msgs, prev, MAX_ACTIVE_MESSAGES));
+        }
+      } else {
+        const ordered = trimMessagesTail(sortMessagesAsc(msgs), MAX_ACTIVE_MESSAGES);
+        if (ordered.length > 0) {
+          oldestIdRef.current = ordered[0]._id;
+          latestIdRef.current = ordered[ordered.length - 1]._id;
+        } else {
+          oldestIdRef.current = undefined;
+          latestIdRef.current = undefined;
+        }
+        setMessages(ordered);
+      }
     } catch {
-      setMessages([]);
+      if (!append) {
+        setMessages([]);
+        oldestIdRef.current = undefined;
+        latestIdRef.current = undefined;
+      }
+    } finally {
+      if (append) {
+        setLoadingOlder(false);
+        loadingOlderRef.current = false;
+      } else {
+        setLoadingMessages(false);
+      }
     }
-    setLoadingMessages(false);
   }, [fetchMessagesForConversation]);
 
   useEffect(() => {
     if (!isOpen || isMinimized) return;
     oldestIdRef.current = undefined;
+    latestIdRef.current = undefined;
     shouldAutoScrollRef.current = true;
     setDmStatus(null);
     setReplyingTo(null);
@@ -999,59 +1057,96 @@ export default function ChatPanel({
     }
   }
 
+  const loadOlderMessages = useCallback(async () => {
+    if (!activeConversationId || !activeConversation?.type) return;
+    if (loadingOlderRef.current || loadingMessages) return;
+    if (!oldestIdRef.current) return;
+    await loadMessages(activeConversationId, activeConversation?.type, true);
+  }, [activeConversationId, activeConversation?.type, loadMessages, loadingMessages]);
+
+  const refreshMessageDeltas = useCallback(async () => {
+    if (!activeConversationId || !activeConversation?.type) return;
+
+    const newestId = latestIdRef.current;
+    const delta = await fetchMessagesForConversation(activeConversationId, activeConversation?.type, {
+      after: newestId,
+      limit: DELTA_MESSAGE_LIMIT,
+    });
+    if (!delta.length) return;
+
+    setMessages(prev => {
+      const merged = mergeMessagesById(prev, delta, MAX_ACTIVE_MESSAGES);
+      if (merged.length > 0) {
+        oldestIdRef.current = merged[0]._id;
+        latestIdRef.current = merged[merged.length - 1]._id;
+      }
+      return merged;
+    });
+  }, [activeConversationId, activeConversation?.type, fetchMessagesForConversation]);
+
   // ── Poll fallback ──────────────────────────────────────────────────────
   useEffect(() => {
     if (!isOpen || isMinimized || !isAuthed) return;
     pollRef.current = setInterval(async () => {
       try {
         await reloadConversations();
-        const msgs = await fetchMessagesForConversation(activeConversationId, activeConversation?.type, { limit: 20 });
-        setMessages(msgs);
+        await refreshMessageDeltas();
       } catch {}
     }, POLL_INTERVAL);
     return () => { if (pollRef.current) clearInterval(pollRef.current); };
-  }, [isOpen, isMinimized, isAuthed, activeConversationId, activeConversation?.type, reloadConversations, fetchMessagesForConversation]);
+  }, [isOpen, isMinimized, isAuthed, activeConversationId, activeConversation?.type, reloadConversations, refreshMessageDeltas]);
 
   // ── FCM foreground listener ────────────────────────────────────────────
   useEffect(() => {
     if (!isAuthed) return () => {};
     return onForegroundMessage(async () => {
       await reloadConversations();
-      const msgs = await fetchMessagesForConversation(activeConversationId, activeConversation?.type, { limit: 20 });
-      setMessages(msgs);
+      await refreshMessageDeltas();
     });
-  }, [isAuthed, activeConversationId, activeConversation?.type, reloadConversations, fetchMessagesForConversation]);
+  }, [isAuthed, activeConversationId, activeConversation?.type, reloadConversations, refreshMessageDeltas]);
 
   // ── Auto-scroll to bottom on new messages ─────────────────────────────
   useEffect(() => {
-    if (!shouldAutoScrollRef.current) return;
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
+    if (!messages.length) {
+      setShowJumpToNow(false);
+      return;
+    }
 
-  useEffect(() => {
-    if (!messages.length) return;
-    if (!shouldAutoScrollRef.current) setShowJumpToNow(true);
-  }, [messages]);
+    oldestIdRef.current = messages[0]?._id;
+    latestIdRef.current = messages[messages.length - 1]?._id;
 
-  function handleMessagesScroll() {
-    const el = messagesContainerRef.current;
-    if (!el) return;
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    shouldAutoScrollRef.current = distanceFromBottom < 80;
-    setShowJumpToNow(distanceFromBottom > 160);
-  }
+    if (!shouldAutoScrollRef.current) {
+      setShowJumpToNow(true);
+      return;
+    }
+
+    const lastIndex = messages.length - 1;
+    if (lastIndex < 0) return;
+
+    virtuosoRef.current?.scrollToIndex({
+      index: lastIndex,
+      align: 'end',
+      behavior: 'auto',
+    });
+
+    setShowJumpToNow(false);
+  }, [messages]);
 
   function jumpToLatestMention() {
     if (!latestMention) return;
-    const el = messageNodeRefs.current[latestMention.msg._id];
-    if (!el) return;
-    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    virtuosoRef.current?.scrollToIndex({
+      index: latestMention.idx,
+      align: 'center',
+      behavior: 'smooth',
+    });
   }
 
   function jumpToNow() {
     shouldAutoScrollRef.current = true;
     setShowJumpToNow(false);
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
+    const lastIndex = messages.length - 1;
+    if (lastIndex < 0) return;
+    virtuosoRef.current?.scrollToIndex({ index: lastIndex, align: 'end', behavior: 'smooth' });
   }
 
   function handleResizeStart(e: ReactMouseEvent<HTMLDivElement>) {
@@ -1160,7 +1255,7 @@ export default function ChatPanel({
       } else {
         msg = await chatService.sendMessage(activeConversation._id, content, replyTo);
       }
-      setMessages(prev => [...prev, msg]);
+      setMessages(prev => trimMessagesTail([...prev, msg], MAX_ACTIVE_MESSAGES));
       setMessageCache(prev => ({ ...prev, [msg._id]: msg }));
       setReplyingTo(null);
       try { await chatService.setTyping(activeConversation._id, false); } catch {}
@@ -1676,79 +1771,94 @@ export default function ChatPanel({
                   <Divider mt={2} borderColor="whiteAlpha.200" />
                 </Box>
               )}
-              <Flex
-                ref={messagesContainerRef}
-                onScroll={handleMessagesScroll}
+              <Box
                 flex="1"
-                direction="column"
-                overflowY="auto"
+                position="relative"
                 px={4}
                 py={3}
-                gap={2}
                 sx={{
                   overscrollBehavior: 'contain',
                   WebkitOverflowScrolling: 'touch',
-                  '&::-webkit-scrollbar': { width: '3px' },
-                  '&::-webkit-scrollbar-track': { bg: 'transparent' },
-                  '&::-webkit-scrollbar-thumb': { bg: 'whiteAlpha.200', borderRadius: 'full' },
+                  '& [data-virtuoso-scroller]::-webkit-scrollbar': { width: '3px' },
+                  '& [data-virtuoso-scroller]::-webkit-scrollbar-track': { bg: 'transparent' },
+                  '& [data-virtuoso-scroller]::-webkit-scrollbar-thumb': { bg: 'whiteAlpha.200', borderRadius: 'full' },
                 }}
               >
                 {loadingMessages ? (
-                  <Flex justify="center" align="center" flex="1">
+                  <Flex justify="center" align="center" flex="1" h="100%">
                     <Spinner color="blue.300" size="sm" />
                   </Flex>
                 ) : messages.length === 0 ? (
-                  <Flex direction="column" justify="center" align="center" flex="1" gap={2} opacity={0.5}>
+                  <Flex direction="column" justify="center" align="center" flex="1" gap={2} opacity={0.5} h="100%">
                     <Icon as={FiMessageSquare} boxSize={8} color="whiteAlpha.400" />
                     <Text fontSize="xs" color="whiteAlpha.500">No messages yet. Say hello!</Text>
                   </Flex>
                 ) : (
-                  <VStack align="stretch" spacing={2}>
-                    {messages.map(msg => (
-                    <Box
-                      key={msg._id}
-                      ref={el => {
-                        messageNodeRefs.current[msg._id] = el;
-                      }}
-                    >
-                      <MessageBubble
-                        msg={msg}
-                        isOwn={msg.sender === user}
-                        onOpenDm={openDmByUsername}
-                        onReplySelect={setReplyingTo}
-                        onMentionSelect={insertMentionForUser}
-                        replyPreview={msg.replyTo ? messageCache[msg.replyTo] || null : null}
-                        onEditSelect={msg.sender === user ? (m) => {
-                          setEditingMessage(m);
-                          setReplyingTo(null);
-                          setDraft(m.content);
-                        } : undefined}
-                        activeUsername={user}
-                        highlightMention={messageMentionsUser(msg.content, user)}
-                      />
-                    </Box>
-                    ))}
-                    {activeConversation?.type === 'dm' && (() => {
-                      const myLast = [...messages].reverse().find(m => m.sender === user);
-                      if (!myLast) return null;
-                      const peerSeenTs = dmStatus?.peerSeenAt ? new Date(dmStatus.peerSeenAt).getTime() : 0;
-                      const msgTs = new Date(myLast.createdAt).getTime();
-                      if (peerSeenTs && peerSeenTs >= msgTs) {
-                        return (
-                          <Text fontSize="10px" color="whiteAlpha.500" textAlign="right" pr={1}>
-                            Seen
-                          </Text>
-                        );
-                      }
-                      return null;
-                    })()}
-                  </VStack>
-                )}
-                <div ref={messagesEndRef} />
-                {!!typingLabel && (
-                  <Text fontSize="11px" color="whiteAlpha.600" mt={1}>
-                    {typingLabel}
-                  </Text>
+                  <Virtuoso
+                    ref={virtuosoRef}
+                    style={{ height: '100%' }}
+                    data={messages}
+                    atBottomStateChange={(atBottom) => {
+                      shouldAutoScrollRef.current = atBottom;
+                      if (atBottom) setShowJumpToNow(false);
+                    }}
+                    startReached={loadOlderMessages}
+                    itemContent={(index, msg) => (
+                      <Box
+                        key={msg._id}
+                        ref={el => {
+                          messageNodeRefs.current[msg._id] = el;
+                        }}
+                        pb={2}
+                      >
+                        <MessageBubble
+                          msg={msg}
+                          isOwn={msg.sender === user}
+                          onOpenDm={openDmByUsername}
+                          onReplySelect={setReplyingTo}
+                          onMentionSelect={insertMentionForUser}
+                          replyPreview={msg.replyTo ? messageCache[msg.replyTo] || null : null}
+                          onEditSelect={msg.sender === user ? (m) => {
+                            setEditingMessage(m);
+                            setReplyingTo(null);
+                            setDraft(m.content);
+                          } : undefined}
+                          activeUsername={user}
+                          highlightMention={messageMentionsUser(msg.content, user)}
+                        />
+                      </Box>
+                    )}
+                    components={{
+                      Header: () => loadingOlder ? (
+                        <Flex justify="center" align="center" py={2}>
+                          <Spinner color="blue.300" size="xs" />
+                        </Flex>
+                      ) : <></>,
+                      Footer: () => (
+                        <>
+                          {activeConversation?.type === 'dm' && (() => {
+                            const myLast = [...messages].reverse().find(m => m.sender === user);
+                            if (!myLast) return null;
+                            const peerSeenTs = dmStatus?.peerSeenAt ? new Date(dmStatus.peerSeenAt).getTime() : 0;
+                            const msgTs = new Date(myLast.createdAt).getTime();
+                            if (peerSeenTs && peerSeenTs >= msgTs) {
+                              return (
+                                <Text fontSize="10px" color="whiteAlpha.500" textAlign="right" pr={1}>
+                                  Seen
+                                </Text>
+                              );
+                            }
+                            return null;
+                          })()}
+                          {!!typingLabel && (
+                            <Text fontSize="11px" color="whiteAlpha.600" mt={1}>
+                              {typingLabel}
+                            </Text>
+                          )}
+                        </>
+                      ),
+                    }}
+                  />
                 )}
                 {showJumpToNow && (
                   <IconButton
@@ -1780,7 +1890,7 @@ export default function ChatPanel({
                     title="Jump to latest @mention"
                   />
                 )}
-              </Flex>
+              </Box>
 
               {/* Auth overlay / compose bar */}
               {!isAuthed || authState === 'idle' ? (

--- a/lib/chat/ChatService.ts
+++ b/lib/chat/ChatService.ts
@@ -110,10 +110,11 @@ class ChatService {
 
   async getDmMessages(
     conversationId: string,
-    opts: { before?: string; limit?: number } = {}
+    opts: { before?: string; after?: string; limit?: number } = {}
   ): Promise<{ messages: Message[]; status?: DmStatusInfo | null }> {
     const params = new URLSearchParams();
     if (opts.before) params.set('before', opts.before);
+    if (opts.after) params.set('after', opts.after);
     if (opts.limit) params.set('limit', String(opts.limit));
     const qs = params.toString();
     const { messages, status } = await this.get<{ messages: Message[]; status?: DmStatusInfo | null }>(
@@ -224,10 +225,11 @@ class ChatService {
 
   async getMessages(
     channelId: string,
-    opts: { before?: string; limit?: number } = {}
+    opts: { before?: string; after?: string; limit?: number } = {}
   ): Promise<Message[]> {
     const params = new URLSearchParams();
     if (opts.before) params.set('before', opts.before);
+    if (opts.after) params.set('after', opts.after);
     if (opts.limit) params.set('limit', String(opts.limit));
     const qs = params.toString();
     const { messages } = await this.get<{ messages: Message[] }>(

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-icons": "^5.3.0",
     "react-infinite-scroll-component": "^6.1.0",
     "react-intersection-observer": "^10.0.0",
+    "react-virtuoso": "^4.18.7",
     "styled-components": "^6.1.19",
     "swiper": "^12.0.3",
     "tus-js-client": "4.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       react-intersection-observer:
         specifier: ^10.0.0
         version: 10.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-virtuoso:
+        specifier: ^4.18.7
+        version: 4.18.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       styled-components:
         specifier: ^6.1.19
         version: 6.1.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3619,6 +3622,12 @@ packages:
     peerDependencies:
       react: ^16.8.0  || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0  || ^17.0.0 || ^18.0.0
+
+  react-virtuoso@4.18.7:
+    resolution: {integrity: sha512-xNF5zDGEEIMB7cKwcen/pLig0YDf6OnfFrVgKFa7sHPf9fRem0CaLshyObbBcP88jzn0enavL39EgplgdyT21g==}
+    peerDependencies:
+      react: '>=16 || >=17 || >= 18 || >= 19'
+      react-dom: '>=16 || >=17 || >= 18 || >=19'
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -8292,6 +8301,11 @@ snapshots:
       throttle-debounce: 3.0.1
       ts-easing: 0.2.0
       tslib: 2.8.1
+
+  react-virtuoso@4.18.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react@18.3.1:
     dependencies:


### PR DESCRIPTION
## Summary
- virtualize chat thread rendering in `ChatPanel` with `react-virtuoso` to keep DOM size stable for large chats
- replace full message-list replacement during poll/FCM with incremental delta merges and capped active-message window
- add `after` cursor support to channel and DM message endpoints + `ChatService` to fetch new messages incrementally
- switch auto-anchor behavior to instant on open/switch, while keeping explicit jump actions smooth

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [ ] Open chat with large history and verify open is instant (no long smooth scroll replay)
- [ ] Verify incoming messages append without replacing entire thread
- [ ] Verify jump-to-now and jump-to-mention still work
- [ ] Verify loading older messages triggers when scrolling up

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented virtual message scrolling for improved performance when viewing large conversation histories.
  * Added enhanced pagination with bidirectional message loading support.

* **Refactor**
  * Optimized message loading with delta-based updates for faster refresh and improved responsiveness.
  * Streamlined message list rendering to better handle large conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->