### PR TITLE
fix: notification badge clears immediately after marking all as read

### DIFF
--- a/hooks/useHiveNotifications.ts
+++ b/hooks/useHiveNotifications.ts
@@ -132,6 +132,7 @@ export function useHiveNotifications(
 
       setLastRead(readThroughDate);
       setUnreadCount(0);
+      window.dispatchEvent(new CustomEvent('hive:notifications-read'));
     } catch (err) {
       console.error('[notifications] mark all as read failed:', err);
       throw err;
@@ -191,6 +192,12 @@ export function useHiveNotifications(
       document.removeEventListener('visibilitychange', onVisibilityChange);
     };
   }, [account, poll, refetch]);
+
+  useEffect(() => {
+    const onRead = () => setUnreadCount(0);
+    window.addEventListener('hive:notifications-read', onRead);
+    return () => window.removeEventListener('hive:notifications-read', onRead);
+  }, []);
 
   return {
     notifications,


### PR DESCRIPTION
## Summary

- Sidebar and FooterNavigation each instantiate `useHiveNotifications` independently, so when `markAllAsRead` was called in `NotificationsComp`, those isolated hook instances never heard about it — badge stayed stale until page reload
- On a successful mark-all-read, dispatch a `CustomEvent('hive:notifications-read')` on `window`
- Every hook instance (all 3) listens for this event and immediately zeroes its local `unreadCount`

## Test plan

- [ ] Log in, have unread notifications → badge shows count in sidebar and footer
- [ ] Navigate to `/notifications`, tap "Mark all read"
- [ ] Badge in sidebar and footer nav drops to 0 instantly — no page reload needed
- [ ] Refreshing the page still shows 0 (blockchain state is correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notification unread count not properly resetting after marking all notifications as read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->