### PR TITLE
fix: soften unread notification row styling

### DIFF
--- a/components/notifications/NotificationsComp.tsx
+++ b/components/notifications/NotificationsComp.tsx
@@ -655,18 +655,24 @@ function NotificationShell({
       w="full"
       spacing={3}
       p={nested ? 3 : 4}
-      bg={unread ? 'secondary' : 'muted'}
+      bg="muted"
+      color="text"
       borderRadius="base"
       align="center"
       position="relative"
       _hover={{ transform: 'translateY(-1px)', boxShadow: 'md' }}
       transition="all 0.15s ease"
       onClick={onClick}
-      sx={
-        unread
-          ? { border: '1px solid rgba(102, 228, 255, 0.18)', borderLeft: '3px solid var(--chakra-colors-primary)' }
-          : { border: '1px solid rgba(102, 228, 255, 0.18)' }
-      }
+      sx={{
+        border: '1px solid rgba(102, 228, 255, 0.18)',
+        ...(unread && {
+          borderLeftWidth: '3px',
+          borderLeftColor: 'var(--chakra-colors-primary)',
+          backgroundColor: 'var(--chakra-colors-muted)',
+          backgroundImage:
+            'linear-gradient(90deg, rgba(24, 168, 255, 0.12) 0%, rgba(24, 168, 255, 0.04) 42%, transparent 72%)',
+        }),
+      }}
     >
       {children}
     </HStack>


### PR DESCRIPTION
## Summary
- Unread notification rows no longer use the bright `secondary` theme background that was hard to read with light text.
- Unread items now share the same dark `muted` base as read rows, with a subtle cyan gradient wash and primary left border accent.

## Test plan
- [ ] Open notifications while logged in with unread items
- [ ] Confirm unread rows are readable and still visually distinct from read rows
- [ ] Check read rows look unchanged
- [ ] Verify nested/grouped unread notifications still show the unread treatment


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated notification component styling with refined visual presentation for unread notifications, including enhanced border treatment and improved visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->