### PR TITLE
fix: shorts preload plays on swipe, covers both directions

### DIFF
--- a/components/shorts/ShortCard.tsx
+++ b/components/shorts/ShortCard.tsx
@@ -45,6 +45,18 @@ function ShortVideoPlayer({
     [playerCallbackRef],
   );
 
+  // usePlayer only reads autoPlay at mount and never re-triggers play/pause on prop changes.
+  // When a preloaded slide becomes active (or vice versa), drive it imperatively.
+  useEffect(() => {
+    const el = localRef.current;
+    if (!el) return;
+    if (autoPlay) {
+      el.play().catch(() => {});
+    } else {
+      el.pause();
+    }
+  }, [autoPlay]);
+
   // React's `muted` JSX prop is broken — setting it false via JSX does nothing.
   // Mutate the DOM element directly whenever the muted preference changes.
   useEffect(() => {
@@ -77,12 +89,12 @@ function ShortVideoPlayer({
 interface ShortCardProps {
   short: ShortItem;
   isActive: boolean;
-  isNext: boolean;
+  isPreload: boolean;
   muted: boolean;
   onToggleMute: () => void;
 }
 
-export default function ShortCard({ short, isActive, isNext, muted, onToggleMute }: ShortCardProps) {
+export default function ShortCard({ short, isActive, isPreload, muted, onToggleMute }: ShortCardProps) {
   const { isOpen: commentsOpen, onOpen: openComments, onClose: closeComments } = useDisclosure();
   const [liked, setLiked] = useState(false);
   const [likeCount, setLikeCount] = useState(short.stats.likes);
@@ -126,12 +138,12 @@ export default function ShortCard({ short, isActive, isNext, muted, onToggleMute
   return (
     <Box position="relative" w="100%" h="100%" bg="black" overflow="hidden">
       {/* Active: playing. Next: mounted but invisible (HLS buffers silently). Others: thumbnail. */}
-      {(isActive || isNext) ? (
+      {(isActive || isPreload) ? (
         <ShortVideoPlayer
           author={short.author}
           permlink={short.permlink}
           autoPlay={isActive}
-          muted={isNext ? true : muted}
+          muted={isPreload ? true : muted}
         />
       ) : (
         short.thumbnailUrl && (

--- a/components/shorts/ShortsPlayer.tsx
+++ b/components/shorts/ShortsPlayer.tsx
@@ -61,7 +61,7 @@ export default function ShortsPlayer() {
             <ShortCard
               short={short}
               isActive={i === activeIndex}
-              isNext={i === activeIndex + 1}
+              isPreload={i === activeIndex - 1 || i === activeIndex + 1}
               muted={muted}
               onToggleMute={() => setMuted(m => !m)}
             />


### PR DESCRIPTION
## What was broken

Two bugs introduced in #108:

**1. Preloaded shorts never played on swipe**
`usePlayer` reads `autoPlay` only at mount — changing the prop after the fact does nothing. The slide adjacent to the active one was preloading HLS in the background (good), but sat there buffered and paused forever when you swiped to it.

**Fix:** Added a `useEffect` inside `ShortVideoPlayer` that imperatively calls `video.play()` / `video.pause()` whenever `autoPlay` changes. The moment a preloaded slide becomes active, playback starts.

**2. Preload was forward-only**
`isNext={i === activeIndex + 1}` meant swiping backward always loaded cold. You'd notice a delay going back but not going forward (until bug #1 was also in play).

**Fix:** Renamed to `isPreload`, covers `activeIndex ± 1` so HLS buffers in both directions.

## Test plan

- [ ] Swipe forward — next short plays immediately (no spinner wait)
- [ ] Swipe backward — previous short resumes immediately
- [ ] Mute state persists across swipes in both directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)