### PR TITLE
fix: shuffle shorts client-side for random feed order

### DIFF
--- a/hooks/useShorts.ts
+++ b/hooks/useShorts.ts
@@ -14,6 +14,14 @@ function parseEmbedUrl(embedUrl: string): { author: string; permlink: string } {
   return { author: cleaned.slice(0, slashIdx), permlink: cleaned.slice(slashIdx + 1) };
 }
 
+function shuffle<T>(arr: T[]): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
 function timeAgo(dateStr: string): string {
   const date = new Date(dateStr);
   if (!dateStr || !isFinite(date.getTime())) return '';
@@ -53,7 +61,7 @@ async function fetchPage(page: number, limit: number): Promise<{ shorts: ShortIt
     };
   });
 
-  return { shorts, hasMore: (data.page ?? 1) < (data.totalPages ?? 1) };
+  return { shorts: shuffle(shorts), hasMore: (data.page ?? 1) < (data.totalPages ?? 1) };
 }
 
 export function useShorts() {


### PR DESCRIPTION
## Summary
- The shorts feed was displaying videos in the exact order returned by the API endpoint
- The `seed` param was already being sent to `/shortssorted` but was being ignored server-side
- Added a Fisher-Yates shuffle applied to each fetched page in `useShorts.ts`, so order is randomised on every load and every subsequent page

## Test plan
- [ ] Open the Shorts tab — videos should appear in a different order each visit
- [ ] Scroll down to trigger pagination — new page results should also come in shuffled
- [ ] Pull-to-refresh / reset should produce yet another random order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shorts are now displayed in randomized order when fetched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->