### PR TITLE
fix: image lightbox portal rendering + X close button

### DIFF
--- a/components/shared/MediaRenderer.tsx
+++ b/components/shared/MediaRenderer.tsx
@@ -1,5 +1,7 @@
-import { Box, Image, Link, Text } from "@chakra-ui/react";
+import { Box, Image, Link, Text, IconButton } from "@chakra-ui/react";
 import { useEffect, useMemo, useRef, useState, memo } from "react";
+import { createPortal } from "react-dom";
+import { FiX } from "react-icons/fi";
 import ImageCarousel from "@/components/shared/ImageCarousel";
 import VideoRenderer from "@/components/layout/VideoRenderer";
 import {
@@ -268,7 +270,7 @@ const MediaRenderer = ({ mediaContent }: MediaRendererProps) => {
 
   return (
     <Box mb={4} ref={wrapperRef} data-snapie-media-layout>
-      {lightboxUrl && (
+      {lightboxUrl && typeof document !== 'undefined' && createPortal(
         <Box
           position="fixed"
           inset={0}
@@ -280,6 +282,20 @@ const MediaRenderer = ({ mediaContent }: MediaRendererProps) => {
           onClick={() => setLightboxUrl(null)}
           cursor="zoom-out"
         >
+          <IconButton
+            aria-label="Close image"
+            icon={<FiX />}
+            position="fixed"
+            top={4}
+            right={4}
+            zIndex={10000}
+            size="md"
+            borderRadius="full"
+            bg="blackAlpha.700"
+            color="white"
+            _hover={{ bg: 'blackAlpha.900' }}
+            onClick={() => setLightboxUrl(null)}
+          />
           <Image
             src={lightboxUrl}
             alt="Full size image"
@@ -290,7 +306,8 @@ const MediaRenderer = ({ mediaContent }: MediaRendererProps) => {
             cursor="default"
             onClick={(e) => e.stopPropagation()}
           />
-        </Box>
+        </Box>,
+        document.body
       )}
       {groupedItems.map((group, index) => {
         if (group.kind === 'single-image') {


### PR DESCRIPTION
## Summary

- Renders the image lightbox overlay via `createPortal` at `document.body`, escaping any ancestor `overflow: hidden`, `transform`, or stacking-context CSS that was clipping the expanded image
- Adds a fixed X close button in the top-right corner of the lightbox
- Clicking the dim backdrop outside the image also closes it (existing behaviour preserved)
- Escape key closes it too (existing behaviour preserved)

## Test plan

- [ ] Click an image in a snap — it should open fully without any cropped/missing edges
- [ ] Click the X button in the top-right — lightbox closes
- [ ] Click outside the image on the dark backdrop — lightbox closes
- [ ] Press Escape — lightbox closes
- [ ] Carousel images open correctly via the same lightbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an explicit close button to the lightbox overlay for media viewing, enabling users to easily dismiss the viewer without using keyboard shortcuts or clicking outside the content.
  * Improved accessibility with proper labeling on the close button to support screen reader users and enhance overall usability of the media gallery interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->