### PR TITLE
feat: compose polish — theme colors, corners, draft auto-save

### DIFF
--- a/app/compose/Editor.tsx
+++ b/app/compose/Editor.tsx
@@ -215,9 +215,11 @@ interface EditorProps {
   selectedCommunity?: string;
   onCommunityChange?: (id: string) => void;
   communityOptions?: { id: string; title: string }[];
+  draftRestored?: boolean;
+  onDiscardDraft?: () => void;
 }
 
-const Editor: FC<EditorProps> = ({ markdown, setMarkdown, title, setTitle, hashtagInput, setHashtagInput, hashtags, setHashtags, beneficiaries, setBeneficiaries, lockedAccounts, onSubmit, isSubmitting = false, onVideoEmbedUrlChange, onAudioEmbedUrlChange, onVideoThumbnailChange, selectedCommunity, onCommunityChange, communityOptions }) => {
+const Editor: FC<EditorProps> = ({ markdown, setMarkdown, title, setTitle, hashtagInput, setHashtagInput, hashtags, setHashtags, beneficiaries, setBeneficiaries, lockedAccounts, onSubmit, isSubmitting = false, onVideoEmbedUrlChange, onAudioEmbedUrlChange, onVideoThumbnailChange, selectedCommunity, onCommunityChange, communityOptions, draftRestored, onDiscardDraft }) => {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const toast = useToast();
     const isMobile = useBreakpointValue({ base: true, sm: false }, { ssr: false });
@@ -598,6 +600,31 @@ const Editor: FC<EditorProps> = ({ markdown, setMarkdown, title, setTitle, hasht
                         overflowY="auto"
                         pr={2}
                     >
+                        {/* Draft restored banner */}
+                        {draftRestored && (
+                            <Flex
+                                px={3}
+                                py={2}
+                                bg="muted"
+                                borderRadius="10px"
+                                align="center"
+                                justify="space-between"
+                                fontSize="xs"
+                                color="gray.400"
+                            >
+                                <Text>Draft restored — your previous work is back.</Text>
+                                <Button
+                                    size="xs"
+                                    variant="ghost"
+                                    color="gray.400"
+                                    _hover={{ color: 'text', bg: 'background' }}
+                                    onClick={onDiscardDraft}
+                                >
+                                    Discard
+                                </Button>
+                            </Flex>
+                        )}
+
                         {/* Title Input */}
                         <Box
                             border="1px solid"

--- a/app/compose/page.tsx
+++ b/app/compose/page.tsx
@@ -3,7 +3,7 @@ import { useAioha } from '@aioha/react-ui';
 import { signAndBroadcastWithKeychain, getUserSubscribedCommunities } from '@/lib/hive/client-functions'
 import { Flex, Input, Tag, TagCloseButton, TagLabel, Wrap, WrapItem, Button, useToast } from '@chakra-ui/react'
 import dynamic from 'next/dynamic'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { prepareImageArray, validateTitle, validateContent } from '@/lib/utils/composeUtils'
 import { createComposer, type Beneficiary } from '@snapie/operations'
@@ -12,6 +12,7 @@ import type { Beneficiary as BeneficiaryInputType } from '@/components/compose/B
 const Editor = dynamic(() => import('./Editor'), { ssr: false })
 
 const communityTag = process.env.NEXT_PUBLIC_HIVE_COMMUNITY_TAG || 'hive-blog'
+const DRAFT_KEY = 'snapie_compose_draft'
 
 // Create a configured composer for blog posts
 const blogComposer = createComposer({
@@ -60,6 +61,8 @@ export default function Home() {
   const [communityOptions, setCommunityOptions] = useState<{ id: string; title: string }[]>([
     { id: communityTag, title: 'Snapie' },
   ])
+  const [draftRestored, setDraftRestored] = useState(false)
+  const draftTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Sync state when search params change (e.g., same-route navigation from recording upload)
   useEffect(() => {
@@ -78,6 +81,37 @@ export default function Home() {
         : buildHangoutBodyAwaitingAudio(hangoutThumbnail)
     )
   }, [isHangout, hangoutTitle, hangoutAudioUrl, hangoutThumbnail])
+
+  // Restore draft on mount (skip hangout posts — they're pre-filled from URL)
+  useEffect(() => {
+    if (isHangout) return
+    try {
+      const raw = localStorage.getItem(DRAFT_KEY)
+      if (!raw) return
+      const draft = JSON.parse(raw)
+      if (draft.title) setTitle(draft.title)
+      if (draft.markdown) setMarkdown(draft.markdown)
+      if (Array.isArray(draft.hashtags) && draft.hashtags.length) setHashtags(draft.hashtags)
+      if (draft.selectedCommunity) setSelectedCommunity(draft.selectedCommunity)
+      setDraftRestored(true)
+    } catch {
+      // corrupt draft — ignore
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-save draft to localStorage (debounced 1s, skipped for hangout posts)
+  useEffect(() => {
+    if (isHangout) return
+    if (draftTimer.current) clearTimeout(draftTimer.current)
+    draftTimer.current = setTimeout(() => {
+      if (!title && !markdown && hashtags.length === 0) {
+        localStorage.removeItem(DRAFT_KEY)
+        return
+      }
+      localStorage.setItem(DRAFT_KEY, JSON.stringify({ title, markdown, hashtags, selectedCommunity }))
+    }, 1000)
+    return () => { if (draftTimer.current) clearTimeout(draftTimer.current) }
+  }, [title, markdown, hashtags, selectedCommunity, isHangout])
 
   const { user } = useAioha()
   const toast = useToast()
@@ -112,6 +146,16 @@ export default function Home() {
 
   const removeHashtag = (index: number) => {
     setHashtags(hashtags.filter((_, i) => i !== index))
+  }
+
+  function clearDraft() {
+    localStorage.removeItem(DRAFT_KEY)
+    setDraftRestored(false)
+    setTitle('')
+    setMarkdown('')
+    setHashtags([])
+    setHashtagInput('')
+    setSelectedCommunity(communityTag)
   }
 
   function handleVideoEmbedUrlChange(url: string | null) {
@@ -233,12 +277,14 @@ export default function Home() {
           isClosable: true,
         })
 
-        // Clear form
+        // Clear form and saved draft
+        localStorage.removeItem(DRAFT_KEY)
+        setDraftRestored(false)
         setMarkdown('')
         setTitle('')
         setHashtags([])
         setHashtagInput('')
-        setBeneficiaries([{ account: 'snapie', weight: 300 }]) // Reset to default
+        setBeneficiaries([{ account: 'snapie', weight: 300 }])
         setVideoEmbedUrl(null)
         setAudioEmbedUrl(null)
         setVideoThumbnailUrl(null)
@@ -322,6 +368,8 @@ export default function Home() {
           selectedCommunity={selectedCommunity}
           onCommunityChange={setSelectedCommunity}
           communityOptions={communityOptions}
+          draftRestored={draftRestored}
+          onDiscardDraft={clearDraft}
         />
       </Flex>
     </Flex>


### PR DESCRIPTION
## Summary

Follow-up polish to the blog composer, building on #111.

**Theme colors**
- Toolbar strip and preview header: `bg="secondary"` (vivid blue) → `bg="muted"` (dark gray)
- View mode buttons (Editor/Split/Preview): ghost style with muted active tint, no blue fill
- Publish Post + Add Beneficiary: outline style with primary border — no harsh filled button

**Corners**
- Community selector wrapper: `overflow="hidden"` so the Select clips to the 10px radius
- Editor panel + Preview panel: `overflow="hidden"` so the muted toolbar header clips cleanly
- All `borderRadius="md"/"base"` → `10px` to match the main snap feed

**Community selector UX**
- "Post to" label inline with the dropdown so the field is self-explanatory
- Select gets `flex={1} minW={0}` so long community names aren't clipped

**Draft auto-save**
- Writes `title`, `body`, `hashtags`, `selectedCommunity` to `localStorage` with a 1s debounce
- Restores draft on page load with a dismissible "Draft restored" banner + Discard button
- Auto-clears on successful publish
- Hangout posts excluded (they're pre-filled from URL params)

## Test plan

- [ ] Type in the composer, close the tab, reopen — draft is restored with the banner
- [ ] Click Discard — form clears, banner disappears, localStorage is wiped
- [ ] Publish a post — no draft left in localStorage afterwards
- [ ] Toolbar icons readable in all themes (no white-on-white or blue background)
- [ ] Editor/Preview panel corners are clean — no toolbar background bleeding out

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drafts are now automatically saved as you compose
  * Previously saved drafts are restored when you return to the compose page
  * A banner with a "Discard" option appears when a draft is restored

<!-- end of auto-generated comment: release notes by coderabbit.ai -->