### PR TITLE
feat: Shorts — vertical 3speak video feed

### DIFF
--- a/app/shorts/page.tsx
+++ b/app/shorts/page.tsx
@@ -1,0 +1,11 @@
+import dynamic from 'next/dynamic';
+
+// SSR disabled — Swiper and usePlayer require browser APIs
+const ShortsPlayer = dynamic(() => import('@/components/shorts/ShortsPlayer'), {
+  ssr: false,
+  loading: () => <div style={{ height: '100dvh', background: '#000' }} />,
+});
+
+export default function ShortsPage() {
+  return <ShortsPlayer />;
+}

--- a/components/layout/FooterNavigation.tsx
+++ b/components/layout/FooterNavigation.tsx
@@ -139,6 +139,7 @@ export default function FooterNavigation({ isChatOpen = false, setIsChatOpen, ch
                     <Button
                         as={NextLink}
                         href="/shorts"
+                        aria-label="Shorts"
                         variant="ghost"
                         color="white"
                         size="sm"

--- a/components/layout/FooterNavigation.tsx
+++ b/components/layout/FooterNavigation.tsx
@@ -3,7 +3,7 @@ import { useLoginModal } from '@/contexts/LoginModalContext';
 import { Box, Button, HStack, Icon, Tooltip, useColorMode } from '@chakra-ui/react';
 import { CountBadge } from '@/components/ui/CountBadge';
 import NextLink from 'next/link';
-import { FiBell, FiBook, FiCreditCard, FiHome, FiUser, FiLogIn, FiLogOut, FiMessageSquare, FiChevronLeft, FiChevronRight, FiRadio, FiUserPlus } from 'react-icons/fi';
+import { FiBell, FiBook, FiCreditCard, FiHome, FiUser, FiLogIn, FiLogOut, FiMessageSquare, FiChevronLeft, FiChevronRight, FiRadio, FiUserPlus, FiPlay } from 'react-icons/fi';
 import { useState, useRef, useEffect } from 'react';
 import { useOpenPodsCount } from '@/hooks/useOpenPodsCount';
 import { useHiveNotifications } from '@/hooks/useHiveNotifications';
@@ -132,6 +132,20 @@ export default function FooterNavigation({ isChatOpen = false, setIsChatOpen, ch
                         borderRadius="full"
                         _hover={{ bg: 'whiteAlpha.200', color: 'accent' }}
                         leftIcon={<Icon as={FiBook} boxSize={4} />}
+                    />
+                </Tooltip>
+
+                <Tooltip label="Shorts" aria-label="Shorts tooltip">
+                    <Button
+                        as={NextLink}
+                        href="/shorts"
+                        variant="ghost"
+                        color="white"
+                        size="sm"
+                        minW="40px"
+                        borderRadius="full"
+                        _hover={{ bg: 'whiteAlpha.200', color: 'accent' }}
+                        leftIcon={<Icon as={FiPlay} boxSize={4} />}
                     />
                 </Tooltip>
 

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -184,6 +184,7 @@ export default function Sidebar({ isChatOpen = false, setIsChatOpen, chatUnreadC
                             <Button
                                 as={NextLink}
                                 href="/shorts"
+                                aria-label="Shorts"
                                 variant="ghost"
                                 w="full"
                                 justifyContent={iconJustify}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -6,7 +6,7 @@ import { usePathname } from 'next/navigation';
 import NextLink from 'next/link';
 import { useAioha } from '@aioha/react-ui';
 import { useLoginModal } from '@/contexts/LoginModalContext';
-import { FiHome, FiBell, FiUser, FiShoppingCart, FiBook, FiCreditCard, FiLogIn, FiLogOut, FiMessageSquare, FiRadio, FiInfo, FiUserPlus } from 'react-icons/fi';
+import { FiHome, FiBell, FiUser, FiShoppingCart, FiBook, FiCreditCard, FiLogIn, FiLogOut, FiMessageSquare, FiRadio, FiInfo, FiUserPlus, FiPlay } from 'react-icons/fi';
 import { getCommunityInfo, getProfile } from '@/lib/hive/client-functions';
 import { animate, color, motion, px } from 'framer-motion';
 import { getHiveAvatarUrl } from '@/lib/utils/avatarUtils';
@@ -176,6 +176,23 @@ export default function Sidebar({ isChatOpen = false, setIsChatOpen, chatUnreadC
                                 _hover={{ bg: 'rgba(24, 168, 255, 0.14)', color: 'accent' }}
                             >
                                 <Text display={textDisplay}>Blog</Text>
+                            </Button>
+                        </Box>
+                    </Tooltip>
+                    <Tooltip label="Shorts" placement="right" hasArrow isDisabled={!isCompactMode}>
+                        <Box w="full">
+                            <Button
+                                as={NextLink}
+                                href="/shorts"
+                                variant="ghost"
+                                w="full"
+                                justifyContent={iconJustify}
+                                leftIcon={<Icon as={FiPlay} boxSize={4} />}
+                                px={3}
+                                borderRadius="10px"
+                                _hover={{ bg: 'rgba(24, 168, 255, 0.14)', color: 'accent' }}
+                            >
+                                <Text display={textDisplay}>Shorts</Text>
                             </Button>
                         </Box>
                     </Tooltip>

--- a/components/shorts/ShortCard.tsx
+++ b/components/shorts/ShortCard.tsx
@@ -1,0 +1,202 @@
+'use client';
+import {
+  Box, Flex, Text, Image, VStack, IconButton, useDisclosure, useToast,
+} from '@chakra-ui/react';
+import { usePlayer } from '@mantequilla-soft/3speak-player/react';
+import { FaHeart, FaRegHeart, FaComment, FaShare } from 'react-icons/fa';
+import { ShortItem } from '@/lib/shorts/types';
+import { useState } from 'react';
+import { useAioha } from '@aioha/react-ui';
+import { vote } from '@/lib/hive/client-functions';
+import ShortsCommentSheet from './ShortsCommentSheet';
+
+function ShortVideoPlayer({ author, permlink }: { author: string; permlink: string }) {
+  const { ref } = usePlayer({
+    apiBase: 'https://play.3speak.tv',
+    autoLoad: `${author}/${permlink}`,
+    autoPlay: true,
+    muted: true,
+    poster: false,
+    hlsConfig: {
+      maxBufferLength: 30,
+      maxMaxBufferLength: 60,
+      maxBufferSize: 30 * 1000 * 1000,
+    },
+  });
+
+  return (
+    <video
+      ref={ref}
+      autoPlay
+      playsInline
+      muted
+      loop
+      style={{
+        position: 'absolute',
+        inset: 0,
+        width: '100%',
+        height: '100%',
+        objectFit: 'cover',
+        background: '#000',
+      }}
+    />
+  );
+}
+
+interface ShortCardProps {
+  short: ShortItem;
+  isActive: boolean;
+}
+
+export default function ShortCard({ short, isActive }: ShortCardProps) {
+  const { isOpen: commentsOpen, onOpen: openComments, onClose: closeComments } = useDisclosure();
+  const [liked, setLiked] = useState(false);
+  const [likeCount, setLikeCount] = useState(short.stats.likes);
+  const { user } = useAioha();
+  const toast = useToast();
+
+  async function handleLike() {
+    if (!user) {
+      toast({ title: 'Login to like', status: 'info', duration: 2000, isClosable: true });
+      return;
+    }
+    if (liked) return;
+    const prev = likeCount;
+    setLiked(true);
+    setLikeCount(p => p + 1);
+    try {
+      const result = await vote({ username: user, author: short.author, permlink: short.hivePermlink, weight: 10000 });
+      if (!result.success) {
+        setLiked(false);
+        setLikeCount(prev);
+        toast({ title: 'Vote failed', status: 'error', duration: 2000, isClosable: true });
+      }
+    } catch {
+      setLiked(false);
+      setLikeCount(prev);
+    }
+  }
+
+  function handleShare() {
+    const url = `https://3speak.tv/watch?v=${short.author}/${short.hivePermlink}`;
+    if (typeof navigator !== 'undefined' && navigator.share) {
+      navigator.share({ url }).catch(() => {});
+    } else {
+      navigator.clipboard?.writeText(url);
+      toast({ title: 'Link copied', status: 'success', duration: 2000, isClosable: true });
+    }
+  }
+
+  return (
+    <Box position="relative" w="100%" h="100%" bg="black" overflow="hidden">
+      {/* Player or thumbnail */}
+      {isActive ? (
+        <ShortVideoPlayer author={short.author} permlink={short.hivePermlink} />
+      ) : (
+        short.thumbnailUrl && (
+          <Image
+            src={short.thumbnailUrl}
+            alt={short.title}
+            position="absolute"
+            inset="0"
+            w="100%"
+            h="100%"
+            objectFit="cover"
+          />
+        )
+      )}
+
+      {/* Bottom gradient */}
+      <Box
+        position="absolute"
+        bottom={0}
+        left={0}
+        right={0}
+        h="55%"
+        bgGradient="linear(to-t, blackAlpha.900, transparent)"
+        pointerEvents="none"
+      />
+
+      {/* Author + title */}
+      <Box position="absolute" bottom={8} left={4} right="80px" zIndex={2}>
+        <Flex align="center" mb={2} gap={2}>
+          <Image
+            src={`https://images.hive.blog/u/${short.author}/avatar/sm`}
+            borderRadius="full"
+            boxSize="34px"
+            border="2px solid white"
+            alt={short.author}
+            fallbackSrc="https://images.hive.blog/DQmb2DQKTTRSZ8vNn5yppkcMbNnsSHzPeLsz5H5Kzgh2KuM/user.png"
+          />
+          <Text color="white" fontWeight="bold" fontSize="sm">@{short.author}</Text>
+          {short.timeAgo && (
+            <Text color="whiteAlpha.700" fontSize="xs">{short.timeAgo}</Text>
+          )}
+        </Flex>
+        {short.title && (
+          <Text color="white" fontSize="sm" noOfLines={2} lineHeight="1.4">
+            {short.title}
+          </Text>
+        )}
+      </Box>
+
+      {/* Right-rail actions */}
+      <VStack
+        position="absolute"
+        right={3}
+        bottom={10}
+        spacing={5}
+        align="center"
+        zIndex={2}
+      >
+        <VStack spacing={0}>
+          <IconButton
+            aria-label="Like"
+            icon={liked ? <FaHeart /> : <FaRegHeart />}
+            variant="ghost"
+            color={liked ? 'red.400' : 'white'}
+            fontSize="24px"
+            size="lg"
+            onClick={handleLike}
+            _hover={{ bg: 'whiteAlpha.200' }}
+          />
+          <Text color="white" fontSize="xs" fontWeight="bold">{likeCount}</Text>
+        </VStack>
+
+        <VStack spacing={0}>
+          <IconButton
+            aria-label="Comments"
+            icon={<FaComment />}
+            variant="ghost"
+            color="white"
+            fontSize="22px"
+            size="lg"
+            onClick={openComments}
+            _hover={{ bg: 'whiteAlpha.200' }}
+          />
+          <Text color="white" fontSize="xs" fontWeight="bold">{short.stats.comments}</Text>
+        </VStack>
+
+        <IconButton
+          aria-label="Share"
+          icon={<FaShare />}
+          variant="ghost"
+          color="white"
+          fontSize="22px"
+          size="lg"
+          onClick={handleShare}
+          _hover={{ bg: 'whiteAlpha.200' }}
+        />
+      </VStack>
+
+      {/* Comments drawer - stays mounted over the swiper */}
+      <ShortsCommentSheet
+        isOpen={commentsOpen}
+        onClose={closeComments}
+        author={short.author}
+        permlink={short.hivePermlink}
+        commentCount={short.stats.comments}
+      />
+    </Box>
+  );
+}

--- a/components/shorts/ShortCard.tsx
+++ b/components/shorts/ShortCard.tsx
@@ -103,7 +103,7 @@ export default function ShortCard({ short, isActive, isNext }: ShortCardProps) {
     <Box position="relative" w="100%" h="100%" bg="black" overflow="hidden">
       {/* Active: playing. Next: mounted but invisible (HLS buffers silently). Others: thumbnail. */}
       {(isActive || isNext) ? (
-        <ShortVideoPlayer author={short.author} permlink={short.hivePermlink} autoPlay={isActive} />
+        <ShortVideoPlayer author={short.author} permlink={short.permlink} autoPlay={isActive} />
       ) : (
         short.thumbnailUrl && (
           <Image

--- a/components/shorts/ShortCard.tsx
+++ b/components/shorts/ShortCard.tsx
@@ -10,11 +10,19 @@ import { useAioha } from '@aioha/react-ui';
 import { vote } from '@/lib/hive/client-functions';
 import ShortsCommentSheet from './ShortsCommentSheet';
 
-function ShortVideoPlayer({ author, permlink }: { author: string; permlink: string }) {
+function ShortVideoPlayer({
+  author,
+  permlink,
+  autoPlay,
+}: {
+  author: string;
+  permlink: string;
+  autoPlay: boolean;
+}) {
   const { ref } = usePlayer({
     apiBase: 'https://play.3speak.tv',
     autoLoad: `${author}/${permlink}`,
-    autoPlay: true,
+    autoPlay,
     muted: true,
     poster: false,
     hlsConfig: {
@@ -27,10 +35,10 @@ function ShortVideoPlayer({ author, permlink }: { author: string; permlink: stri
   return (
     <video
       ref={ref}
-      autoPlay
+      autoPlay={autoPlay}
       playsInline
       muted
-      loop
+      loop={autoPlay}
       style={{
         position: 'absolute',
         inset: 0,
@@ -38,6 +46,9 @@ function ShortVideoPlayer({ author, permlink }: { author: string; permlink: stri
         height: '100%',
         objectFit: 'cover',
         background: '#000',
+        // Invisible preload: HLS buffers silently, zero visual footprint
+        opacity: autoPlay ? 1 : 0,
+        pointerEvents: autoPlay ? 'auto' : 'none',
       }}
     />
   );
@@ -46,9 +57,10 @@ function ShortVideoPlayer({ author, permlink }: { author: string; permlink: stri
 interface ShortCardProps {
   short: ShortItem;
   isActive: boolean;
+  isNext: boolean;
 }
 
-export default function ShortCard({ short, isActive }: ShortCardProps) {
+export default function ShortCard({ short, isActive, isNext }: ShortCardProps) {
   const { isOpen: commentsOpen, onOpen: openComments, onClose: closeComments } = useDisclosure();
   const [liked, setLiked] = useState(false);
   const [likeCount, setLikeCount] = useState(short.stats.likes);
@@ -89,9 +101,9 @@ export default function ShortCard({ short, isActive }: ShortCardProps) {
 
   return (
     <Box position="relative" w="100%" h="100%" bg="black" overflow="hidden">
-      {/* Player or thumbnail */}
-      {isActive ? (
-        <ShortVideoPlayer author={short.author} permlink={short.hivePermlink} />
+      {/* Active: playing. Next: mounted but invisible (HLS buffers silently). Others: thumbnail. */}
+      {(isActive || isNext) ? (
+        <ShortVideoPlayer author={short.author} permlink={short.hivePermlink} autoPlay={isActive} />
       ) : (
         short.thumbnailUrl && (
           <Image

--- a/components/shorts/ShortCard.tsx
+++ b/components/shorts/ShortCard.tsx
@@ -3,9 +3,9 @@ import {
   Box, Flex, Text, Image, VStack, IconButton, useDisclosure, useToast,
 } from '@chakra-ui/react';
 import { usePlayer } from '@mantequilla-soft/3speak-player/react';
-import { FaHeart, FaRegHeart, FaComment, FaShare } from 'react-icons/fa';
+import { FaHeart, FaRegHeart, FaComment, FaShare, FaVolumeUp, FaVolumeMute } from 'react-icons/fa';
 import { ShortItem } from '@/lib/shorts/types';
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAioha } from '@aioha/react-ui';
 import { vote } from '@/lib/hive/client-functions';
 import ShortsCommentSheet from './ShortsCommentSheet';
@@ -14,16 +14,21 @@ function ShortVideoPlayer({
   author,
   permlink,
   autoPlay,
+  muted,
 }: {
   author: string;
   permlink: string;
   autoPlay: boolean;
+  muted: boolean;
 }) {
-  const { ref } = usePlayer({
+  // usePlayer returns a callback ref, not a RefObject — we can't read .current from it.
+  // Capture the element ourselves via a combined ref so we can imperatively toggle muted.
+  const localRef = useRef<HTMLVideoElement | null>(null);
+  const { ref: playerCallbackRef } = usePlayer({
     apiBase: 'https://play.3speak.tv',
     autoLoad: `${author}/${permlink}`,
     autoPlay,
-    muted: true,
+    muted: true, // always start muted — autoplay requires it; we flip it below
     poster: false,
     hlsConfig: {
       maxBufferLength: 30,
@@ -32,9 +37,25 @@ function ShortVideoPlayer({
     },
   });
 
+  const combinedRef = useCallback(
+    (el: HTMLVideoElement | null) => {
+      localRef.current = el;
+      playerCallbackRef(el);
+    },
+    [playerCallbackRef],
+  );
+
+  // React's `muted` JSX prop is broken — setting it false via JSX does nothing.
+  // Mutate the DOM element directly whenever the muted preference changes.
+  useEffect(() => {
+    if (localRef.current) {
+      localRef.current.muted = muted;
+    }
+  }, [muted]);
+
   return (
     <video
-      ref={ref}
+      ref={combinedRef}
       autoPlay={autoPlay}
       playsInline
       muted
@@ -46,7 +67,6 @@ function ShortVideoPlayer({
         height: '100%',
         objectFit: 'cover',
         background: '#000',
-        // Invisible preload: HLS buffers silently, zero visual footprint
         opacity: autoPlay ? 1 : 0,
         pointerEvents: autoPlay ? 'auto' : 'none',
       }}
@@ -58,9 +78,11 @@ interface ShortCardProps {
   short: ShortItem;
   isActive: boolean;
   isNext: boolean;
+  muted: boolean;
+  onToggleMute: () => void;
 }
 
-export default function ShortCard({ short, isActive, isNext }: ShortCardProps) {
+export default function ShortCard({ short, isActive, isNext, muted, onToggleMute }: ShortCardProps) {
   const { isOpen: commentsOpen, onOpen: openComments, onClose: closeComments } = useDisclosure();
   const [liked, setLiked] = useState(false);
   const [likeCount, setLikeCount] = useState(short.stats.likes);
@@ -103,7 +125,12 @@ export default function ShortCard({ short, isActive, isNext }: ShortCardProps) {
     <Box position="relative" w="100%" h="100%" bg="black" overflow="hidden">
       {/* Active: playing. Next: mounted but invisible (HLS buffers silently). Others: thumbnail. */}
       {(isActive || isNext) ? (
-        <ShortVideoPlayer author={short.author} permlink={short.permlink} autoPlay={isActive} />
+        <ShortVideoPlayer
+          author={short.author}
+          permlink={short.permlink}
+          autoPlay={isActive}
+          muted={isNext ? true : muted}
+        />
       ) : (
         short.thumbnailUrl && (
           <Image
@@ -161,6 +188,20 @@ export default function ShortCard({ short, isActive, isNext }: ShortCardProps) {
         align="center"
         zIndex={2}
       >
+        {/* Mute toggle — only shown on active slide */}
+        {isActive && (
+          <IconButton
+            aria-label={muted ? 'Unmute' : 'Mute'}
+            icon={muted ? <FaVolumeMute /> : <FaVolumeUp />}
+            variant="ghost"
+            color="white"
+            fontSize="22px"
+            size="lg"
+            onClick={onToggleMute}
+            _hover={{ bg: 'whiteAlpha.200' }}
+          />
+        )}
+
         <VStack spacing={0}>
           <IconButton
             aria-label="Like"

--- a/components/shorts/ShortCard.tsx
+++ b/components/shorts/ShortCard.tsx
@@ -116,8 +116,10 @@ export default function ShortCard({ short, isActive, isNext, muted, onToggleMute
     if (typeof navigator !== 'undefined' && navigator.share) {
       navigator.share({ url }).catch(() => {});
     } else {
-      navigator.clipboard?.writeText(url);
-      toast({ title: 'Link copied', status: 'success', duration: 2000, isClosable: true });
+      navigator.clipboard?.writeText(url).then(
+        () => toast({ title: 'Link copied', status: 'success', duration: 2000, isClosable: true }),
+        () => toast({ title: 'Copy failed', status: 'error', duration: 2000, isClosable: true }),
+      );
     }
   }
 

--- a/components/shorts/ShortsCommentSheet.tsx
+++ b/components/shorts/ShortsCommentSheet.tsx
@@ -63,7 +63,7 @@ export default function ShortsCommentSheet({
               <VStack spacing={1} align="stretch">
                 {(comments as ExtendedComment[]).map((c) => (
                   <Snap
-                    key={c.permlink}
+                    key={`${c.author}/${c.permlink}`}
                     comment={c}
                     onOpen={openReply}
                     setReply={(r) => setReply(r as Comment)}

--- a/components/shorts/ShortsCommentSheet.tsx
+++ b/components/shorts/ShortsCommentSheet.tsx
@@ -1,0 +1,88 @@
+'use client';
+import {
+  Drawer, DrawerOverlay, DrawerContent, DrawerHeader,
+  DrawerBody, DrawerCloseButton, Spinner, Text, VStack, Box, useDisclosure,
+} from '@chakra-ui/react';
+import { useComments, ExtendedComment } from '@/hooks/useComments';
+import { useHiveUser } from '@/contexts/UserContext';
+import Snap from '@/components/homepage/Snap';
+import { useState } from 'react';
+import SnapReplyModal from '@/components/homepage/SnapReplyModal';
+import { Comment } from '@hiveio/dhive';
+
+interface ShortsCommentSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  author: string;
+  permlink: string;
+  commentCount: number;
+}
+
+export default function ShortsCommentSheet({
+  isOpen,
+  onClose,
+  author,
+  permlink,
+  commentCount,
+}: ShortsCommentSheetProps) {
+  const { hiveUser } = useHiveUser();
+  const { comments, isLoading, addComment } = useComments(author, permlink, false, hiveUser?.name);
+  const [reply, setReply] = useState<Comment | null>(null);
+  const { isOpen: replyOpen, onOpen: openReply, onClose: closeReply } = useDisclosure();
+
+  return (
+    <>
+      <Drawer isOpen={isOpen} onClose={onClose} placement="bottom" size="full">
+        <DrawerOverlay bg="blackAlpha.700" />
+        <DrawerContent
+          bg="rgba(8, 24, 40, 0.97)"
+          borderTopRadius="16px"
+          backdropFilter="blur(18px)"
+          maxH="75dvh"
+        >
+          <DrawerCloseButton color="white" />
+          <DrawerHeader
+            fontSize="md"
+            fontWeight="semibold"
+            borderBottom="1px solid"
+            borderColor="rgba(102, 228, 255, 0.12)"
+            color="white"
+          >
+            {commentCount} Comments
+          </DrawerHeader>
+          <DrawerBody overflowY="auto" pb={8} px={2}>
+            {isLoading ? (
+              <Box textAlign="center" py={10}>
+                <Spinner color="blue.300" size="lg" />
+              </Box>
+            ) : comments.length === 0 ? (
+              <Text color="gray.500" textAlign="center" py={10} fontSize="sm">
+                No comments yet. Be the first!
+              </Text>
+            ) : (
+              <VStack spacing={1} align="stretch">
+                {(comments as ExtendedComment[]).map((c) => (
+                  <Snap
+                    key={c.permlink}
+                    comment={c}
+                    onOpen={openReply}
+                    setReply={(r) => setReply(r as Comment)}
+                  />
+                ))}
+              </VStack>
+            )}
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
+
+      {reply && (
+        <SnapReplyModal
+          isOpen={replyOpen}
+          onClose={closeReply}
+          comment={reply}
+          onNewReply={(newComment) => addComment(newComment as Comment)}
+        />
+      )}
+    </>
+  );
+}

--- a/components/shorts/ShortsPlayer.tsx
+++ b/components/shorts/ShortsPlayer.tsx
@@ -10,6 +10,7 @@ import ShortCard from './ShortCard';
 export default function ShortsPlayer() {
   const { shorts, loading, error, hasMore, load } = useShorts();
   const [activeIndex, setActiveIndex] = useState(0);
+  const [muted, setMuted] = useState(true);
 
   useEffect(() => {
     load(true);
@@ -61,6 +62,8 @@ export default function ShortsPlayer() {
               short={short}
               isActive={i === activeIndex}
               isNext={i === activeIndex + 1}
+              muted={muted}
+              onToggleMute={() => setMuted(m => !m)}
             />
           </SwiperSlide>
         ))}

--- a/components/shorts/ShortsPlayer.tsx
+++ b/components/shorts/ShortsPlayer.tsx
@@ -1,0 +1,74 @@
+'use client';
+import { Box, Center, Spinner, Text, Button } from '@chakra-ui/react';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Mousewheel, Keyboard } from 'swiper/modules';
+import 'swiper/css';
+import { useEffect, useState, useCallback } from 'react';
+import { useShorts } from '@/hooks/useShorts';
+import ShortCard from './ShortCard';
+
+export default function ShortsPlayer() {
+  const { shorts, loading, error, hasMore, load } = useShorts();
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    load(true);
+  }, [load]);
+
+  const onSlideChange = useCallback(
+    (swiper: any) => {
+      setActiveIndex(swiper.activeIndex);
+      if (swiper.activeIndex >= shorts.length - 3 && hasMore && !loading) {
+        load();
+      }
+    },
+    [shorts.length, hasMore, loading, load],
+  );
+
+  if (loading && shorts.length === 0) {
+    return (
+      <Center h="100dvh" bg="black">
+        <Spinner size="xl" color="blue.400" thickness="3px" />
+      </Center>
+    );
+  }
+
+  if (error && shorts.length === 0) {
+    return (
+      <Center h="100dvh" bg="black" flexDir="column" gap={4}>
+        <Text color="red.400">Failed to load shorts</Text>
+        <Button onClick={() => load(true)} colorScheme="blue" size="sm">
+          Retry
+        </Button>
+      </Center>
+    );
+  }
+
+  return (
+    <Box h="100dvh" overflow="hidden" bg="black">
+      <Swiper
+        direction="vertical"
+        slidesPerView={1}
+        modules={[Mousewheel, Keyboard]}
+        mousewheel={{ sensitivity: 1, thresholdDelta: 10 }}
+        keyboard={{ enabled: true }}
+        onSlideChange={onSlideChange}
+        style={{ height: '100%', width: '100%' }}
+      >
+        {shorts.map((short, i) => (
+          <SwiperSlide key={short.id} style={{ height: '100%' }}>
+            <ShortCard short={short} isActive={i === activeIndex} />
+          </SwiperSlide>
+        ))}
+
+        {(loading || hasMore) && (
+          <SwiperSlide style={{ height: '100%' }}>
+            <Center h="100%" bg="black">
+              <Spinner color="blue.400" thickness="2px" />
+            </Center>
+          </SwiperSlide>
+        )}
+      </Swiper>
+    </Box>
+  );
+}

--- a/components/shorts/ShortsPlayer.tsx
+++ b/components/shorts/ShortsPlayer.tsx
@@ -57,7 +57,11 @@ export default function ShortsPlayer() {
       >
         {shorts.map((short, i) => (
           <SwiperSlide key={short.id} style={{ height: '100%' }}>
-            <ShortCard short={short} isActive={i === activeIndex} />
+            <ShortCard
+              short={short}
+              isActive={i === activeIndex}
+              isNext={i === activeIndex + 1}
+            />
           </SwiperSlide>
         ))}
 

--- a/hooks/useShorts.ts
+++ b/hooks/useShorts.ts
@@ -1,0 +1,92 @@
+'use client';
+import { useState, useCallback, useRef } from 'react';
+import { ShortItem } from '@/lib/shorts/types';
+
+const CHECKER_URL = process.env.NEXT_PUBLIC_CHECKER_URL || 'https://3speak-checker.okinoko.io';
+const SHORTS_API = `${CHECKER_URL}/shortssorted`;
+
+let seed = Math.floor(Math.random() * 1_000_000);
+
+function parseEmbedUrl(embedUrl: string): { author: string; permlink: string } {
+  const cleaned = (embedUrl || '').replace(/^@/, '');
+  const slashIdx = cleaned.indexOf('/');
+  if (slashIdx === -1) return { author: cleaned, permlink: '' };
+  return { author: cleaned.slice(0, slashIdx), permlink: cleaned.slice(slashIdx + 1) };
+}
+
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return 'Just now';
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+async function fetchPage(page: number, limit: number): Promise<{ shorts: ShortItem[]; hasMore: boolean }> {
+  const url = `${SHORTS_API}?page=${page}&limit=${limit}&seed=${seed}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Shorts API error: ${res.status}`);
+  const data = await res.json();
+
+  const shorts: ShortItem[] = (data.shorts || []).map((s: any) => {
+    const { author, permlink: hivePermlink } = parseEmbedUrl(s.embed_url || '');
+    const finalAuthor = author || s.owner || '';
+    return {
+      id: `${finalAuthor}-${s.permlink}-${s.createdAt}`,
+      author: finalAuthor,
+      hivePermlink,
+      permlink: s.permlink,
+      thumbnailUrl: s.thumbnail_url || '',
+      title: s.hive_title || s.embed_title || '',
+      views: s.views || 0,
+      timeAgo: timeAgo(s.createdAt || ''),
+      stats: {
+        likes: s.hive_votes || 0,
+        comments: s.hive_comments || 0,
+        payout: s.hive_reward != null ? String(s.hive_reward) : '0.00',
+      },
+    };
+  });
+
+  return { shorts, hasMore: (data.page ?? 1) < (data.totalPages ?? 1) };
+}
+
+export function useShorts() {
+  const [shorts, setShorts] = useState<ShortItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(true);
+  const pageRef = useRef(1);
+  const inflightRef = useRef(false);
+
+  const load = useCallback(async (reset = false) => {
+    if (inflightRef.current) return;
+    inflightRef.current = true;
+
+    if (reset) {
+      seed = Math.floor(Math.random() * 1_000_000);
+      pageRef.current = 1;
+      setShorts([]);
+      setHasMore(true);
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const { shorts: newShorts, hasMore: more } = await fetchPage(pageRef.current, 10);
+      setShorts(prev => (reset ? newShorts : [...prev, ...newShorts]));
+      setHasMore(more);
+      pageRef.current += 1;
+    } catch (e: any) {
+      setError(e.message || 'Failed to load shorts');
+    } finally {
+      setLoading(false);
+      inflightRef.current = false;
+    }
+  }, []);
+
+  return { shorts, loading, error, hasMore, load };
+}

--- a/hooks/useShorts.ts
+++ b/hooks/useShorts.ts
@@ -15,7 +15,9 @@ function parseEmbedUrl(embedUrl: string): { author: string; permlink: string } {
 }
 
 function timeAgo(dateStr: string): string {
-  const diff = Date.now() - new Date(dateStr).getTime();
+  const date = new Date(dateStr);
+  if (!dateStr || !isFinite(date.getTime())) return '';
+  const diff = Date.now() - date.getTime();
   const s = Math.floor(diff / 1000);
   if (s < 60) return 'Just now';
   const m = Math.floor(s / 60);
@@ -61,14 +63,18 @@ export function useShorts() {
   const [hasMore, setHasMore] = useState(true);
   const pageRef = useRef(1);
   const inflightRef = useRef(false);
+  const failedPageRef = useRef<number | null>(null);
 
   const load = useCallback(async (reset = false) => {
     if (inflightRef.current) return;
+    // Skip a page that already failed to prevent a hot retry loop
+    if (!reset && failedPageRef.current === pageRef.current) return;
     inflightRef.current = true;
 
     if (reset) {
       seed = Math.floor(Math.random() * 1_000_000);
       pageRef.current = 1;
+      failedPageRef.current = null;
       setShorts([]);
       setHasMore(true);
     }
@@ -77,10 +83,12 @@ export function useShorts() {
     setError(null);
     try {
       const { shorts: newShorts, hasMore: more } = await fetchPage(pageRef.current, 10);
+      failedPageRef.current = null;
       setShorts(prev => (reset ? newShorts : [...prev, ...newShorts]));
       setHasMore(more);
       pageRef.current += 1;
     } catch (e: any) {
+      failedPageRef.current = pageRef.current;
       setError(e.message || 'Failed to load shorts');
     } finally {
       setLoading(false);

--- a/lib/shorts/types.ts
+++ b/lib/shorts/types.ts
@@ -1,0 +1,15 @@
+export interface ShortItem {
+  id: string;
+  author: string;
+  hivePermlink: string;
+  permlink: string;
+  thumbnailUrl: string;
+  title: string;
+  views: number;
+  timeAgo: string;
+  stats: {
+    likes: number;
+    comments: number;
+    payout: string;
+  };
+}


### PR DESCRIPTION
## Summary

- Adds a full-screen vertical Shorts feed at `/shorts`, backed by the 3speak checker API (`3speak-checker.okinoko.io/shortssorted`)
- All shorts from any 3speak-compatible frontend (Snapie, Ecency, etc.) appear in a randomized order that changes every session (seed-based shuffle)
- **Sidebar** (desktop) and **footer nav** (mobile) both get a Shorts entry (play icon)

## How it works

- `useShorts` hook fetches paginated shorts, parses `@author/permlink` embed URLs, and manages infinite scroll (next page fires when 3 slides from the end)
- **Vertical Swiper** (`swiper/react`, mousewheel + keyboard) — one short per slide, full-screen
- **Background preloading**: the next slide's HLS stream buffers silently while you watch the current one — near-instant swipe
- **Video player**: reuses existing `@mantequilla-soft/3speak-player` SDK already in the app
- **Comments drawer**: tapping the comment icon opens a Chakra bottom `Drawer` overlaid on the swiper — doom-scroll position is fully preserved, no navigation away
- **Mute toggle**: videos start muted (browser autoplay requirement); a speaker button in the right rail lets users unmute, and that preference carries across every swipe
- **Voting**: like button calls the existing Aioha vote infrastructure (`weight: 10000`)
- **Share**: native share sheet on mobile, clipboard fallback on desktop

## New env var

```
NEXT_PUBLIC_CHECKER_URL=https://3speak-checker.okinoko.io
```

(already added to `.env`)

## New files

```
app/shorts/page.tsx
components/shorts/ShortsPlayer.tsx
components/shorts/ShortCard.tsx
components/shorts/ShortsCommentSheet.tsx
hooks/useShorts.ts
lib/shorts/types.ts
```

## Test plan

- [ ] Navigate to `/shorts` — spinner then first short plays
- [ ] Scroll/swipe down — transitions to next short, previous stops
- [ ] Tap speaker icon — audio unmutes and stays unmuted on next swipes
- [ ] Tap comment icon — drawer slides up, comments load, swiper stays put
- [ ] Scroll to bottom of feed — new page loads automatically
- [ ] Reload page — different ordering (seed regenerates)
- [ ] Mobile: footer nav shows Shorts icon and navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Shorts section with vertical video feed
  * Added Shorts navigation to sidebar and footer
  * Video cards include mute, like, comments, and share controls
  * Like functionality displays live count
  * Comments section supports replies
  * Share videos via native share or clipboard copy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->