### PR TITLE
fix: harden video embeds and blocked-player fallbacks

### DIFF
--- a/components/blog/PostDetails.tsx
+++ b/components/blog/PostDetails.tsx
@@ -109,18 +109,26 @@ export default function PostDetails({ post, isEmbedMode = false }: PostDetailsPr
         html = html.replace(
             /<div class="videoWrapper">\s*<iframe[^>]*src="https?:\/\/(?:www\.)?(?:youtube(?:-nocookie)?\.com\/embed\/|youtu\.be\/)([^"?&/]+)[^"]*"[^>]*>\s*<\/iframe>\s*<\/div>/gi,
             (_match, embeddedId: string) => {
+                const id =
+                    extractYouTubeId(`https://www.youtube.com/embed/${embeddedId}`) ??
+                    (/^[a-zA-Z0-9_-]{11}$/.test(embeddedId) ? embeddedId : null);
+                if (!id) return _match;
                 const key = `__YOUTUBE_${youtubeIdx++}__`;
-                youtubeMap.set(key, embeddedId);
+                youtubeMap.set(key, id);
                 return key;
             }
         );
 
         // Fallback: promote un-embedded YouTube links (including /live/) into placeholders
         // so users still see the video block + fallback affordance.
+        // Only when the anchor text IS the raw URL (auto-linked), not labelled markdown links.
         html = html.replace(
-            /<a[^>]*href="(https?:\/\/(?:www\.)?(?:youtube\.com|youtu\.be)\/[^"]+)"[^>]*>.*?<\/a>/gi,
-            (match, rawUrl: string) => {
-                const id = extractYouTubeId(rawUrl);
+            /<a[^>]*href="(https?:\/\/(?:www\.)?(?:youtube\.com|youtu\.be)\/[^"]+)"[^>]*>(.*?)<\/a>/gi,
+            (match, rawUrl: string, innerText: string) => {
+                const clean = rawUrl.replace(/&amp;/gi, '&').replace(/&#38;/gi, '&').trim();
+                const textOnly = innerText.replace(/<[^>]*>/g, '').trim();
+                if (textOnly && textOnly !== clean && textOnly !== rawUrl.trim()) return match;
+                const id = extractYouTubeId(clean);
                 if (!id) return match;
                 const key = `__YOUTUBE_${youtubeIdx++}__`;
                 youtubeMap.set(key, id);

--- a/components/blog/PostDetails.tsx
+++ b/components/blog/PostDetails.tsx
@@ -13,12 +13,13 @@ import InteractionBar from '@/components/shared/InteractionBar';
 import SnapieSpeakAudio from '@/components/shared/SnapieSpeakAudio';
 import ThreeSpeakVideoPlayer from '@/components/shared/ThreeSpeakVideoPlayer';
 import TwitterEmbed from '@/components/shared/TwitterEmbed';
-import { isSnapContainer } from '@/lib/utils/snapUtils';
+import { extractYouTubeId, isSnapContainer } from '@/lib/utils/snapUtils';
 
 type BodySegment =
     | { type: 'html'; html: string }
     | { type: 'audio'; url: string }
     | { type: 'speak-video'; author: string; permlink: string }
+    | { type: 'youtube'; videoId: string }
     | { type: 'twitter'; tweetId: string };
 
 interface PostDetailsProps {
@@ -101,6 +102,32 @@ export default function PostDetails({ post, isEmbedMode = false }: PostDetailsPr
             }
         );
 
+        // Extract YouTube wrappers so we can provide an explicit fallback link in-app
+        // when privacy-focused browsers block iframe playback.
+        const youtubeMap = new Map<string, string>();
+        let youtubeIdx = 0;
+        html = html.replace(
+            /<div class="videoWrapper">\s*<iframe[^>]*src="https?:\/\/(?:www\.)?(?:youtube(?:-nocookie)?\.com\/embed\/|youtu\.be\/)([^"?&/]+)[^"]*"[^>]*>\s*<\/iframe>\s*<\/div>/gi,
+            (_match, embeddedId: string) => {
+                const key = `__YOUTUBE_${youtubeIdx++}__`;
+                youtubeMap.set(key, embeddedId);
+                return key;
+            }
+        );
+
+        // Fallback: promote un-embedded YouTube links (including /live/) into placeholders
+        // so users still see the video block + fallback affordance.
+        html = html.replace(
+            /<a[^>]*href="(https?:\/\/(?:www\.)?(?:youtube\.com|youtu\.be)\/[^"]+)"[^>]*>.*?<\/a>/gi,
+            (match, rawUrl: string) => {
+                const id = extractYouTubeId(rawUrl);
+                if (!id) return match;
+                const key = `__YOUTUBE_${youtubeIdx++}__`;
+                youtubeMap.set(key, id);
+                return key;
+            }
+        );
+
         // Extract Twitter embed containers and replace with placeholders so they
         // render as stable <TwitterEmbed> components instead of dangerouslySetInnerHTML.
         const twitterMap = new Map<string, string>();
@@ -140,10 +167,10 @@ export default function PostDetails({ post, isEmbedMode = false }: PostDetailsPr
         const base = rawSegments.length > 0 ? rawSegments : [{ type: 'html' as const, html }];
 
         // Fast path: no extracted embeds
-        if (speakVideoMap.size === 0 && twitterMap.size === 0) return base;
+        if (speakVideoMap.size === 0 && twitterMap.size === 0 && youtubeMap.size === 0) return base;
 
         // Expand speak-video and twitter placeholders within html segments
-        const placeholderRe = /(__SPEAKVIDEO_\d+__|__TWITTER_\d+__)/g;
+        const placeholderRe = /(__SPEAKVIDEO_\d+__|__TWITTER_\d+__|__YOUTUBE_\d+__)/g;
         const expanded: BodySegment[] = [];
         for (const seg of base) {
             if (seg.type !== 'html') { expanded.push(seg); continue; }
@@ -157,6 +184,11 @@ export default function PostDetails({ post, isEmbedMode = false }: PostDetailsPr
                 const tweetId = twitterMap.get(part);
                 if (tweetId) {
                     expanded.push({ type: 'twitter', tweetId });
+                    continue;
+                }
+                const youtubeId = youtubeMap.get(part);
+                if (youtubeId) {
+                    expanded.push({ type: 'youtube', videoId: youtubeId });
                     continue;
                 }
                 if (part) {
@@ -238,6 +270,46 @@ export default function PostDetails({ post, isEmbedMode = false }: PostDetailsPr
                     }
                     if (seg.type === 'twitter') {
                         return <TwitterEmbed key={`twitter-${seg.tweetId}-${i}`} tweetId={seg.tweetId} />;
+                    }
+                    if (seg.type === 'youtube') {
+                        return (
+                            <Box
+                                key={`youtube-${seg.videoId}-${i}`}
+                                position="relative"
+                                w="100%"
+                                maxW={{ base: '100%', md: '640px', lg: '800px' }}
+                                aspectRatio="16/9"
+                                mx="auto"
+                                my={4}
+                                borderRadius="md"
+                                overflow="hidden"
+                                bg="black"
+                            >
+                                <Box
+                                    as="iframe"
+                                    src={`https://www.youtube-nocookie.com/embed/${seg.videoId}`}
+                                    title="YouTube video player"
+                                    loading="lazy"
+                                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                                    allowFullScreen
+                                    w="100%"
+                                    h="100%"
+                                    border="none"
+                                />
+                                <Box position="absolute" bottom={2} right={2} bg="blackAlpha.700" px={2} py={1} borderRadius="sm">
+                                    <Link
+                                        href={`https://www.youtube.com/watch?v=${seg.videoId}`}
+                                        isExternal
+                                        fontSize="xs"
+                                        color="blue.200"
+                                        textDecoration="underline"
+                                        fontWeight="semibold"
+                                    >
+                                        Open on YouTube
+                                    </Link>
+                                </Box>
+                            </Box>
+                        );
                     }
                     return <Box key={`html-${i}`} dangerouslySetInnerHTML={{ __html: seg.html }} />;
                 })}

--- a/components/shared/MediaRenderer.tsx
+++ b/components/shared/MediaRenderer.tsx
@@ -20,6 +20,8 @@ interface MediaRendererProps {
 }
 
 /** Isolated + memoized so parent re-renders do not rewrite iframe innerHTML and reload 3Speak. */
+const EMBED_READY_TIMEOUT_MS = 4000;
+
 const IframeEmbedBox = memo(function IframeEmbedBox({
   item,
   isVertical3Speak,
@@ -27,15 +29,47 @@ const IframeEmbedBox = memo(function IframeEmbedBox({
   item: MediaItem;
   isVertical3Speak: boolean;
 }) {
-  const [embedFailed, setEmbedFailed] = useState(false);
+  const [embedBlocked, setEmbedBlocked] = useState(false);
   const fallback = useMemo(
     () => (item.src ? getEmbedFallback(item.src) : null),
     [item.src]
   );
+  const is3SpeakIframe = Boolean(item.src?.includes("play.3speak.tv"));
 
+  // Brave/CSP blocks often never fire iframe error events; use a readiness timeout for 3Speak
+  // and always show an external link when we have one (YouTube / 3Speak).
   useEffect(() => {
-    setEmbedFailed(false);
-  }, [item.src, item.content]);
+    setEmbedBlocked(false);
+    if (!fallback) return;
+
+    let ready = false;
+
+    const markReady = () => {
+      ready = true;
+      setEmbedBlocked(false);
+    };
+
+    const onMessage = (event: MessageEvent) => {
+      if (event.data?.type === "3speak-player-ready") {
+        markReady();
+      }
+    };
+
+    if (is3SpeakIframe) {
+      window.addEventListener("message", onMessage);
+    }
+
+    const timer = window.setTimeout(() => {
+      if (!ready && is3SpeakIframe) {
+        setEmbedBlocked(true);
+      }
+    }, EMBED_READY_TIMEOUT_MS);
+
+    return () => {
+      window.clearTimeout(timer);
+      window.removeEventListener("message", onMessage);
+    };
+  }, [item.src, item.content, fallback, is3SpeakIframe]);
 
   const sanitizedHtml = useMemo(() => {
     let iframeMarkup = item.content.replace(/<iframe/i, '<iframe loading="lazy"');
@@ -98,22 +132,31 @@ const IframeEmbedBox = memo(function IframeEmbedBox({
         },
       }}
     >
-      <Box
-        dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
-        onLoadCapture={(event) => {
-          const target = event.target as HTMLElement | null;
-          if (target?.tagName.toLowerCase() === 'iframe') {
-            setEmbedFailed(false);
-          }
-        }}
-        onErrorCapture={(event) => {
-          const target = event.target as HTMLElement | null;
-          if (target?.tagName.toLowerCase() === 'iframe') {
-            setEmbedFailed(true);
-          }
-        }}
-      />
-      {embedFailed && fallback && (
+      <Box dangerouslySetInnerHTML={{ __html: sanitizedHtml }} />
+      {fallback && (
+        <Box
+          position="absolute"
+          bottom={2}
+          right={2}
+          bg="blackAlpha.700"
+          px={2}
+          py={1}
+          borderRadius="sm"
+          zIndex={1}
+        >
+          <Link
+            href={fallback.href}
+            isExternal
+            fontSize="xs"
+            color="blue.200"
+            textDecoration="underline"
+            fontWeight="semibold"
+          >
+            {fallback.label}
+          </Link>
+        </Box>
+      )}
+      {embedBlocked && fallback && (
         <Box
           position="absolute"
           inset={0}
@@ -125,6 +168,7 @@ const IframeEmbedBox = memo(function IframeEmbedBox({
           px={4}
           textAlign="center"
           gap={2}
+          zIndex={2}
         >
           <Text fontSize="sm" color="whiteAlpha.900">
             This browser blocked the embedded player.

--- a/components/shared/MediaRenderer.tsx
+++ b/components/shared/MediaRenderer.tsx
@@ -1,4 +1,4 @@
-import { Box, Image } from "@chakra-ui/react";
+import { Box, Image, Link, Text } from "@chakra-ui/react";
 import { useEffect, useMemo, useRef, useState, memo } from "react";
 import VideoRenderer from "@/components/layout/VideoRenderer";
 import {
@@ -8,6 +8,7 @@ import {
   speakPlaybackUrl,
   speakVideoKeyFromUrl,
   finalizeAudio3SpeakEmbedUrl,
+  getEmbedFallback,
 } from "@/lib/utils/snapUtils";
 import SnapieSpeakAudio from "@/components/shared/SnapieSpeakAudio";
 import TwitterEmbed from "@/components/shared/TwitterEmbed";
@@ -26,6 +27,16 @@ const IframeEmbedBox = memo(function IframeEmbedBox({
   item: MediaItem;
   isVertical3Speak: boolean;
 }) {
+  const [embedFailed, setEmbedFailed] = useState(false);
+  const fallback = useMemo(
+    () => (item.src ? getEmbedFallback(item.src) : null),
+    [item.src]
+  );
+
+  useEffect(() => {
+    setEmbedFailed(false);
+  }, [item.src, item.content]);
+
   const sanitizedHtml = useMemo(() => {
     let iframeMarkup = item.content.replace(/<iframe/i, '<iframe loading="lazy"');
     if (item.src?.includes("play.3speak.tv")) {
@@ -73,7 +84,6 @@ const IframeEmbedBox = memo(function IframeEmbedBox({
       aspectRatio={boxAspect}
       maxW={maxW}
       mx="auto"
-      dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
       sx={{
         iframe: {
           width: "100%",
@@ -87,7 +97,44 @@ const IframeEmbedBox = memo(function IframeEmbedBox({
           overflow: "hidden",
         },
       }}
-    />
+    >
+      <Box
+        dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+        onLoadCapture={(event) => {
+          const target = event.target as HTMLElement | null;
+          if (target?.tagName.toLowerCase() === 'iframe') {
+            setEmbedFailed(false);
+          }
+        }}
+        onErrorCapture={(event) => {
+          const target = event.target as HTMLElement | null;
+          if (target?.tagName.toLowerCase() === 'iframe') {
+            setEmbedFailed(true);
+          }
+        }}
+      />
+      {embedFailed && fallback && (
+        <Box
+          position="absolute"
+          inset={0}
+          bg="blackAlpha.700"
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          justifyContent="center"
+          px={4}
+          textAlign="center"
+          gap={2}
+        >
+          <Text fontSize="sm" color="whiteAlpha.900">
+            This browser blocked the embedded player.
+          </Text>
+          <Link href={fallback.href} isExternal color="blue.200" textDecoration="underline" fontWeight="semibold">
+            {fallback.label}
+          </Link>
+        </Box>
+      )}
+    </Box>
   );
 }, (prev, next) => {
   return (

--- a/lib/utils/snapUtils.ts
+++ b/lib/utils/snapUtils.ts
@@ -144,13 +144,15 @@ function fix3SpeakUrl(url: string): string {
 }
 
 /**
- * Extract YouTube video ID from various YouTube URL formats
+ * Extract YouTube video ID from various YouTube URL formats.
+ * Supports watch, short links, shorts, embed, and live routes.
  */
-function extractYouTubeId(url: string): string | null {
+export function extractYouTubeId(url: string): string | null {
   const patterns = [
     /(?:youtube\.com\/watch\?v=|youtu\.be\/)([a-zA-Z0-9_-]{11})/,
     /youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})/,
-    /youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/
+    /youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/,
+    /youtube\.com\/live\/([a-zA-Z0-9_-]{11})/
   ];
   
   for (const pattern of patterns) {
@@ -160,6 +162,49 @@ function extractYouTubeId(url: string): string | null {
     }
   }
   
+  return null;
+}
+
+/**
+ * Build a safe external fallback URL for blocked iframe embeds.
+ * Useful for privacy-focused browsers/extensions that block embedded players.
+ */
+export function getEmbedFallback(src: string): { href: string; label: string } | null {
+  if (!src) return null;
+
+  // YouTube embed variants (youtube.com/embed/* and youtube-nocookie.com/embed/*)
+  if (src.includes('youtube.com/embed/') || src.includes('youtube-nocookie.com/embed/')) {
+    const idMatch = src.match(/\/embed\/([a-zA-Z0-9_-]{11})/i);
+    if (!idMatch?.[1]) return null;
+    return {
+      href: `https://www.youtube.com/watch?v=${idMatch[1]}`,
+      label: 'Open video on YouTube',
+    };
+  }
+
+  // 3Speak embed/watch variants
+  if (src.includes('play.3speak.tv')) {
+    try {
+      const u = new URL(src);
+      const v = u.searchParams.get('v');
+      if (!v) return null;
+      const decoded = decodeURIComponent(v);
+      return {
+        href: `https://3speak.tv/watch?v=${decoded}`,
+        label: 'Open video on 3Speak',
+      };
+    } catch {
+      const m = src.match(/[?&]v=([^&]+)/);
+      if (!m?.[1]) return null;
+      let decoded = m[1];
+      try { decoded = decodeURIComponent(decoded); } catch {}
+      return {
+        href: `https://3speak.tv/watch?v=${decoded}`,
+        label: 'Open video on 3Speak',
+      };
+    }
+  }
+
   return null;
 }
 


### PR DESCRIPTION
## Summary
- harden YouTube ID extraction to support additional URL formats (including `youtube.com/live/...`)
- add shared embed fallback URL helper for blocked iframe scenarios
- improve media embed UX by showing a clear external fallback link when iframe playback fails
- harden `PostDetails` YouTube extraction so renderer-output variations still map to stable embed blocks

## Why
Some privacy-focused browser configurations (e.g. Brave shields/extension mixes) can block iframe playback even when post markdown is valid. This change preserves a usable path to the content and reduces format fragility.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm build`
- [ ] Validate `watch`, `youtu.be`, `shorts`, and `live` YouTube URLs in post body
- [ ] Verify blocked iframe scenario still shows actionable fallback link

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * YouTube video playback: Blog posts now render embedded YouTube videos and convert YouTube links into playable content with responsive player display
  * Fallback links for blocked embeds: When browsers block embedded players, users can access content via external links to YouTube or 3Speak

<!-- end of auto-generated comment: release notes by coderabbit.ai -->