### PR TITLE
feat: Snapie Auth — custodial email/Google login + wallet ops

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -8,7 +8,8 @@
       "Bash(git checkout *)",
       "Bash(pnpm update *)",
       "Bash(node *)",
-      "Read(//home/meno/.pm2/logs/**)"
+      "Read(//home/meno/.pm2/logs/**)",
+      "Bash(git push *)"
     ]
   }
 }

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,4 +1,10 @@
 NEXT_PUBLIC_THEME=nounish
+
+# Snapie Auth — custodial account gateway (https://auth.snapie.io)
+# Dev: http://localhost:3500  |  Prod: https://auth.snapie.io
+SNAPIE_AUTH_URL=http://localhost:3500
+# Server-side key for /api/internal/* calls (sponsor tokens, provisioning)
+SNAPIE_AUTH_INTERNAL_KEY=
 NEXT_PUBLIC_HIVE_COMMUNITY_TAG=hive-167980
 NEXT_PUBLIC_HIVE_SEARCH_TAG=hive-167980
 NEXT_PUBLIC_HIVE_USER=skatedev
@@ -6,6 +12,9 @@ HIVE_POSTING_KEY=posting_private_key_here_
 # Optional server-side account utilities (only if using account-create helpers)
 # ACCOUNT_CREATOR=your_creator_account
 # ACCOUNT_KEY=your_creator_private_key
+# Account that receives posting authority on every new account created via the faucet or sponsor flow.
+# Defaults to 'snapie' if not set.
+NEXT_PUBLIC_POSTING_AUTHORITY_ACCOUNT=snapie
 NEXT_PUBLIC_DISPLAY_CURRENCY=
 NEXT_PUBLIC_HIVESIGNER_ENABLED=false
 NEXT_PUBLIC_3SPEAK_API_KEY=your_3speak_api_key_here

--- a/app/LayoutContent.tsx
+++ b/app/LayoutContent.tsx
@@ -10,6 +10,7 @@ import { chatService } from '@/lib/chat/ChatService';
 import { useHangout } from '@/contexts/HangoutContext';
 
 const HangoutModal = dynamic(() => import('@/components/hangouts/HangoutModal'), { ssr: false });
+const EmancipationBanner = dynamic(() => import('@/components/auth/EmancipationBanner'), { ssr: false });
 
 export default function LayoutContent({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
@@ -92,7 +93,10 @@ export default function LayoutContent({ children }: { children: React.ReactNode 
             flex="1"
             h="100vh"
             overflowY="auto"
+            display="flex"
+            flexDirection="column"
           >
+            <EmancipationBanner />
             {!isChatPopoutMode && children}
           </Box>
         </Flex>

--- a/app/api/snapie-auth/[...path]/route.ts
+++ b/app/api/snapie-auth/[...path]/route.ts
@@ -19,21 +19,36 @@ async function proxy(req: NextRequest, path: string[]): Promise<NextResponse> {
   const qs = req.nextUrl.searchParams.toString()
   const url = qs ? `${upstream}?${qs}` : upstream
 
-  const cookieHeader = req.headers.get('cookie') ?? ''
+  const rawCookies = req.headers.get('cookie') ?? ''
   const isMutating = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)
 
+  // Only forward Snapie Auth cookies — never leak unrelated session cookies.
+  const SNAPIE_COOKIE_NAMES = ['snapieauth_session', 'snapieauth_csrf']
+  const filteredCookies = rawCookies
+    .split(';')
+    .map((c) => c.trim())
+    .filter((c) => SNAPIE_COOKIE_NAMES.some((n) => c.startsWith(n + '=')))
+    .join('; ')
+
   const fwdHeaders: Record<string, string> = {}
-  if (cookieHeader) fwdHeaders['Cookie'] = cookieHeader
+  if (filteredCookies) fwdHeaders['Cookie'] = filteredCookies
   if (isMutating) {
     const ct = req.headers.get('content-type')
     if (ct) fwdHeaders['Content-Type'] = ct
-    // Proxy extracts CSRF from cookies and injects it as a header so the client
-    // doesn't need to manage it manually.
-    const m = cookieHeader.match(/snapieauth_csrf=([^;]+)/)
-    if (m) fwdHeaders['x-csrf-token'] = decodeURIComponent(m[1])
+    const m = rawCookies.match(/snapieauth_csrf=([^;]+)/)
+    if (m) {
+      try {
+        fwdHeaders['x-csrf-token'] = decodeURIComponent(m[1])
+      } catch {
+        // Malformed percent-encoding — skip injecting the token
+      }
+    }
   }
 
   const body = isMutating ? await req.text() : undefined
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 10_000)
 
   let res: Response
   try {
@@ -41,10 +56,13 @@ async function proxy(req: NextRequest, path: string[]): Promise<NextResponse> {
       method: req.method,
       headers: fwdHeaders,
       body: body || undefined,
+      signal: controller.signal,
     })
   } catch (err) {
     console.error('[snapie-auth proxy] upstream error:', err)
     return NextResponse.json({ error: 'proxy_upstream_error' }, { status: 502 })
+  } finally {
+    clearTimeout(timeout)
   }
 
   const resBody = await res.arrayBuffer()

--- a/app/api/snapie-auth/[...path]/route.ts
+++ b/app/api/snapie-auth/[...path]/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+const BASE = process.env.SNAPIE_AUTH_URL
+
+if (!BASE && process.env.NODE_ENV === 'production') {
+  console.warn('SNAPIE_AUTH_URL is not set — Snapie Auth proxy will fail')
+}
+
+function stripDomain(setCookieHeader: string): string {
+  return setCookieHeader.replace(/;\s*domain=[^;]*/gi, '')
+}
+
+async function proxy(req: NextRequest, path: string[]): Promise<NextResponse> {
+  if (!BASE) {
+    return NextResponse.json({ error: 'snapie_auth_not_configured' }, { status: 503 })
+  }
+
+  const upstream = `${BASE}/api/${path.join('/')}`
+  const qs = req.nextUrl.searchParams.toString()
+  const url = qs ? `${upstream}?${qs}` : upstream
+
+  const cookieHeader = req.headers.get('cookie') ?? ''
+  const isMutating = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)
+
+  const fwdHeaders: Record<string, string> = {}
+  if (cookieHeader) fwdHeaders['Cookie'] = cookieHeader
+  if (isMutating) {
+    const ct = req.headers.get('content-type')
+    if (ct) fwdHeaders['Content-Type'] = ct
+    // Proxy extracts CSRF from cookies and injects it as a header so the client
+    // doesn't need to manage it manually.
+    const m = cookieHeader.match(/snapieauth_csrf=([^;]+)/)
+    if (m) fwdHeaders['x-csrf-token'] = decodeURIComponent(m[1])
+  }
+
+  const body = isMutating ? await req.text() : undefined
+
+  let res: Response
+  try {
+    res = await fetch(url, {
+      method: req.method,
+      headers: fwdHeaders,
+      body: body || undefined,
+    })
+  } catch (err) {
+    console.error('[snapie-auth proxy] upstream error:', err)
+    return NextResponse.json({ error: 'proxy_upstream_error' }, { status: 502 })
+  }
+
+  const resBody = await res.arrayBuffer()
+  const next = new NextResponse(resBody, { status: res.status })
+
+  const ct = res.headers.get('content-type')
+  if (ct) next.headers.set('content-type', ct)
+
+  // Forward Set-Cookie headers, stripping Domain so they land on our domain.
+  // getSetCookie() returns an array (one entry per Set-Cookie header).
+  const cookies: string[] =
+    typeof (res.headers as any).getSetCookie === 'function'
+      ? (res.headers as any).getSetCookie()
+      : [res.headers.get('set-cookie')].filter(Boolean)
+
+  for (const c of cookies) {
+    if (c) next.headers.append('set-cookie', stripDomain(c))
+  }
+
+  return next
+}
+
+export async function GET(req: NextRequest, { params }: { params: { path: string[] } }) {
+  return proxy(req, params.path)
+}
+export async function POST(req: NextRequest, { params }: { params: { path: string[] } }) {
+  return proxy(req, params.path)
+}
+export async function PUT(req: NextRequest, { params }: { params: { path: string[] } }) {
+  return proxy(req, params.path)
+}
+export async function PATCH(req: NextRequest, { params }: { params: { path: string[] } }) {
+  return proxy(req, params.path)
+}
+export async function DELETE(req: NextRequest, { params }: { params: { path: string[] } }) {
+  return proxy(req, params.path)
+}

--- a/app/compose/Editor.tsx
+++ b/app/compose/Editor.tsx
@@ -13,7 +13,7 @@ import { IGif } from '@giphy/js-types';
 import { useDropzone } from 'react-dropzone';
 import { compressImage } from '@/lib/utils/composeUtils';
 import BeneficiariesInput, { Beneficiary } from '@/components/compose/BeneficiariesInput';
-import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 
 // SDK import for markdown editing utilities
 import { useEditorToolbar, ALL_COMMON_EMOJIS } from '@snapie/composer/react';
@@ -238,8 +238,7 @@ const Editor: FC<EditorProps> = ({ markdown, setMarkdown, title, setTitle, hasht
     const [audioEmbedUrl, setAudioEmbedUrl] = useState<string | null>(null);
     const [isAudioRecorderOpen, setAudioRecorderOpen] = useState(false);
 
-    // Aioha for image signing
-    const { user } = useAioha();
+    const { username: user } = useCurrentUser();
 
     // Use SDK toolbar hook for markdown editing
     const toolbar = useEditorToolbar(textareaRef, markdown, setMarkdown);

--- a/app/compose/page.tsx
+++ b/app/compose/page.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { signAndBroadcastWithKeychain, getUserSubscribedCommunities } from '@/lib/hive/client-functions'
 import { Flex, Input, Tag, TagCloseButton, TagLabel, Wrap, WrapItem, Button, useToast } from '@chakra-ui/react'
 import dynamic from 'next/dynamic'
@@ -113,7 +113,7 @@ export default function Home() {
     return () => { if (draftTimer.current) clearTimeout(draftTimer.current) }
   }, [title, markdown, hashtags, selectedCommunity, isHangout])
 
-  const { user } = useAioha()
+  const { username: user } = useCurrentUser()
   const toast = useToast()
   const router = useRouter()
 

--- a/app/edit/[author]/[permlink]/page.tsx
+++ b/app/edit/[author]/[permlink]/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { Box, Flex, Spinner, useToast } from '@chakra-ui/react';
 import dynamic from 'next/dynamic';
-import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { getPost, commentWithKeychain } from '@/lib/hive/client-functions';
 import { prepareImageArray } from '@/lib/utils/composeUtils';
 import type { Beneficiary as BeneficiaryInputType } from '@/components/compose/BeneficiariesInput';
@@ -16,7 +16,7 @@ export default function EditPostPage() {
     const author = decodeURIComponent(params.author);
     const permlink = decodeURIComponent(params.permlink);
 
-    const { user } = useAioha();
+    const { username: user } = useCurrentUser();
     const router = useRouter();
     const toast = useToast();
 

--- a/app/edit/[author]/[permlink]/page.tsx
+++ b/app/edit/[author]/[permlink]/page.tsx
@@ -69,13 +69,16 @@ export default function EditPostPage() {
             }
         }
         load();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [author, permlink]);
+    }, [author, permlink, user, router, toast]);
 
     async function handleSubmit() {
         const username = typeof user === 'string' ? user : (user as any)?.username || '';
         if (!username) {
             toast({ title: 'Not logged in', status: 'error', duration: 3000 });
+            return;
+        }
+        if (username !== author) {
+            toast({ title: 'Unauthorized', description: 'You can only edit your own posts.', status: 'error', duration: 4000 });
             return;
         }
 

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -1,17 +1,110 @@
-'use client';
+'use client'
 
-import { Suspense } from 'react';
-import { Box, Spinner } from '@chakra-ui/react';
-import { useSearchParams } from 'next/navigation';
-import CreateAccountForm from '@/components/join/CreateAccountForm';
-import SponsorFlow from '@/components/join/SponsorFlow';
+import { Suspense } from 'react'
+import { Box, Button, Divider, Heading, Spinner, Text, VStack } from '@chakra-ui/react'
+import { useSearchParams, useRouter } from 'next/navigation'
+import SponsorFlow from '@/components/join/SponsorFlow'
+import QuotaWidget from '@/components/join/QuotaWidget'
+import { useLoginModal } from '@/contexts/LoginModalContext'
 
 function JoinPageInner() {
-  const searchParams = useSearchParams();
-  const code = searchParams.get('code');
+  const searchParams = useSearchParams()
+  const code = searchParams.get('code')
+  const { openLoginModal } = useLoginModal()
 
-  if (code) return <SponsorFlow code={code} />;
-  return <CreateAccountForm />;
+  // Existing sponsor-link flow: /join?code=... shows the sponsor redemption UI.
+  if (code) return <SponsorFlow code={code} />
+
+  return (
+    <Box maxW="520px" mx="auto" px={4} py={12}>
+      <VStack spacing={8} align="stretch">
+        {/* Header */}
+        <VStack spacing={2} align="center">
+          <Heading size="lg">Get your Hive account</Heading>
+          <Text color="gray.500" fontSize="sm" textAlign="center">
+            Hive is a decentralised social blockchain. Your account is your passport to Snapie and the
+            entire Hive ecosystem.
+          </Text>
+          <QuotaWidget />
+        </VStack>
+
+        {/* Path A — Quick Join */}
+        <Box
+          borderWidth={2}
+          borderColor="blue.400"
+          borderRadius="xl"
+          p={6}
+          position="relative"
+        >
+          <Box
+            position="absolute"
+            top="-12px"
+            left={4}
+            bg="blue.400"
+            color="white"
+            fontSize="xs"
+            fontWeight="bold"
+            px={3}
+            py={1}
+            borderRadius="full"
+          >
+            Easiest
+          </Box>
+          <VStack spacing={3} align="stretch">
+            <Heading size="sm">Quick Join</Heading>
+            <Text fontSize="sm" color="gray.500">
+              Sign up with Google or email — we create your Hive account automatically. No keys,
+              no setup. You can export your keys any time.
+            </Text>
+            <Button colorScheme="blue" size="lg" onClick={openLoginModal} borderRadius="lg">
+              Get started →
+            </Button>
+          </VStack>
+        </Box>
+
+        {/* Path B — Sponsor Link */}
+        <Box borderWidth={1} borderRadius="xl" p={6}>
+          <VStack spacing={3} align="stretch">
+            <Heading size="sm">Got a sponsor link?</Heading>
+            <Text fontSize="sm" color="gray.500">
+              If someone sent you a link or QR code, paste the URL here or click the link directly.
+              Sponsor tokens bypass the daily quota.
+            </Text>
+            <Button
+              variant="outline"
+              size="md"
+              onClick={() => {
+                const link = prompt('Paste your sponsor link here:')
+                if (!link) return
+                try {
+                  const url = new URL(link)
+                  const c = url.searchParams.get('code')
+                  if (c) window.location.href = `/join?code=${c}`
+                  else alert('That link does not look like a valid sponsor link.')
+                } catch {
+                  alert('Invalid URL. Please paste the full link.')
+                }
+              }}
+            >
+              Redeem sponsor link
+            </Button>
+          </VStack>
+        </Box>
+
+        <Divider />
+
+        {/* Path C — Already on Hive */}
+        <VStack spacing={2} align="center">
+          <Text fontSize="sm" color="gray.500">
+            Already have a Hive account?
+          </Text>
+          <Button variant="link" colorScheme="blue" size="sm" onClick={openLoginModal}>
+            Sign in with your Hive wallet →
+          </Button>
+        </VStack>
+      </VStack>
+    </Box>
+  )
 }
 
 export default function JoinPage() {
@@ -19,5 +112,5 @@ export default function JoinPage() {
     <Suspense fallback={<Box display="flex" justifyContent="center" py={16}><Spinner /></Box>}>
       <JoinPageInner />
     </Suspense>
-  );
+  )
 }

--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -79,7 +79,7 @@ function JoinPageInner() {
                 try {
                   const url = new URL(link)
                   const c = url.searchParams.get('code')
-                  if (c) window.location.href = `/join?code=${c}`
+                  if (c) window.location.href = `/join?code=${encodeURIComponent(c)}`
                   else alert('That link does not look like a valid sponsor link.')
                 } catch {
                   alert('Invalid URL. Please paste the full link.')

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,7 +10,7 @@ import SnapReplyModal from '@/components/homepage/SnapReplyModal';
 import { useSnaps, SnapFilterType } from '@/hooks/useSnaps';
 import FeedTabFilter from '@/components/homepage/FeedTabFilter';
 import OpenPodsLiveStrip from '@/components/hangouts/OpenPodsLiveStrip';
-import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { getCommunityInfo } from '@/lib/hive/client-functions';
 
 interface CommunityInfo {
@@ -31,7 +31,7 @@ export default function Home() {
   const [activeFilter, setActiveFilter] = useState<SnapFilterType>('community');
   const [communityName, setCommunityName] = useState<string>('Community');
 
-  const { user } = useAioha();
+  const { username: user, isLoggedIn } = useCurrentUser();
 
   useEffect(() => {
     const loadCommunityInfo = async () => {
@@ -99,7 +99,7 @@ export default function Home() {
           activeFilter={activeFilter}
           onFilterChange={handleFilterChange}
           communityName={communityName}
-          isLoggedIn={!!user}
+          isLoggedIn={isLoggedIn}
         />
         {!conversation ? (
 

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -18,6 +18,7 @@ import { HangoutContextProvider } from '@/contexts/HangoutContext'
 import { AiohaProvider } from '@aioha/react-ui'
 import { HiveAuthProvider } from '@/contexts/HiveAuthContext'
 import { LoginModalProvider } from '@/contexts/LoginModalContext'
+import { SnapieAuthProvider } from '@/contexts/SnapieAuthContext'
 import { getAioha } from '@/lib/hive/aioha'
 
 const themeMap = {
@@ -165,13 +166,15 @@ export function Providers({ children }: { children: React.ReactNode }) {
     <AiohaProvider aioha={aioha}>
       <ChakraProvider theme={selectedTheme}>
         <UserProvider>
-          <HiveAuthProvider>
-            <LoginModalProvider>
-              <HangoutContextProvider>
-                {children}
-              </HangoutContextProvider>
-            </LoginModalProvider>
-          </HiveAuthProvider>
+          <SnapieAuthProvider>
+            <HiveAuthProvider>
+              <LoginModalProvider>
+                <HangoutContextProvider>
+                  {children}
+                </HangoutContextProvider>
+              </LoginModalProvider>
+            </HiveAuthProvider>
+          </SnapieAuthProvider>
         </UserProvider>
       </ChakraProvider>
     </AiohaProvider>

--- a/components/auth/AccountSetupPanel.tsx
+++ b/components/auth/AccountSetupPanel.tsx
@@ -1,0 +1,237 @@
+'use client'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  Alert,
+  AlertIcon,
+  Box,
+  Button,
+  Divider,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  Progress,
+  Text,
+  VStack,
+} from '@chakra-ui/react'
+import {
+  checkUsername,
+  createAccount,
+  getEligibility,
+  getMe,
+  pollJob,
+} from '@/lib/snapie-auth/client'
+import { SnapieAuthError } from '@/lib/snapie-auth/types'
+import { validateAccountName } from '@/lib/hive/account-create-client'
+import type { SnapieUser } from '@/lib/snapie-auth/types'
+
+const JOB_STATUS_LABEL: Record<string, string> = {
+  pending: 'Queued…',
+  broadcasting: 'Broadcasting to Hive…',
+  acked: 'Transaction acknowledged…',
+  confirmed: 'Account confirmed!',
+  failed: 'Account creation failed.',
+  expired: 'Request expired.',
+}
+
+const RC_ERROR_MSG =
+  'The account creation service is temporarily out of resource credits. ' +
+  'Please try again in a few minutes.'
+
+const ERROR_MESSAGES: Record<string, string> = {
+  global_daily_limit: "We've hit today's free-account limit. Try again tomorrow, or use a sponsor link.",
+  ip_daily_limit: "You've reached the daily limit from your network. Try again tomorrow.",
+  previously_had_account: "This email was already used for a free account. Use a sponsor link to get another.",
+  no_acts: "Account provisioning is temporarily unavailable. Please try again later.",
+  insufficient_rc: RC_ERROR_MSG,
+}
+
+interface Props {
+  onComplete: (user: SnapieUser) => void
+}
+
+export default function AccountSetupPanel({ onComplete }: Props) {
+  const [username, setUsername] = useState('')
+  const [usernameError, setUsernameError] = useState('')
+  const [checking, setChecking] = useState(false)
+  const [available, setAvailable] = useState<boolean | null>(null)
+  const [eligibility, setEligibility] = useState<{
+    canCreate: boolean
+    reason?: string
+    sponsored?: boolean
+  } | null>(null)
+  const [eligibilityError, setEligibilityError] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [jobStatus, setJobStatus] = useState<string | null>(null)
+  const [submitError, setSubmitError] = useState('')
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    getEligibility()
+      .then((r) => setEligibility(r))
+      .catch((e: SnapieAuthError) => {
+        setEligibilityError(ERROR_MESSAGES[e.code] ?? 'Could not check eligibility.')
+      })
+  }, [])
+
+  const handleUsernameChange = useCallback((val: string) => {
+    const lower = val.toLowerCase().replace(/[^a-z0-9.-]/g, '')
+    setUsername(lower)
+    setAvailable(null)
+
+    if (lower.length === 0) {
+      setUsernameError('')
+      return
+    }
+    const localErr = validateAccountName(lower)
+    if (!localErr.isValid) {
+      setUsernameError(localErr.error ?? 'Invalid username')
+      return
+    }
+    setUsernameError('')
+
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(async () => {
+      setChecking(true)
+      try {
+        const res = await checkUsername(lower)
+        setAvailable(res.available)
+        if (!res.available) setUsernameError(res.reason ?? 'Username not available.')
+      } catch {
+        setUsernameError('Could not check availability.')
+      } finally {
+        setChecking(false)
+      }
+    }, 500)
+  }, [])
+
+  const handleSubmit = useCallback(async () => {
+    if (!available || usernameError || submitting) return
+    setSubmitting(true)
+    setSubmitError('')
+
+    try {
+      const { jobId } = await createAccount(username)
+      setJobStatus('pending')
+
+      let status = 'pending'
+      while (!['confirmed', 'failed', 'expired'].includes(status)) {
+        await new Promise((r) => setTimeout(r, 3000))
+        const job = await pollJob(jobId)
+        status = job.status
+        setJobStatus(job.status)
+        if (job.error) {
+          setSubmitError(ERROR_MESSAGES[job.error] ?? `Error: ${job.error}`)
+          setSubmitting(false)
+          return
+        }
+      }
+
+      if (status === 'confirmed') {
+        const updated = await getMe()
+        onComplete(updated)
+      } else {
+        setSubmitError('Account creation did not complete. Please try again.')
+        setSubmitting(false)
+      }
+    } catch (e: any) {
+      const code = e?.code ?? ''
+      setSubmitError(ERROR_MESSAGES[code] ?? 'Something went wrong. Please try again.')
+      setSubmitting(false)
+      setJobStatus(null)
+    }
+  }, [available, usernameError, submitting, username, onComplete])
+
+  const jobProgress: Record<string, number> = {
+    pending: 20,
+    broadcasting: 50,
+    acked: 75,
+    confirmed: 100,
+  }
+
+  if (eligibilityError) {
+    return (
+      <Alert status="warning" borderRadius="md">
+        <AlertIcon />
+        <Text fontSize="sm">{eligibilityError}</Text>
+      </Alert>
+    )
+  }
+
+  return (
+    <VStack spacing={4} align="stretch">
+      <Box>
+        <Text fontWeight="semibold" fontSize="lg">
+          Choose your Hive username
+        </Text>
+        <Text fontSize="sm" color="gray.500" mt={1}>
+          This is your permanent on-chain identity. Choose wisely — it cannot be changed.
+          {eligibility?.sponsored && (
+            <Text as="span" color="green.500">
+              {' '}
+              You have a sponsor token — your account is free!
+            </Text>
+          )}
+        </Text>
+      </Box>
+
+      <FormControl isInvalid={!!usernameError}>
+        <FormLabel fontSize="sm">Username</FormLabel>
+        <Input
+          placeholder="e.g. alice"
+          value={username}
+          onChange={(e) => handleUsernameChange(e.target.value)}
+          isDisabled={submitting}
+          autoComplete="off"
+          autoCapitalize="none"
+        />
+        {usernameError ? (
+          <FormErrorMessage>{usernameError}</FormErrorMessage>
+        ) : available === true ? (
+          <Text fontSize="xs" color="green.500" mt={1}>
+            ✓ @{username} is available
+          </Text>
+        ) : checking ? (
+          <Text fontSize="xs" color="gray.400" mt={1}>
+            Checking…
+          </Text>
+        ) : null}
+      </FormControl>
+
+      {submitError && (
+        <Alert status="error" borderRadius="md">
+          <AlertIcon />
+          <Text fontSize="sm">{submitError}</Text>
+        </Alert>
+      )}
+
+      {jobStatus && (
+        <Box>
+          <Text fontSize="sm" mb={2}>
+            {JOB_STATUS_LABEL[jobStatus] ?? jobStatus}
+          </Text>
+          <Progress
+            value={jobProgress[jobStatus] ?? 10}
+            size="sm"
+            borderRadius="full"
+            colorScheme={jobStatus === 'confirmed' ? 'green' : 'blue'}
+            isAnimated={!['confirmed', 'failed', 'expired'].includes(jobStatus)}
+          />
+        </Box>
+      )}
+
+      {!jobStatus && (
+        <Button
+          colorScheme="blue"
+          onClick={handleSubmit}
+          isLoading={submitting}
+          isDisabled={!available || !!usernameError || checking || !username}
+          size="lg"
+          width="full"
+        >
+          Create My Account
+        </Button>
+      )}
+    </VStack>
+  )
+}

--- a/components/auth/AccountSetupPanel.tsx
+++ b/components/auth/AccountSetupPanel.tsx
@@ -65,6 +65,7 @@ export default function AccountSetupPanel({ onComplete }: Props) {
   const [jobStatus, setJobStatus] = useState<string | null>(null)
   const [submitError, setSubmitError] = useState('')
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const checkReqIdRef = useRef(0)
 
   useEffect(() => {
     getEligibility()
@@ -91,16 +92,19 @@ export default function AccountSetupPanel({ onComplete }: Props) {
     setUsernameError('')
 
     if (debounceRef.current) clearTimeout(debounceRef.current)
+    const reqId = ++checkReqIdRef.current
     debounceRef.current = setTimeout(async () => {
       setChecking(true)
       try {
         const res = await checkUsername(lower)
+        if (reqId !== checkReqIdRef.current) return
         setAvailable(res.available)
         if (!res.available) setUsernameError(res.reason ?? 'Username not available.')
       } catch {
+        if (reqId !== checkReqIdRef.current) return
         setUsernameError('Could not check availability.')
       } finally {
-        setChecking(false)
+        if (reqId === checkReqIdRef.current) setChecking(false)
       }
     }, 500)
   }, [])
@@ -115,7 +119,14 @@ export default function AccountSetupPanel({ onComplete }: Props) {
       setJobStatus('pending')
 
       let status = 'pending'
+      const deadline = Date.now() + 120_000 // 2 min max
       while (!['confirmed', 'failed', 'expired'].includes(status)) {
+        if (Date.now() > deadline) {
+          setSubmitError('Account creation timed out. Please try again.')
+          setSubmitting(false)
+          setJobStatus(null)
+          return
+        }
         await new Promise((r) => setTimeout(r, 3000))
         const job = await pollJob(jobId)
         status = job.status

--- a/components/auth/EmancipationBanner.tsx
+++ b/components/auth/EmancipationBanner.tsx
@@ -1,0 +1,112 @@
+'use client'
+import { useEffect, useState } from 'react'
+import {
+  Alert,
+  AlertIcon,
+  AlertTitle,
+  AlertDescription,
+  Button,
+  CloseButton,
+  Flex,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react'
+import { useSnapieAuth } from '@/contexts/SnapieAuthContext'
+import { getEmancipationStatus } from '@/lib/snapie-auth/client'
+import dynamic from 'next/dynamic'
+
+const EmancipationModal = dynamic(() => import('./EmancipationModal'), { ssr: false })
+
+const DISMISS_KEY = 'snapie_emancipation_dismissed_v1'
+
+export default function EmancipationBanner() {
+  const { isSnapieLoggedIn, emancipationRequired } = useSnapieAuth()
+  const { isOpen: isBannerOpen, onClose: closeBanner, onOpen: openBanner } = useDisclosure()
+  const { isOpen: isModalOpen, onClose: closeModal, onOpen: openModal } = useDisclosure()
+  const [totalUsd, setTotalUsd] = useState<number | null>(null)
+  const [thresholdUsd, setThresholdUsd] = useState<number | null>(null)
+
+  // Show banner when emancipation is required, unless dismissed this session
+  useEffect(() => {
+    if (!isSnapieLoggedIn || !emancipationRequired) return
+    const dismissed = sessionStorage.getItem(DISMISS_KEY)
+    if (!dismissed) openBanner()
+  }, [isSnapieLoggedIn, emancipationRequired, openBanner])
+
+  // Re-open on post-transaction signal (dispatched by Snapie active-key interceptors)
+  useEffect(() => {
+    const handler = () => {
+      sessionStorage.removeItem(DISMISS_KEY)
+      openBanner()
+    }
+    window.addEventListener('snapie:emancipation-required', handler)
+    return () => window.removeEventListener('snapie:emancipation-required', handler)
+  }, [openBanner])
+
+  // Fetch detailed status when banner is visible
+  useEffect(() => {
+    if (!isBannerOpen) return
+    getEmancipationStatus()
+      .then(({ totalUsd: t, thresholdUsd: th }) => {
+        setTotalUsd(t)
+        setThresholdUsd(th)
+      })
+      .catch(() => {})
+  }, [isBannerOpen])
+
+  const handleDismiss = () => {
+    sessionStorage.setItem(DISMISS_KEY, '1')
+    closeBanner()
+  }
+
+  if (!isBannerOpen) return null
+
+  return (
+    <>
+      <Alert
+        status="warning"
+        variant="left-accent"
+        px={4}
+        py={3}
+        alignItems="flex-start"
+        flexShrink={0}
+      >
+        <AlertIcon mt={0.5} />
+        <Flex direction="column" flex={1} gap={1}>
+          <AlertTitle fontSize="sm">Your account has grown — consider securing your keys</AlertTitle>
+          <AlertDescription fontSize="xs">
+            {totalUsd !== null && thresholdUsd !== null ? (
+              <Text>
+                Your account value is <strong>${totalUsd.toFixed(2)}</strong>, above the{' '}
+                <strong>${thresholdUsd.toFixed(2)}</strong> self-custody threshold. Export your keys
+                to take full ownership of your Hive account.
+              </Text>
+            ) : (
+              <Text>
+                Your account value has exceeded our recommended self-custody threshold. Export your
+                keys to take full ownership of your Hive account.
+              </Text>
+            )}
+          </AlertDescription>
+          <Button
+            mt={2}
+            size="xs"
+            colorScheme="orange"
+            variant="solid"
+            alignSelf="flex-start"
+            onClick={openModal}
+          >
+            Export my keys →
+          </Button>
+        </Flex>
+        <CloseButton
+          alignSelf="flex-start"
+          size="sm"
+          onClick={handleDismiss}
+          title="Dismiss (until next transaction)"
+        />
+      </Alert>
+      <EmancipationModal isOpen={isModalOpen} onClose={closeModal} />
+    </>
+  )
+}

--- a/components/auth/EmancipationBanner.tsx
+++ b/components/auth/EmancipationBanner.tsx
@@ -26,22 +26,26 @@ export default function EmancipationBanner() {
   const [totalUsd, setTotalUsd] = useState<number | null>(null)
   const [thresholdUsd, setThresholdUsd] = useState<number | null>(null)
 
-  // Show banner when emancipation is required, unless dismissed this session
+  // Sync banner visibility with current requirement state
   useEffect(() => {
-    if (!isSnapieLoggedIn || !emancipationRequired) return
-    const dismissed = sessionStorage.getItem(DISMISS_KEY)
-    if (!dismissed) openBanner()
-  }, [isSnapieLoggedIn, emancipationRequired, openBanner])
+    if (isSnapieLoggedIn && emancipationRequired) {
+      const dismissed = sessionStorage.getItem(DISMISS_KEY)
+      if (!dismissed) openBanner()
+    } else {
+      closeBanner()
+    }
+  }, [isSnapieLoggedIn, emancipationRequired, openBanner, closeBanner])
 
-  // Re-open on post-transaction signal (dispatched by Snapie active-key interceptors)
+  // Re-open after a transaction signals the account is over threshold
   useEffect(() => {
     const handler = () => {
+      if (!isSnapieLoggedIn) return
       sessionStorage.removeItem(DISMISS_KEY)
       openBanner()
     }
     window.addEventListener('snapie:emancipation-required', handler)
     return () => window.removeEventListener('snapie:emancipation-required', handler)
-  }, [openBanner])
+  }, [isSnapieLoggedIn, openBanner])
 
   // Fetch detailed status when banner is visible
   useEffect(() => {

--- a/components/auth/EmancipationModal.tsx
+++ b/components/auth/EmancipationModal.tsx
@@ -1,0 +1,218 @@
+'use client'
+import { useState } from 'react'
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  Button,
+  Text,
+  Box,
+  Code,
+  VStack,
+  Alert,
+  AlertIcon,
+  AlertDescription,
+  useToast,
+  Spinner,
+  Divider,
+} from '@chakra-ui/react'
+import { getEmancipationStatus, startEmancipation } from '@/lib/snapie-auth/client'
+
+interface EmancipationModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+type Step = 'info' | 'confirm' | 'keys' | 'loading'
+
+interface Keys {
+  owner: string
+  active: string
+  posting: string
+  memo: string
+}
+
+export default function EmancipationModal({ isOpen, onClose }: EmancipationModalProps) {
+  const [step, setStep] = useState<Step>('info')
+  const [totalUsd, setTotalUsd] = useState<number | null>(null)
+  const [thresholdUsd, setThresholdUsd] = useState<number | null>(null)
+  const [keys, setKeys] = useState<Keys | null>(null)
+  const [statusLoading, setStatusLoading] = useState(false)
+  const toast = useToast()
+
+  const fetchStatus = async () => {
+    setStatusLoading(true)
+    try {
+      const { totalUsd: t, thresholdUsd: th } = await getEmancipationStatus()
+      setTotalUsd(t)
+      setThresholdUsd(th)
+    } catch {
+      // non-fatal — proceed anyway
+    } finally {
+      setStatusLoading(false)
+    }
+  }
+
+  const handleOpen = () => {
+    setStep('info')
+    setKeys(null)
+    fetchStatus()
+  }
+
+  const handleExport = async () => {
+    setStep('loading')
+    try {
+      const { keys: k } = await startEmancipation()
+      setKeys(k)
+      setStep('keys')
+    } catch (err: any) {
+      toast({
+        title: 'Export failed',
+        description: err?.message ?? 'Could not export keys. Try again.',
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      })
+      setStep('confirm')
+    }
+  }
+
+  const copyKey = (label: string, value: string) => {
+    navigator.clipboard.writeText(value).then(() => {
+      toast({ title: `${label} key copied`, status: 'success', duration: 2000 })
+    })
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      size="lg"
+      closeOnOverlayClick={step !== 'loading'}
+      onCloseComplete={handleOpen}
+    >
+      <ModalOverlay />
+      <ModalContent>
+        {step === 'info' && (
+          <>
+            <ModalHeader>Export your Hive keys</ModalHeader>
+            <ModalCloseButton />
+            <ModalBody>
+              <VStack align="start" spacing={4}>
+                {statusLoading ? (
+                  <Spinner size="sm" />
+                ) : totalUsd !== null && thresholdUsd !== null ? (
+                  <Alert status="warning" borderRadius="md">
+                    <AlertIcon />
+                    <AlertDescription fontSize="sm">
+                      Your account value is <strong>${totalUsd.toFixed(2)}</strong>, above the{' '}
+                      <strong>${thresholdUsd.toFixed(2)}</strong> self-custody threshold.
+                    </AlertDescription>
+                  </Alert>
+                ) : null}
+                <Text fontSize="sm">
+                  Your account is currently managed by Snapie (custodial mode). Exporting your keys
+                  lets you take full ownership — you&apos;ll be able to sign transactions yourself
+                  using Keychain, HiveAuth, or any other wallet.
+                </Text>
+                <Text fontSize="sm" fontWeight="bold">
+                  What happens when you export:
+                </Text>
+                <VStack align="start" spacing={1} pl={3}>
+                  <Text fontSize="sm">• Your four Hive keys will be shown <strong>once</strong>.</Text>
+                  <Text fontSize="sm">• Save them securely — they cannot be shown again.</Text>
+                  <Text fontSize="sm">• Snapie will stop managing your keys.</Text>
+                  <Text fontSize="sm">• You keep full access to your account and content.</Text>
+                </VStack>
+              </VStack>
+            </ModalBody>
+            <ModalFooter>
+              <Button variant="ghost" mr={3} onClick={onClose}>Cancel</Button>
+              <Button colorScheme="orange" onClick={() => setStep('confirm')}>
+                I understand, continue →
+              </Button>
+            </ModalFooter>
+          </>
+        )}
+
+        {step === 'confirm' && (
+          <>
+            <ModalHeader>Are you sure?</ModalHeader>
+            <ModalCloseButton />
+            <ModalBody>
+              <Alert status="error" borderRadius="md">
+                <AlertIcon />
+                <AlertDescription fontSize="sm">
+                  This action is <strong>irreversible</strong>. Your keys will be shown exactly once.
+                  If you lose them, you lose access to your account permanently.
+                </AlertDescription>
+              </Alert>
+              <Text fontSize="sm" mt={4}>
+                Have a password manager or secure note ready before proceeding.
+              </Text>
+            </ModalBody>
+            <ModalFooter>
+              <Button variant="ghost" mr={3} onClick={() => setStep('info')}>Back</Button>
+              <Button colorScheme="red" onClick={handleExport}>
+                Export keys now
+              </Button>
+            </ModalFooter>
+          </>
+        )}
+
+        {step === 'loading' && (
+          <>
+            <ModalHeader>Exporting keys…</ModalHeader>
+            <ModalBody>
+              <VStack py={8} spacing={4}>
+                <Spinner size="lg" />
+                <Text fontSize="sm" color="gray.400">Generating key export…</Text>
+              </VStack>
+            </ModalBody>
+          </>
+        )}
+
+        {step === 'keys' && keys && (
+          <>
+            <ModalHeader>Your Hive keys</ModalHeader>
+            <ModalBody>
+              <Alert status="warning" borderRadius="md" mb={4}>
+                <AlertIcon />
+                <AlertDescription fontSize="sm">
+                  Save all four keys now. This screen will not appear again.
+                </AlertDescription>
+              </Alert>
+              <VStack align="start" spacing={3}>
+                {(['owner', 'active', 'posting', 'memo'] as const).map((k) => (
+                  <Box key={k} w="100%">
+                    <Text fontSize="xs" fontWeight="bold" textTransform="uppercase" mb={1} color="gray.400">
+                      {k} key
+                    </Text>
+                    <Box display="flex" alignItems="center" gap={2}>
+                      <Code fontSize="xs" p={2} borderRadius="md" flex={1} overflowX="auto" userSelect="all">
+                        {keys[k]}
+                      </Code>
+                      <Button size="xs" variant="outline" onClick={() => copyKey(k, keys[k])}>
+                        Copy
+                      </Button>
+                    </Box>
+                    {k !== 'memo' && <Divider mt={3} />}
+                  </Box>
+                ))}
+              </VStack>
+            </ModalBody>
+            <ModalFooter>
+              <Button colorScheme="green" onClick={onClose}>
+                I&apos;ve saved my keys — done
+              </Button>
+            </ModalFooter>
+          </>
+        )}
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/components/auth/EmancipationModal.tsx
+++ b/components/auth/EmancipationModal.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   Modal,
   ModalOverlay,
@@ -57,11 +57,14 @@ export default function EmancipationModal({ isOpen, onClose }: EmancipationModal
     }
   }
 
-  const handleOpen = () => {
-    setStep('info')
-    setKeys(null)
-    fetchStatus()
-  }
+  useEffect(() => {
+    if (isOpen) {
+      setStep('info')
+      setKeys(null)
+      fetchStatus()
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen])
 
   const handleExport = async () => {
     setStep('loading')
@@ -93,7 +96,6 @@ export default function EmancipationModal({ isOpen, onClose }: EmancipationModal
       onClose={onClose}
       size="lg"
       closeOnOverlayClick={step !== 'loading'}
-      onCloseComplete={handleOpen}
     >
       <ModalOverlay />
       <ModalContent>

--- a/components/auth/GoogleLoginButton.tsx
+++ b/components/auth/GoogleLoginButton.tsx
@@ -24,7 +24,11 @@ function loadGIS(): Promise<void> {
       gisReady = true
       resolve()
     }
-    script.onerror = reject
+    script.onerror = (err) => {
+      gisLoading = null
+      gisReady = false
+      reject(err)
+    }
     document.head.appendChild(script)
   })
   return gisLoading

--- a/components/auth/GoogleLoginButton.tsx
+++ b/components/auth/GoogleLoginButton.tsx
@@ -1,0 +1,100 @@
+'use client'
+import { useEffect, useRef, useState } from 'react'
+import { Box, Spinner, Text } from '@chakra-ui/react'
+import { getPublicConfig } from '@/lib/snapie-auth/client'
+
+interface Props {
+  onCredential: (credential: string) => void
+  width?: number
+}
+
+// Module-level singleton so we only load the script once.
+let gisReady = false
+let gisLoading: Promise<void> | null = null
+
+function loadGIS(): Promise<void> {
+  if (gisReady) return Promise.resolve()
+  if (gisLoading) return gisLoading
+  gisLoading = new Promise((resolve, reject) => {
+    const script = document.createElement('script')
+    script.src = 'https://accounts.google.com/gsi/client'
+    script.async = true
+    script.defer = true
+    script.onload = () => {
+      gisReady = true
+      resolve()
+    }
+    script.onerror = reject
+    document.head.appendChild(script)
+  })
+  return gisLoading
+}
+
+export default function GoogleLoginButton({ onCredential, width = 368 }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [loading, setLoading] = useState(true)
+  const [failed, setFailed] = useState(false)
+  // Keep a stable ref so the GIS callback doesn't capture a stale closure.
+  const onCredentialRef = useRef(onCredential)
+  useEffect(() => { onCredentialRef.current = onCredential }, [onCredential])
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function init() {
+      try {
+        const config = await getPublicConfig()
+        if (cancelled) return
+
+        await loadGIS()
+        if (cancelled) return
+
+        const g = (window as any).google
+        g.accounts.id.initialize({
+          client_id: config.googleClientId,
+          callback: (res: { credential: string }) => onCredentialRef.current(res.credential),
+          auto_select: false,
+        })
+
+        if (containerRef.current) {
+          g.accounts.id.renderButton(containerRef.current, {
+            theme: 'outline',
+            size: 'large',
+            width,
+            text: 'signin_with',
+            shape: 'rectangular',
+            logo_alignment: 'left',
+          })
+        }
+        if (!cancelled) setLoading(false)
+      } catch {
+        if (!cancelled) {
+          setLoading(false)
+          setFailed(true)
+        }
+      }
+    }
+
+    init()
+    return () => { cancelled = true }
+  }, [width])
+
+  if (failed) return null
+
+  return (
+    <Box position="relative" width={`${width}px`} height="44px">
+      {loading && (
+        <Box
+          position="absolute"
+          inset={0}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Spinner size="sm" />
+        </Box>
+      )}
+      <Box ref={containerRef} opacity={loading ? 0 : 1} transition="opacity 0.15s" />
+    </Box>
+  )
+}

--- a/components/auth/LoginModal.tsx
+++ b/components/auth/LoginModal.tsx
@@ -104,7 +104,7 @@ export default function LoginModal({
   )
 
   const handleEmailSubmit = useCallback(async () => {
-    if (!email || !password) return
+    if (!email || !password || loading) return
     setLoading(true)
     setError('')
     try {
@@ -242,7 +242,6 @@ export default function LoginModal({
                           size="sm"
                           variant="ghost"
                           onClick={() => setShowPassword((p) => !p)}
-                          tabIndex={-1}
                         />
                       </InputRightElement>
                     </InputGroup>

--- a/components/auth/LoginModal.tsx
+++ b/components/auth/LoginModal.tsx
@@ -1,31 +1,348 @@
-'use client';
-import { AiohaModal } from '@aioha/react-ui';
-import { Providers } from '@aioha/aioha';
-import './login-modal.css';
+'use client'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  Alert,
+  AlertIcon,
+  Box,
+  Button,
+  Divider,
+  FormControl,
+  FormLabel,
+  HStack,
+  IconButton,
+  Input,
+  InputGroup,
+  InputRightElement,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Text,
+  VStack,
+} from '@chakra-ui/react'
+import { AiohaModal } from '@aioha/react-ui'
+import { Providers } from '@aioha/aioha'
+import { FiEye, FiEyeOff } from 'react-icons/fi'
+import { loginWithEmail, loginWithGoogle, registerWithEmail, resendVerification } from '@/lib/snapie-auth/client'
+import { SnapieAuthError } from '@/lib/snapie-auth/types'
+import type { SnapieUser } from '@/lib/snapie-auth/types'
+import GoogleLoginButton from './GoogleLoginButton'
+import AccountSetupPanel from './AccountSetupPanel'
+import './login-modal.css'
 
-interface LoginModalProps {
-  displayed: boolean;
-  onLogin: (loginResult: any) => void;
-  onClose: () => void;
-  loginTitle?: string;
-  loginOptions?: any;
-  forceShowProviders?: Providers[];
+type View = 'providers' | 'email-pending' | 'account-setup' | 'hive-wallet'
+type EmailMode = 'login' | 'register'
+
+const EMAIL_ERRORS: Record<string, string> = {
+  unauthorized: 'Invalid email or password.',
+  email_not_verified: 'Please verify your email before signing in. Check your inbox.',
+  insufficient_rc: 'Service temporarily busy — please try again in a moment.',
+}
+
+interface Props {
+  displayed: boolean
+  onSnapieLoginSuccess: (user: SnapieUser) => void
+  onAiohaLogin: (result: any) => void
+  onClose: () => void
+  loginOptions?: any
+  forceShowProviders?: Providers[]
 }
 
 export default function LoginModal({
   displayed,
-  onLogin,
+  onSnapieLoginSuccess,
+  onAiohaLogin,
   onClose,
-  loginTitle = 'Login',
   loginOptions,
-}: LoginModalProps) {
+  forceShowProviders,
+}: Props) {
+  const [view, setView] = useState<View>('providers')
+  const [emailMode, setEmailMode] = useState<EmailMode>('register')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [pendingEmail, setPendingEmail] = useState('')
+  const [resending, setResending] = useState(false)
+  const [resent, setResent] = useState(false)
+
+  // Reset to default view whenever the modal reopens.
+  useEffect(() => {
+    if (displayed) {
+      setView('providers')
+      setError('')
+      setEmail('')
+      setPassword('')
+    }
+  }, [displayed])
+
+  const clearError = useCallback(() => setError(''), [])
+
+  const handleGoogleCredential = useCallback(
+    async (credential: string) => {
+      setLoading(true)
+      setError('')
+      try {
+        const user = await loginWithGoogle(credential)
+        onSnapieLoginSuccess(user)
+        if (!user.hiveUsername) setView('account-setup')
+      } catch (e: any) {
+        setError(EMAIL_ERRORS[e?.code] ?? 'Google sign-in failed. Please try again.')
+      } finally {
+        setLoading(false)
+      }
+    },
+    [onSnapieLoginSuccess],
+  )
+
+  const handleEmailSubmit = useCallback(async () => {
+    if (!email || !password) return
+    setLoading(true)
+    setError('')
+    try {
+      if (emailMode === 'register') {
+        await registerWithEmail(email, password)
+        setPendingEmail(email)
+        setView('email-pending')
+      } else {
+        const user = await loginWithEmail(email, password)
+        onSnapieLoginSuccess(user)
+        if (!user.hiveUsername) setView('account-setup')
+      }
+    } catch (e: any) {
+      const code = e?.code ?? ''
+      setError(EMAIL_ERRORS[code] ?? (emailMode === 'register'
+        ? 'Registration failed. Please try again.'
+        : 'Sign-in failed. Check your email and password.'))
+    } finally {
+      setLoading(false)
+    }
+  }, [email, password, emailMode, onSnapieLoginSuccess])
+
+  const handleResend = useCallback(async () => {
+    setResending(true)
+    try {
+      await resendVerification()
+      setResent(true)
+    } catch {
+      // Silently ignore — user can try again
+    } finally {
+      setResending(false)
+    }
+  }, [])
+
+  const handleAccountComplete = useCallback(
+    (user: SnapieUser) => {
+      onSnapieLoginSuccess(user)
+    },
+    [onSnapieLoginSuccess],
+  )
+
+  const modalTitles: Record<View, string> = {
+    providers: 'Welcome to Snapie',
+    'email-pending': 'Check your email',
+    'account-setup': 'Create your Hive account',
+    'hive-wallet': '',
+  }
+
   return (
-    <AiohaModal
-      displayed={displayed}
-      onLogin={onLogin}
-      onClose={onClose}
-      loginTitle={loginTitle}
-      loginOptions={loginOptions}
-    />
-  );
+    <>
+      {/* Custom Snapie Auth modal */}
+      <Modal
+        isOpen={displayed && view !== 'hive-wallet'}
+        onClose={onClose}
+        isCentered
+        motionPreset="slideInBottom"
+        size="sm"
+      >
+        <ModalOverlay backdropFilter="blur(4px)" />
+        <ModalContent mx={4}>
+          <ModalHeader pb={2}>{modalTitles[view]}</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody pb={6}>
+            {/* ── PROVIDERS VIEW ─────────────────────────────── */}
+            {view === 'providers' && (
+              <VStack spacing={4} align="stretch">
+                <Box display="flex" justifyContent="center">
+                  <GoogleLoginButton onCredential={handleGoogleCredential} width={320} />
+                </Box>
+
+                <HStack>
+                  <Divider />
+                  <Text fontSize="xs" color="gray.500" whiteSpace="nowrap" px={2}>
+                    or use email
+                  </Text>
+                  <Divider />
+                </HStack>
+
+                <Tabs
+                  index={emailMode === 'register' ? 0 : 1}
+                  onChange={(i) => { setEmailMode(i === 0 ? 'register' : 'login'); clearError() }}
+                  variant="soft-rounded"
+                  colorScheme="blue"
+                  size="sm"
+                >
+                  <TabList mb={3}>
+                    <Tab flex={1}>Create Account</Tab>
+                    <Tab flex={1}>Sign In</Tab>
+                  </TabList>
+
+                  <TabPanels>
+                    {/* Both panels share the same form fields — rendered once below */}
+                    <TabPanel p={0} />
+                    <TabPanel p={0} />
+                  </TabPanels>
+                </Tabs>
+
+                <VStack spacing={3} align="stretch">
+                  {error && (
+                    <Alert status="error" borderRadius="md" py={2}>
+                      <AlertIcon />
+                      <Text fontSize="sm">{error}</Text>
+                    </Alert>
+                  )}
+
+                  <FormControl>
+                    <FormLabel fontSize="sm">Email</FormLabel>
+                    <Input
+                      type="email"
+                      placeholder="you@example.com"
+                      value={email}
+                      onChange={(e) => { setEmail(e.target.value); clearError() }}
+                      onKeyDown={(e) => { if (e.key === 'Enter') handleEmailSubmit() }}
+                      isDisabled={loading}
+                      size="md"
+                    />
+                  </FormControl>
+
+                  <FormControl>
+                    <FormLabel fontSize="sm">Password</FormLabel>
+                    <InputGroup>
+                      <Input
+                        type={showPassword ? 'text' : 'password'}
+                        placeholder="••••••••"
+                        value={password}
+                        onChange={(e) => { setPassword(e.target.value); clearError() }}
+                        onKeyDown={(e) => { if (e.key === 'Enter') handleEmailSubmit() }}
+                        isDisabled={loading}
+                        size="md"
+                      />
+                      <InputRightElement>
+                        <IconButton
+                          aria-label={showPassword ? 'Hide password' : 'Show password'}
+                          icon={showPassword ? <FiEyeOff /> : <FiEye />}
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => setShowPassword((p) => !p)}
+                          tabIndex={-1}
+                        />
+                      </InputRightElement>
+                    </InputGroup>
+                  </FormControl>
+
+                  <Button
+                    colorScheme="blue"
+                    onClick={handleEmailSubmit}
+                    isLoading={loading}
+                    isDisabled={!email || !password}
+                    size="md"
+                    width="full"
+                  >
+                    {emailMode === 'register' ? 'Create Account' : 'Sign In'}
+                  </Button>
+                </VStack>
+
+                <HStack>
+                  <Divider />
+                  <Text fontSize="xs" color="gray.500" whiteSpace="nowrap" px={2}>
+                    already on Hive?
+                  </Text>
+                  <Divider />
+                </HStack>
+
+                <Button
+                  variant="outline"
+                  size="sm"
+                  width="full"
+                  onClick={() => setView('hive-wallet')}
+                >
+                  Sign in with Hive Wallet
+                </Button>
+              </VStack>
+            )}
+
+            {/* ── EMAIL PENDING VIEW ─────────────────────────── */}
+            {view === 'email-pending' && (
+              <VStack spacing={4} align="stretch">
+                <Alert status="info" borderRadius="md">
+                  <AlertIcon />
+                  <Box>
+                    <Text fontWeight="semibold" fontSize="sm">
+                      Verify your email
+                    </Text>
+                    <Text fontSize="sm" mt={1}>
+                      We sent a verification link to{' '}
+                      <Text as="span" fontWeight="semibold">
+                        {pendingEmail}
+                      </Text>
+                      . Click the link to activate your account, then come back and sign in.
+                    </Text>
+                  </Box>
+                </Alert>
+
+                {resent ? (
+                  <Text fontSize="sm" color="green.500" textAlign="center">
+                    Email resent! Check your inbox.
+                  </Text>
+                ) : (
+                  <Button
+                    variant="link"
+                    size="sm"
+                    colorScheme="blue"
+                    onClick={handleResend}
+                    isLoading={resending}
+                  >
+                    Resend verification email
+                  </Button>
+                )}
+
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => { setView('providers'); setEmailMode('login') }}
+                >
+                  Back to sign in
+                </Button>
+              </VStack>
+            )}
+
+            {/* ── ACCOUNT SETUP VIEW ─────────────────────────── */}
+            {view === 'account-setup' && (
+              <AccountSetupPanel onComplete={handleAccountComplete} />
+            )}
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+
+      {/* Aioha modal — rendered separately, shown when user chooses Hive wallet */}
+      <AiohaModal
+        displayed={displayed && view === 'hive-wallet'}
+        onLogin={(result: any) => {
+          onAiohaLogin(result)
+        }}
+        onClose={() => setView('providers')}
+        loginTitle="Sign in with Hive Wallet"
+        loginOptions={loginOptions}
+        forceShowProviders={forceShowProviders}
+      />
+    </>
+  )
 }

--- a/components/blog/PostDetails.tsx
+++ b/components/blog/PostDetails.tsx
@@ -7,7 +7,7 @@ import { getPostDate } from '@/lib/utils/GetPostDate';
 import markdownRenderer from '@/lib/utils/MarkdownRenderer';
 import NextLink from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { FaEdit } from 'react-icons/fa';
 import InteractionBar from '@/components/shared/InteractionBar';
 import SnapieSpeakAudio from '@/components/shared/SnapieSpeakAudio';
@@ -48,7 +48,7 @@ const bodySx = {
 export default function PostDetails({ post, isEmbedMode = false }: PostDetailsProps) {
     const { title, author, body, created } = post;
     const postDate = getPostDate(created);
-    const { user } = useAioha();
+    const { username: user } = useCurrentUser();
     const router = useRouter();
     const canEdit = !isEmbedMode && user === author;
     // Suppress the parent link for "top snaps" (direct replies to the snap container):

--- a/components/blog/PostSidebar.tsx
+++ b/components/blog/PostSidebar.tsx
@@ -5,7 +5,7 @@ import {
   Image, Icon,
 } from '@chakra-ui/react';
 import { FaGlobe, FaMapMarkerAlt } from 'react-icons/fa';
-import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { getProfile, getAccountPosts, getSimilarPosts } from '@/lib/hive/client-functions';
 import { getHiveAvatarUrl } from '@/lib/utils/avatarUtils';
 import UserActionButtons from '@/components/profile/UserActionButtons';
@@ -64,7 +64,7 @@ function SidebarBlock({ title, children }: { title: string; children: React.Reac
 }
 
 export default function PostSidebar({ author, permlink }: PostSidebarProps) {
-  const { user } = useAioha();
+  const { username: user } = useCurrentUser();
   const [profile, setProfile] = useState<any>(null);
   const [recentPosts, setRecentPosts] = useState<any[]>([]);
   const [similarPosts, setSimilarPosts] = useState<any[]>([]);

--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -27,7 +27,8 @@ import {
 import { keyframes } from '@emotion/react';
 import { useState, useEffect, useRef, useCallback, useMemo, KeyboardEvent, MouseEvent as ReactMouseEvent } from 'react';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
-import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { signMessageWithAioha } from '@/lib/hive/aioha';
 import { FiArrowDown, FiArrowLeft, FiArrowUp, FiChevronDown, FiCornerUpLeft, FiExternalLink, FiHash, FiImage, FiMaximize2, FiMessageSquare, FiMinus, FiPlus, FiSend, FiUsers, FiX } from 'react-icons/fi';
 import { KeyTypes } from '@aioha/aioha';
 import { chatService, Channel, Conversation, DmStatusInfo, Message } from '@/lib/chat/ChatService';
@@ -493,7 +494,7 @@ export default function ChatPanel({
   onPopout,
   isPopoutWindow,
 }: ChatPanelProps) {
-  const { user, aioha } = useAioha();
+  const { username: user } = useCurrentUser();
   const isMobile = useBreakpointValue({ base: true, md: false });
   const isTablet = useBreakpointValue({ base: false, md: true, lg: false }) ?? false;
 
@@ -1032,7 +1033,7 @@ export default function ChatPanel({
     setUploadingImage(true);
     setPanelError('');
     try {
-      const signatureRes = await aioha.signMessage(file.name, KeyTypes.Posting);
+      const signatureRes = await signMessageWithAioha(file.name, KeyTypes.Posting);
       if (!signatureRes.success || !signatureRes.result) {
         throw new Error('Could not sign image upload request');
       }
@@ -1206,7 +1207,7 @@ export default function ChatPanel({
     setAuthState('connecting');
     try {
       await chatService.authenticate(user, async (challenge) => {
-        const res = await aioha.signMessage(challenge, KeyTypes.Posting);
+        const res = await signMessageWithAioha(challenge, KeyTypes.Posting);
         if (!res.success || !res.result) throw new Error('Sign failed');
         return res.result as string;
       });

--- a/components/hangouts/HangoutModal.tsx
+++ b/components/hangouts/HangoutModal.tsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom';
 import { Center, Spinner, Text, VStack, Button, Box } from '@chakra-ui/react';
 import { HangoutsProvider, HangoutsRoom, useHangoutsRoom, HangoutsApiClient } from '@snapie/hangouts-react';
 import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useHangout } from '@/contexts/HangoutContext';
 import { useWakeLock } from '@/hooks/useWakeLock';
 import { providerSignPrompt } from '@/lib/utils/aiohaProviderUi';
@@ -58,7 +59,7 @@ interface RoomBodyProps {
 
 function RoomBody({ roomName, onClose }: RoomBodyProps) {
   const router = useRouter();
-  const { user } = useAioha();
+  const { username: user } = useCurrentUser();
   const { roomMeta } = useHangoutsRoom();
   const [roomData, setRoomData] = useState<any | null>(null);
 
@@ -133,7 +134,8 @@ function RoomBody({ roomName, onClose }: RoomBodyProps) {
 
 export default function HangoutModal({ isOpen, onClose, roomName }: HangoutModalProps) {
   useWakeLock(isOpen);
-  const { user, aioha } = useAioha();
+  const { aioha } = useAioha();
+  const { username: user } = useCurrentUser();
   const { sessionToken, sessionLoading, error, retryLogin } = useHangout();
 
   useEffect(() => {

--- a/components/hangouts/HangoutsLobbyView.tsx
+++ b/components/hangouts/HangoutsLobbyView.tsx
@@ -5,6 +5,7 @@ import '@snapie/hangouts-react/src/styles/hangouts.css';
 import '@/app/hangouts/overrides.css';
 import { useHangout } from '@/contexts/HangoutContext';
 import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { snapieHangoutComposer } from '@/lib/utils/composerSdk';
 import { getLastSnapsContainer, signAndBroadcastWithKeychain } from '@/lib/hive/client-functions';
 import { providerSignPrompt } from '@/lib/utils/aiohaProviderUi';
@@ -104,7 +105,8 @@ function GuestLobby() {
 }
 
 export default function HangoutsLobbyView({ roomName }: HangoutsLobbyViewProps) {
-  const { user, aioha } = useAioha();
+  const { aioha } = useAioha();
+  const { username: user } = useCurrentUser();
   const { openRoom, sessionToken, sessionLoading, error, retryLogin } = useHangout();
 
   // Lazy-sign on landing — the context no longer auto-signs on user change.

--- a/components/homepage/Snap.tsx
+++ b/components/homepage/Snap.tsx
@@ -2,7 +2,7 @@ import { Box, Text, HStack, Button, Avatar, Link, VStack, Flex, Modal, ModalOver
 import { Comment } from '@hiveio/dhive';
 import { ExtendedComment } from '@/hooks/useComments';
 import { FaRegComment, FaRegHeart, FaShare, FaHeart, FaEdit, FaRetweet } from "react-icons/fa";
-import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useState, useMemo, memo, useCallback } from 'react';
 import { getPostDate } from '@/lib/utils/GetPostDate';
 import { separateContent, extractHivePostUrls, extractHangoutUrls } from '@/lib/utils/snapUtils';
@@ -26,7 +26,7 @@ interface SnapProps {
 
 const Snap = memo(({ comment, onOpen, setReply, setConversation, level = 0 }: SnapProps) => {
     const commentDate = getPostDate(comment.created);
-    const { user } = useAioha();
+    const { username: user } = useCurrentUser();
     const [isEditModalOpen, setIsEditModalOpen] = useState(false);
     const [editedBody, setEditedBody] = useState(comment.body);
     const [isEditing, setIsEditing] = useState(false);

--- a/components/homepage/SnapComposer.tsx
+++ b/components/homepage/SnapComposer.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef } from 'react';
 import { Box, Textarea, HStack, Button, Image, IconButton, Wrap, Spinner, Progress, Text, VStack } from '@chakra-ui/react';
-import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import GiphySelector from './GiphySelector';
 import ImageUploader from './ImageUploader';
 import VideoUploader from './VideoUploader';
@@ -40,7 +40,7 @@ interface SnapComposerProps {
 }
 
 export default function SnapComposer ({ pa, pp, onNewComment, post = false, onClose }: SnapComposerProps) {
-    const { user } = useAioha();
+    const { username: user } = useCurrentUser();
 
     const postBodyRef = useRef<HTMLTextAreaElement>(null);
     const [uploadingImages, setUploadingImages] = useState<UploadingImage[]>([]);

--- a/components/join/QuotaWidget.tsx
+++ b/components/join/QuotaWidget.tsx
@@ -14,7 +14,7 @@ export default function QuotaWidget() {
     async function fetch() {
       try {
         const q = await getQuota()
-        if (!cancelled) setQuota(q)
+        if (!cancelled) { setQuota(q); setError(false) }
       } catch {
         if (!cancelled) setError(true)
       }
@@ -30,7 +30,7 @@ export default function QuotaWidget() {
   }
 
   const resetsAt = new Date(quota.resetsAt)
-  const resetStr = resetsAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  const resetStr = resetsAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', timeZone: 'UTC' })
 
   return (
     <Tooltip

--- a/components/join/QuotaWidget.tsx
+++ b/components/join/QuotaWidget.tsx
@@ -1,0 +1,55 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { Badge, Box, Skeleton, Text, Tooltip } from '@chakra-ui/react'
+import { getQuota } from '@/lib/snapie-auth/client'
+import type { QuotaResponse } from '@/lib/snapie-auth/types'
+
+export default function QuotaWidget() {
+  const [quota, setQuota] = useState<QuotaResponse | null>(null)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function fetch() {
+      try {
+        const q = await getQuota()
+        if (!cancelled) setQuota(q)
+      } catch {
+        if (!cancelled) setError(true)
+      }
+    }
+
+    fetch()
+    const interval = setInterval(fetch, 60_000)
+    return () => { cancelled = true; clearInterval(interval) }
+  }, [])
+
+  if (error || !quota) {
+    return <Skeleton height="20px" width="200px" borderRadius="full" />
+  }
+
+  const resetsAt = new Date(quota.resetsAt)
+  const resetStr = resetsAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+
+  return (
+    <Tooltip
+      label={`Resets at ${resetStr} UTC. Use a sponsor link to bypass this limit.`}
+      placement="bottom"
+    >
+      <Box display="inline-flex" alignItems="center" gap={2} cursor="default">
+        <Badge
+          colorScheme={quota.remaining === 0 ? 'red' : quota.remaining <= 3 ? 'orange' : 'green'}
+          borderRadius="full"
+          px={2}
+          fontSize="xs"
+        >
+          {quota.remaining === 0 ? 'Full today' : `${quota.remaining} of ${quota.total} free slots`}
+        </Badge>
+        <Text fontSize="xs" color="gray.500">
+          resets {resetStr} UTC
+        </Text>
+      </Box>
+    </Tooltip>
+  )
+}

--- a/components/join/SponsorFlow.tsx
+++ b/components/join/SponsorFlow.tsx
@@ -109,7 +109,7 @@ export default function SponsorFlow({ code }: SponsorFlowProps) {
     if (!data || !hiveUser?.name) return;
     setMode('broadcasting');
     setError(null);
-    const postingDelegate = process.env.NEXT_PUBLIC_POSTING_AUTHORITY_ACCOUNT ?? 'snapie';
+    const postingDelegate = process.env.NEXT_PUBLIC_POSTING_AUTHORITY_ACCOUNT?.trim() || 'snapie';
     try {
       let op: [string, Record<string, unknown>];
       let title: string;

--- a/components/join/SponsorFlow.tsx
+++ b/components/join/SponsorFlow.tsx
@@ -40,6 +40,14 @@ function buildAuth(pub: string) {
   };
 }
 
+function buildPostingAuth(pub: string, delegate: string) {
+  return {
+    weight_threshold: 1,
+    account_auths: [[delegate, 1]] as Array<[string, number]>,
+    key_auths: [[pub, 1]] as Array<[string, number]>,
+  };
+}
+
 export default function SponsorFlow({ code }: SponsorFlowProps) {
   const { hiveUser } = useHiveUser();
   const { openLoginModal } = useLoginModal();
@@ -101,6 +109,7 @@ export default function SponsorFlow({ code }: SponsorFlowProps) {
     if (!data || !hiveUser?.name) return;
     setMode('broadcasting');
     setError(null);
+    const postingDelegate = process.env.NEXT_PUBLIC_POSTING_AUTHORITY_ACCOUNT ?? 'snapie';
     try {
       let op: [string, Record<string, unknown>];
       let title: string;
@@ -118,7 +127,7 @@ export default function SponsorFlow({ code }: SponsorFlowProps) {
           new_account_name: data.username,
           owner: buildAuth(data.ownerPubkey),
           active: buildAuth(data.activePubkey),
-          posting: buildAuth(data.postingPubkey),
+          posting: buildPostingAuth(data.postingPubkey, postingDelegate),
           memo_key: data.memoPubkey,
           json_metadata: '',
           extensions: [],
@@ -131,7 +140,7 @@ export default function SponsorFlow({ code }: SponsorFlowProps) {
           new_account_name: data.username,
           owner: buildAuth(data.ownerPubkey),
           active: buildAuth(data.activePubkey),
-          posting: buildAuth(data.postingPubkey),
+          posting: buildPostingAuth(data.postingPubkey, postingDelegate),
           memo_key: data.memoPubkey,
           json_metadata: '',
         }];

--- a/components/layout/FooterNavigation.tsx
+++ b/components/layout/FooterNavigation.tsx
@@ -166,7 +166,7 @@ export default function FooterNavigation({ isChatOpen = false, setIsChatOpen, ch
                     </Box>
                 </Tooltip>
 
-                {isLoggedIn ? (
+                {user ? (
                     <>
                         <Tooltip label="Notifications" aria-label="Notifications tooltip">
                             <Box position="relative">

--- a/components/layout/FooterNavigation.tsx
+++ b/components/layout/FooterNavigation.tsx
@@ -1,4 +1,4 @@
-import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useLoginModal } from '@/contexts/LoginModalContext';
 import { Box, Button, HStack, Icon, Tooltip, useColorMode } from '@chakra-ui/react';
 import { CountBadge } from '@/components/ui/CountBadge';
@@ -16,9 +16,8 @@ interface FooterNavigationProps {
 
 export default function FooterNavigation({ isChatOpen = false, setIsChatOpen, chatUnreadCount = 0 }: FooterNavigationProps) {
 
-    const { user, aioha } = useAioha();
+    const { username: user, isLoggedIn, logout } = useCurrentUser();
     const { openLoginModal } = useLoginModal();
-    const logout = () => aioha.logout();
     const { colorMode } = useColorMode();
     const scrollRef = useRef<HTMLDivElement>(null);
     const [showLeftFade, setShowLeftFade] = useState(false);
@@ -167,7 +166,7 @@ export default function FooterNavigation({ isChatOpen = false, setIsChatOpen, ch
                     </Box>
                 </Tooltip>
 
-                {user ? (
+                {isLoggedIn ? (
                     <>
                         <Tooltip label="Notifications" aria-label="Notifications tooltip">
                             <Box position="relative">

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Flex, Text, Button, Image, useColorMode, useToast } from '@chakra-ui/react';
 import { getCommunityInfo, getProfile } from '@/lib/hive/client-functions';
-import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useLoginModal } from '@/contexts/LoginModalContext';
 import { getHiveAvatarUrl } from '@/lib/utils/avatarUtils';
 
@@ -10,9 +10,8 @@ export default function Header() {
     const { colorMode } = useColorMode();
     const [profileInfo, setProfileInfo] = useState<any>();
     const [communityInfo, setCommunityInfo] = useState<any>();
-    const { user, aioha } = useAioha();
+    const { username: user, isLoggedIn, logout } = useCurrentUser();
     const { openLoginModal } = useLoginModal();
-    const isLoggedIn = !!user;
     const toast = useToast();
 
     const communityTag = process.env.NEXT_PUBLIC_HIVE_COMMUNITY_TAG;
@@ -81,7 +80,7 @@ export default function Header() {
                     </Flex>
                 </Flex>
                 {isLoggedIn ? (
-                    <Button onClick={() => aioha.logout()}>
+                    <Button onClick={logout}>
                         Logout ({user})
                     </Button>
                 ) : (

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -81,7 +81,7 @@ export default function Header() {
                 </Flex>
                 {isLoggedIn ? (
                     <Button onClick={logout}>
-                        Logout ({user})
+                        Logout ({user ?? 'account'})
                     </Button>
                 ) : (
                     <Button onClick={openLoginModal}>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -4,7 +4,7 @@ import { Box, VStack, Button, Icon, Image, Spinner, Flex, Text, useColorMode, tr
 import { CountBadge } from '@/components/ui/CountBadge';
 import { usePathname } from 'next/navigation';
 import NextLink from 'next/link';
-import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { useLoginModal } from '@/contexts/LoginModalContext';
 import { FiHome, FiBell, FiUser, FiShoppingCart, FiBook, FiCreditCard, FiLogIn, FiLogOut, FiMessageSquare, FiRadio, FiInfo, FiUserPlus, FiPlay } from 'react-icons/fi';
 import { getCommunityInfo, getProfile } from '@/lib/hive/client-functions';
@@ -36,10 +36,8 @@ interface SidebarProps {
 }
 
 export default function Sidebar({ isChatOpen = false, setIsChatOpen, chatUnreadCount = 0 }: SidebarProps) {
-    const { user, aioha } = useAioha();
+    const { username: user, isLoggedIn, logout } = useCurrentUser();
     const { openLoginModal } = useLoginModal();
-    const isLoggedIn = !!user;
-    const logout = () => aioha.logout();
     const pathname = usePathname();
     const [communityInfo, setCommunityInfo] = useState<CommunityInfo | null>(null); // State to hold community info
     const [profileInfo, setProfileInfo] = useState<ProfileInfo | null>(null); // State to hold profile info

--- a/components/notifications/NotificationsComp.tsx
+++ b/components/notifications/NotificationsComp.tsx
@@ -17,7 +17,7 @@ import {
   useToast,
   VStack,
 } from '@chakra-ui/react';
-import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { Notifications } from '@hiveio/dhive';
 import { useRouter } from 'next/navigation';
 import {
@@ -199,7 +199,7 @@ function getSummaryItems(summary: ActivitySummary) {
 }
 
 export default function NotificationsComp({ username }: NotificationCompProps) {
-  const { user } = useAioha();
+  const { username: user } = useCurrentUser();
   const router = useRouter();
   const toast = useToast();
   const [filter, setFilter] = useState<NotificationFilter>('all');

--- a/components/profile/ProfilePage.tsx
+++ b/components/profile/ProfilePage.tsx
@@ -15,7 +15,7 @@ import FollowersModal from './FollowersModal';
 import SnapList from '@/components/homepage/SnapList';
 import Conversation from '@/components/homepage/Conversation';
 import SnapReplyModal from '@/components/homepage/SnapReplyModal';
-import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { getHiveAvatarUrl } from '@/lib/utils/avatarUtils';
 import { useProfileSnaps } from '@/hooks/useProfileSnaps';
 import { ExtendedComment } from '@/hooks/useComments';
@@ -25,7 +25,7 @@ interface ProfilePageProps {
 }
 
 export default function ProfilePage({ username }: ProfilePageProps) {
-  const { user } = useAioha();
+  const { username: user } = useCurrentUser();
   const { hiveAccount, isLoading, error } = useHiveAccount(username);
   const [profileInfo, setProfileInfo] = useState<any>(null);
 

--- a/components/profile/UserActionButtons.tsx
+++ b/components/profile/UserActionButtons.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { HStack, Button, useToast, Spinner } from '@chakra-ui/react';
 import { getRelationshipBetweenAccounts, setUserRelationship } from '@/lib/hive/client-functions';
-import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 
 interface UserActionButtonsProps {
   targetUsername: string;
@@ -11,7 +11,7 @@ interface UserActionButtonsProps {
 }
 
 export default function UserActionButtons({ targetUsername, currentUsername, showBlacklist = true }: UserActionButtonsProps) {
-  const { user } = useAioha();
+  const { username: user } = useCurrentUser();
   const toast = useToast();
   const [isFollowing, setIsFollowing] = useState(false);
   const [isMuted, setIsMuted] = useState(false);

--- a/components/shared/InteractionBar.tsx
+++ b/components/shared/InteractionBar.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, Icon, Button, Text, Slider, SliderTrack, SliderFilledTrack, 
 import React, { useState, useEffect } from 'react';
 import { Discussion } from '@hiveio/dhive';
 import { FaHeart, FaComment, FaRegHeart, FaShare, FaRetweet } from 'react-icons/fa';
-import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { vote } from '@/lib/hive/client-functions';
 import { useCurrencyDisplay } from '@/hooks/useCurrencyDisplay';
 import { useVoteCalculator } from '@/hooks/useVoteCalculator';
@@ -20,7 +20,7 @@ export default function InteractionBar({
     onCommentClick,
     isEmbedMode = false 
 }: InteractionBarProps) {
-    const { user } = useAioha();
+    const { username: user } = useCurrentUser();
     const [sliderValue, setSliderValue] = useState(100);
     const [showSlider, setShowSlider] = useState(false);
     const [voted, setVoted] = useState(false);

--- a/components/shorts/ShortCard.tsx
+++ b/components/shorts/ShortCard.tsx
@@ -6,7 +6,7 @@ import { usePlayer } from '@mantequilla-soft/3speak-player/react';
 import { FaHeart, FaRegHeart, FaComment, FaShare, FaVolumeUp, FaVolumeMute } from 'react-icons/fa';
 import { ShortItem } from '@/lib/shorts/types';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { vote } from '@/lib/hive/client-functions';
 import ShortsCommentSheet from './ShortsCommentSheet';
 
@@ -98,7 +98,7 @@ export default function ShortCard({ short, isActive, isPreload, muted, onToggleM
   const { isOpen: commentsOpen, onOpen: openComments, onClose: closeComments } = useDisclosure();
   const [liked, setLiked] = useState(false);
   const [likeCount, setLikeCount] = useState(short.stats.likes);
-  const { user } = useAioha();
+  const { username: user } = useCurrentUser();
   const toast = useToast();
 
   async function handleLike() {

--- a/components/wallet/WalletModal.tsx
+++ b/components/wallet/WalletModal.tsx
@@ -17,7 +17,7 @@ interface WalletModalProps {
     showMemoField?: boolean;
     showUsernameField?: boolean; // New prop to show the username field
     swapConfig?: WalletModalSwapConfig;
-    onConfirm: (amount: number, username?: string, memo?: string, swapDirection?: SwapDirection, slippagePercent?: number) => void; // Include username in the onConfirm callback
+    onConfirm: (amount: number, username?: string, memo?: string, swapDirection?: SwapDirection, slippagePercent?: number) => Promise<void>;
 }
 
 const SLIPPAGE_PRESETS = [0.1, 0.5, 1.0];
@@ -26,6 +26,7 @@ export default function WalletModal ({ isOpen, onClose, title, description, show
     const [amount, setAmount] = useState<number>(0);
     const [memo, setMemo] = useState<string>('');
     const [username, setUsername] = useState<string>(''); // State to hold username
+    const [isLoading, setIsLoading] = useState(false);
     const [customSlippage, setCustomSlippage] = useState<string>('');
     const [selectedSlippage, setSelectedSlippage] = useState<string>('');
 
@@ -57,14 +58,19 @@ export default function WalletModal ({ isOpen, onClose, title, description, show
         ? expectedReceive * (1 - effectiveSlippage / 100)
         : 0;
 
-    const handleConfirm = () => {
-        onConfirm(
-            amount,
-            showUsernameField ? username : undefined,
-            showMemoField ? memo : undefined,
-            swapConfig?.direction,
-            effectiveSlippage,
-        );
+    const handleConfirm = async () => {
+        setIsLoading(true);
+        try {
+            await onConfirm(
+                amount,
+                showUsernameField ? username : undefined,
+                showMemoField ? memo : undefined,
+                swapConfig?.direction,
+                effectiveSlippage,
+            );
+        } finally {
+            setIsLoading(false);
+        }
     };
 
     return (
@@ -161,11 +167,13 @@ export default function WalletModal ({ isOpen, onClose, title, description, show
                     )}
                 </ModalBody>
                 <ModalFooter>
-                    <Button variant="ghost" onClick={onClose}>Cancel</Button>
+                    <Button variant="ghost" onClick={onClose} isDisabled={isLoading}>Cancel</Button>
                     <Button
                         ml={3}
                         onClick={handleConfirm}
-                        isDisabled={isSwapMode && (effectiveSlippage === undefined || Number.isNaN(effectiveSlippage) || effectiveSlippage < 0 || effectiveSlippage > 20)}
+                        isLoading={isLoading}
+                        loadingText="Processing…"
+                        isDisabled={isLoading || (isSwapMode && (effectiveSlippage === undefined || Number.isNaN(effectiveSlippage) || effectiveSlippage < 0 || effectiveSlippage > 20))}
                     >
                         Confirm
                     </Button>

--- a/components/wallet/WalletModal.tsx
+++ b/components/wallet/WalletModal.tsx
@@ -74,11 +74,16 @@ export default function WalletModal ({ isOpen, onClose, title, description, show
     };
 
     return (
-        <Modal isOpen={isOpen} onClose={onClose}>
+        <Modal
+            isOpen={isOpen}
+            onClose={isLoading ? () => {} : onClose}
+            closeOnOverlayClick={!isLoading}
+            closeOnEsc={!isLoading}
+        >
             <ModalOverlay />
             <ModalContent>
                 <ModalHeader>{title}</ModalHeader>
-                <ModalCloseButton />
+                <ModalCloseButton isDisabled={isLoading} />
                 <ModalBody>
                     {description && <Text fontSize={'small'} mb={4}>{description}</Text>}
                     <Box mb={4}>

--- a/components/wallet/WalletPage.tsx
+++ b/components/wallet/WalletPage.tsx
@@ -34,13 +34,15 @@ import {
   getHiveHbdMarketQuote,
   swapHiveHbdWithSlippage,
   claimRewardsWithKeychain,
+  claimHbdSavingsInterest,
   type SwapDirection,
 } from '@/lib/hive/client-functions';
+import { useHbdSavingsInterest } from '@/hooks/useHbdSavingsInterest';
 import { extractNumber } from '@/lib/utils/extractNumber';
 import WalletModal from '@/components/wallet/WalletModal';
 import TransactionHistory from '@/components/wallet/TransactionHistory';
 import { useRouter } from 'next/navigation';
-import { useAioha } from '@aioha/react-ui';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { getHiveAvatarUrl } from '@/lib/utils/avatarUtils';
 
 interface WalletPageProps {
@@ -57,7 +59,7 @@ interface WalletModalContent {
 
 export default function WalletPage({ username }: WalletPageProps) {
   const router = useRouter();
-  const { user } = useAioha();
+  const { username: user } = useCurrentUser();
   const { hiveAccount, isLoading, error, refetch } = useHiveAccount(username);
   const { isOpen, onOpen, onClose } = useDisclosure();
 
@@ -73,13 +75,15 @@ export default function WalletPage({ username }: WalletPageProps) {
   const [swapPrice, setSwapPrice] = useState<number | null>(null);
   const [swapQuote, setSwapQuote] = useState<{ highestBid: number; lowestAsk: number; latest: number } | null>(null);
   const [isClaiming, setIsClaiming] = useState(false);
+  const [isClaimingInterest, setIsClaimingInterest] = useState(false);
+  const { pendingInterest, annualRatePct, isLoading: isInterestLoading } = useHbdSavingsInterest(hiveAccount);
 
   const textMuted = 'gray.400';
   const successColor = 'success';
   const accentColor = 'accent';
 
   useEffect(() => {
-    if (hiveAccount?.json_metadata) {
+    if (hiveAccount?.posting_json_metadata) {
       try {
         const parsedMetadata = JSON.parse(hiveAccount.posting_json_metadata);
         const profile = parsedMetadata?.profile || {};
@@ -173,7 +177,7 @@ export default function WalletPage({ username }: WalletPageProps) {
         case 'Power Up':
           await powerUpWithKeychain(user, amount);
           break;
-        case 'Convert HIVE':
+        case 'Convert HBD → HIVE':
           await broadcastWithKeychain(user, [["convert", { "owner": user, "requestid": Math.floor(1000000000 + Math.random() * 9000000000), "amount": { "amount": amount.toFixed(3), "precision": 3, "nai": "@@000000013" } }]], 'active');
           break;
         case 'Swap HIVE':
@@ -490,7 +494,7 @@ export default function WalletPage({ username }: WalletPageProps) {
               <Flex gap={2} flexWrap="wrap" px={5} pb={4}>
                 <Button size="sm" leftIcon={<FaPaperPlane />} onClick={() => handleModalOpen({ title: 'Send HIVE', description: 'Send Hive to another account', showMemoField: true, showUsernameField: true })} variant="outline" colorScheme="blue">Send</Button>
                 <Button size="sm" leftIcon={<FaArrowUp />} onClick={() => handleModalOpen({ title: 'Power Up', description: 'Power Up your HIVE to HP' })} variant="outline" colorScheme="purple">Power Up</Button>
-                <Button size="sm" leftIcon={<FaExchangeAlt />} onClick={() => handleModalOpen({ title: 'Convert HIVE', description: 'Convert HIVE to HBD (3.5 day settlement)' })} variant="outline" colorScheme="orange">Convert</Button>
+                <Button size="sm" leftIcon={<FaExchangeAlt />} onClick={() => handleModalOpen({ title: 'Convert HBD → HIVE', description: 'Burn HBD to receive HIVE at a 3.5-day average price' })} variant="outline" colorScheme="orange">Convert</Button>
                 <Button size="sm" leftIcon={<FaExchangeAlt />} onClick={() => handleModalOpen({ title: 'Swap HIVE', description: 'Fast market swap HIVE -> HBD (immediate-or-cancel)', swapDirection: 'HIVE_TO_HBD' })} variant="outline" colorScheme="yellow">Swap</Button>
                 <Button size="sm" leftIcon={<FaPiggyBank />} onClick={() => handleModalOpen({ title: 'HIVE Savings', description: 'Transfer to HIVE savings' })} variant="outline" colorScheme="teal">To Savings</Button>
                 <Button
@@ -657,7 +661,41 @@ export default function WalletPage({ username }: WalletPageProps) {
                 </Box>
                 <Box p={4} bg="rgba(66, 231, 162, 0.04)" borderRadius="10px" border="tb1">
                   <Text fontSize="xs" color={textMuted} textTransform="uppercase" letterSpacing="wide" mb={1}>HBD Savings</Text>
-                  <Text fontSize="xl" fontWeight="bold" mb={2}>{hbdSavingsBalance}</Text>
+                  <Text fontSize="xl" fontWeight="bold" mb={1}>{hbdSavingsBalance}</Text>
+                  {annualRatePct > 0 && (
+                    <Text fontSize="xs" color="green.400" mb={2}>{annualRatePct.toFixed(0)}% APR</Text>
+                  )}
+                  {isOwnWallet && pendingInterest >= 0.001 && (
+                    <Box mb={2} p={2} bg="rgba(66, 231, 162, 0.08)" borderRadius="8px" border="1px solid" borderColor="rgba(66, 231, 162, 0.2)">
+                      <Text fontSize="xs" color={textMuted} mb={1}>Pending interest</Text>
+                      <Text fontSize="sm" fontWeight="bold" color="green.300" mb={2}>
+                        {isInterestLoading ? '…' : `~${pendingInterest.toFixed(3)} HBD`}
+                      </Text>
+                      <Button
+                        size="xs"
+                        colorScheme="green"
+                        variant="solid"
+                        isLoading={isClaimingInterest}
+                        loadingText="Claiming…"
+                        isDisabled={parseFloat(String(hiveAccount?.hbd_balance ?? '0')) < 0.001}
+                        title={parseFloat(String(hiveAccount?.hbd_balance ?? '0')) < 0.001 ? 'You need at least 0.001 liquid HBD to trigger interest' : ''}
+                        onClick={async () => {
+                          if (!user) return;
+                          setIsClaimingInterest(true);
+                          try {
+                            await claimHbdSavingsInterest(user);
+                            setTimeout(refetch, 3500);
+                          } catch (e) {
+                            console.error('Failed to claim HBD interest:', e);
+                          } finally {
+                            setIsClaimingInterest(false);
+                          }
+                        }}
+                      >
+                        Claim Interest
+                      </Button>
+                    </Box>
+                  )}
                   {isOwnWallet && (
                     <Button size="xs" leftIcon={<FaDollarSign />} onClick={() => handleModalOpen({ title: 'Withdraw HBD Savings', description: 'Withdraw HBD from Savings' })} variant="ghost" colorScheme="teal">
                       Withdraw

--- a/components/wallet/WalletPage.tsx
+++ b/components/wallet/WalletPage.tsx
@@ -83,20 +83,22 @@ export default function WalletPage({ username }: WalletPageProps) {
   const accentColor = 'accent';
 
   useEffect(() => {
-    if (hiveAccount?.posting_json_metadata) {
-      try {
-        const parsedMetadata = JSON.parse(hiveAccount.posting_json_metadata);
-        const profile = parsedMetadata?.profile || {};
-        setProfileMetadata({
-          profileImage: profile.profile_image || '',
-          coverImage: profile.cover_image || '',
-          website: profile.website || '',
-        });
-      } catch (err) {
-        console.error('Failed to parse profile metadata', err);
-      }
+    const empty = { profileImage: '', coverImage: '', website: '' };
+    const raw = hiveAccount?.posting_json_metadata;
+    if (!raw) { setProfileMetadata(empty); return; }
+    try {
+      const parsedMetadata = JSON.parse(raw);
+      const profile = parsedMetadata?.profile || {};
+      setProfileMetadata({
+        profileImage: profile.profile_image || '',
+        coverImage: profile.cover_image || '',
+        website: profile.website || '',
+      });
+    } catch (err) {
+      console.error('Failed to parse profile metadata', err);
+      setProfileMetadata(empty);
     }
-  }, [hiveAccount]);
+  }, [hiveAccount?.posting_json_metadata]);
 
   useEffect(() => {
     const fetchProfileInfo = async () => {

--- a/contexts/HangoutContext.tsx
+++ b/contexts/HangoutContext.tsx
@@ -3,6 +3,8 @@ import { createContext, useContext, useState, useEffect, useRef, useCallback, ty
 import { HangoutsApiClient, loginWithSignFn } from '@snapie/hangouts-core';
 import { KeyTypes } from '@aioha/aioha';
 import { useAioha } from '@aioha/react-ui';
+import { signMessageWithAioha } from '@/lib/hive/aioha';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
 
 const HANGOUTS_API_URL = process.env.NEXT_PUBLIC_HANGOUTS_API_URL || '';
 const OPENPODS_ENABLED = !!HANGOUTS_API_URL;
@@ -82,7 +84,8 @@ export function HangoutContextProvider({ children }: { children: ReactNode }) {
   const [sessionLoading, setSessionLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const { user, aioha } = useAioha();
+  const { aioha } = useAioha();
+  const { username: user } = useCurrentUser();
   const storageRef = useRef(buildTokenStorage(TOKEN_STORAGE_MODE));
 
   const loginToHangouts = useCallback(async (requestedUser?: string): Promise<string | null> => {
@@ -133,9 +136,7 @@ export function HangoutContextProvider({ children }: { children: ReactNode }) {
     setError(null);
 
     const signFn = async (message: string): Promise<string> => {
-      const res = await aioha.signMessage(message, KeyTypes.Posting);
-      if (!res.success) throw new Error(res.error || 'Failed to sign hangouts challenge');
-      if (!res.result) throw new Error('Sign returned empty result');
+      const res = await signMessageWithAioha(message, KeyTypes.Posting);
       return res.result;
     };
 

--- a/contexts/LoginModalContext.tsx
+++ b/contexts/LoginModalContext.tsx
@@ -84,8 +84,6 @@ export function LoginModalProvider({ children }: { children: ReactNode }) {
   // Clear session on Aioha logout (only when not in Snapie mode).
   useEffect(() => {
     if (aiohaUser || isSnapieLoggedIn) return
-    const existingCookie = document.cookie.match(/(?:^|; )hive_username=([^;]+)/)
-    if (!existingCookie) return
     setSigningAuthMode(null)
     deleteCookie('hive_username')
     localStorage.removeItem('hiveuser')

--- a/contexts/LoginModalContext.tsx
+++ b/contexts/LoginModalContext.tsx
@@ -1,4 +1,4 @@
-'use client';
+'use client'
 import {
   createContext,
   useCallback,
@@ -7,114 +7,127 @@ import {
   useMemo,
   useState,
   type ReactNode,
-} from 'react';
-import { useAioha } from '@aioha/react-ui';
-import { KeyTypes } from '@aioha/aioha';
-import LoginModal from '@/components/auth/LoginModal';
-import HiveClient from '@/lib/hive/hiveclient';
-import { useHiveUser } from '@/contexts/UserContext';
-import type { HiveAccount } from '@/hooks/useHiveAccount';
-import { getLoginProviders } from '@/lib/hive/aioha';
+} from 'react'
+import { useAioha } from '@aioha/react-ui'
+import { KeyTypes } from '@aioha/aioha'
+import LoginModal from '@/components/auth/LoginModal'
+import HiveClient from '@/lib/hive/hiveclient'
+import { useHiveUser } from '@/contexts/UserContext'
+import { useSnapieAuth } from '@/contexts/SnapieAuthContext'
+import { setSigningAuthMode } from '@/lib/hive/signing'
+import type { HiveAccount } from '@/hooks/useHiveAccount'
+import type { SnapieUser } from '@/lib/snapie-auth/types'
+import { getLoginProviders } from '@/lib/hive/aioha'
 
 interface LoginModalContextValue {
-  isOpen: boolean;
-  openLoginModal: () => void;
-  closeLoginModal: () => void;
+  isOpen: boolean
+  openLoginModal: () => void
+  closeLoginModal: () => void
 }
 
-const LoginModalContext = createContext<LoginModalContextValue | null>(null);
+const LoginModalContext = createContext<LoginModalContextValue | null>(null)
 
 const setCookie = (name: string, value: string, days = 30) => {
-  const expires = new Date();
-  expires.setTime(expires.getTime() + days * 24 * 60 * 60 * 1000);
-  document.cookie = `${name}=${value};expires=${expires.toUTCString()};path=/`;
-};
+  const expires = new Date()
+  expires.setTime(expires.getTime() + days * 24 * 60 * 60 * 1000)
+  document.cookie = `${name}=${value};expires=${expires.toUTCString()};path=/`
+}
 
 const deleteCookie = (name: string) => {
-  document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/`;
-};
+  document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/`
+}
 
-async function fetchAndStoreAccount(username: string) {
+export async function fetchAndStoreAccount(username: string): Promise<HiveAccount | null> {
   try {
-    const accounts = await HiveClient.database.getAccounts([username]);
-    if (!accounts?.[0]) return null;
-    const account: HiveAccount = { ...accounts[0] };
-    if (account.posting_json_metadata) {
-      account.metadata = JSON.parse(account.posting_json_metadata);
-    } else if (account.json_metadata) {
-      account.metadata = JSON.parse(account.json_metadata);
-    } else {
-      account.metadata = {};
+    const accounts = await HiveClient.database.getAccounts([username])
+    if (!accounts?.[0]) return null
+    const account: HiveAccount = { ...accounts[0] }
+    try {
+      account.metadata = JSON.parse(
+        account.posting_json_metadata || account.json_metadata || '{}',
+      )
+    } catch {
+      account.metadata = {}
     }
-    localStorage.setItem('hiveuser', JSON.stringify(account));
-    window.dispatchEvent(new Event('hiveuser-saved'));
-    return account;
+    localStorage.setItem('hiveuser', JSON.stringify(account))
+    window.dispatchEvent(new Event('hiveuser-saved'))
+    return account
   } catch (err) {
-    console.error('fetchAndStoreAccount failed', err);
-    return null;
+    console.error('fetchAndStoreAccount failed', err)
+    return null
   }
 }
 
 export function LoginModalProvider({ children }: { children: ReactNode }) {
-  const [isOpen, setIsOpen] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const [loginProof] = useState(() => Math.floor(Date.now() / 1000).toString());
-  const { user: aiohaUser } = useAioha();
-  const { setHiveUser } = useHiveUser();
+  const [isOpen, setIsOpen] = useState(false)
+  const [mounted, setMounted] = useState(false)
+  const [loginProof] = useState(() => Math.floor(Date.now() / 1000).toString())
+  const { user: aiohaUser } = useAioha()
+  const { setHiveUser } = useHiveUser()
+  const { setSnapieUser, isSnapieLoggedIn } = useSnapieAuth()
 
-  // AiohaModal lists enabled providers as <li>s. Provider registration only
-  // runs client-side (see lib/hive/aioha.ts), so SSR renders <ul></ul> but the
-  // first client render would render <ul><li>Keychain</li>…</ul>. Gate the
-  // modal mount on a post-hydration flag to avoid the mismatch.
+  useEffect(() => { setMounted(true) }, [])
+
+  const openLoginModal = useCallback(() => setIsOpen(true), [])
+  const closeLoginModal = useCallback(() => setIsOpen(false), [])
+
+  // Sync Aioha session into app-wide storage (only when not in Snapie mode).
   useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  const openLoginModal = useCallback(() => setIsOpen(true), []);
-  const closeLoginModal = useCallback(() => setIsOpen(false), []);
-
-  // Bridge aioha session into the existing Keychain-based session storage.
-  // When aioha logs a user in (login succeeds OR session restored from disk),
-  // we mirror that into the hive_username cookie + hiveuser localStorage so
-  // the rest of the app (KeychainContext, UserContext) keeps working.
-  useEffect(() => {
-    if (!aiohaUser) return;
-    setCookie('hive_username', aiohaUser, 30);
+    if (!aiohaUser || isSnapieLoggedIn) return
+    setSigningAuthMode('aioha')
+    setCookie('hive_username', aiohaUser, 30)
     fetchAndStoreAccount(aiohaUser).then((acc) => {
-      if (acc) setHiveUser(acc);
-    });
-  }, [aiohaUser, setHiveUser]);
+      if (acc) setHiveUser(acc)
+    })
+  }, [aiohaUser, setHiveUser, isSnapieLoggedIn])
 
-  // When aioha loses its user (logout), clear the app session too.
+  // Clear session on Aioha logout (only when not in Snapie mode).
   useEffect(() => {
-    if (aiohaUser) return;
-    const existingCookie = document.cookie.match(/(?:^|; )hive_username=([^;]+)/);
-    if (!existingCookie) return;
-    deleteCookie('hive_username');
-    localStorage.removeItem('hiveuser');
-    setHiveUser(null);
-  }, [aiohaUser, setHiveUser]);
+    if (aiohaUser || isSnapieLoggedIn) return
+    const existingCookie = document.cookie.match(/(?:^|; )hive_username=([^;]+)/)
+    if (!existingCookie) return
+    setSigningAuthMode(null)
+    deleteCookie('hive_username')
+    localStorage.removeItem('hiveuser')
+    setHiveUser(null)
+  }, [aiohaUser, setHiveUser, isSnapieLoggedIn])
 
-  const handleLogin = useCallback(
+  // Called when Aioha login succeeds (wallet providers).
+  const handleAiohaLogin = useCallback(
     async (loginResult: any) => {
-      if (!loginResult || loginResult.error) {
-        console.error('Aioha login failed', loginResult);
-        return;
-      }
-      const username: string | undefined = loginResult.username;
-      if (!username) return;
-      setCookie('hive_username', username, 30);
-      const acc = await fetchAndStoreAccount(username);
-      if (acc) setHiveUser(acc);
-      setIsOpen(false);
+      if (!loginResult || loginResult.error) return
+      const username: string | undefined = loginResult.username
+      if (!username) return
+      setSigningAuthMode('aioha')
+      setCookie('hive_username', username, 30)
+      const acc = await fetchAndStoreAccount(username)
+      if (acc) setHiveUser(acc)
+      setIsOpen(false)
     },
     [setHiveUser],
-  );
+  )
+
+  // Called when Snapie Auth login succeeds (Google or email).
+  // If the user has no Hive account yet, the modal stays open and transitions
+  // to the account setup view internally — we just persist the session here.
+  const handleSnapieLoginSuccess = useCallback(
+    async (user: SnapieUser) => {
+      setSnapieUser(user)
+      if (user.hiveUsername) {
+        setCookie('hive_username', user.hiveUsername, 30)
+        const acc = await fetchAndStoreAccount(user.hiveUsername)
+        if (acc) setHiveUser(acc)
+        setIsOpen(false)
+      }
+      // No hiveUsername → modal stays open; LoginModal handles account setup view.
+    },
+    [setSnapieUser, setHiveUser],
+  )
 
   const value = useMemo<LoginModalContextValue>(
     () => ({ isOpen, openLoginModal, closeLoginModal }),
     [isOpen, openLoginModal, closeLoginModal],
-  );
+  )
 
   return (
     <LoginModalContext.Provider value={value}>
@@ -122,22 +135,19 @@ export function LoginModalProvider({ children }: { children: ReactNode }) {
       {mounted && (
         <LoginModal
           displayed={isOpen}
-          onLogin={handleLogin}
+          onSnapieLoginSuccess={handleSnapieLoginSuccess}
+          onAiohaLogin={handleAiohaLogin}
           onClose={closeLoginModal}
-          loginTitle="Login to Snapie"
-          loginOptions={{
-            msg: loginProof,
-            keyType: KeyTypes.Posting,
-          }}
+          loginOptions={{ msg: loginProof, keyType: KeyTypes.Posting }}
           forceShowProviders={getLoginProviders()}
         />
       )}
     </LoginModalContext.Provider>
-  );
+  )
 }
 
 export function useLoginModal() {
-  const ctx = useContext(LoginModalContext);
-  if (!ctx) throw new Error('useLoginModal must be used within a LoginModalProvider');
-  return ctx;
+  const ctx = useContext(LoginModalContext)
+  if (!ctx) throw new Error('useLoginModal must be used within a LoginModalProvider')
+  return ctx
 }

--- a/contexts/SnapieAuthContext.tsx
+++ b/contexts/SnapieAuthContext.tsx
@@ -1,0 +1,138 @@
+'use client'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import { getMe, logout as apiLogout } from '@/lib/snapie-auth/client'
+import { setSigningAuthMode } from '@/lib/hive/signing'
+import type { SnapieMeUser, SnapieUser } from '@/lib/snapie-auth/types'
+import HiveClient from '@/lib/hive/hiveclient'
+import { useHiveUser } from '@/contexts/UserContext'
+import type { HiveAccount } from '@/hooks/useHiveAccount'
+
+interface SnapieAuthContextValue {
+  snapieUser: SnapieMeUser | null
+  isSnapieLoggedIn: boolean
+  isLoading: boolean
+  emancipationRequired: boolean
+  setSnapieUser: (user: SnapieUser | null) => void
+  logoutFromSnapie: () => Promise<void>
+}
+
+const SnapieAuthContext = createContext<SnapieAuthContextValue | null>(null)
+
+const setCookie = (name: string, value: string, days = 30) => {
+  const expires = new Date()
+  expires.setTime(expires.getTime() + days * 24 * 60 * 60 * 1000)
+  document.cookie = `${name}=${value};expires=${expires.toUTCString()};path=/`
+}
+
+const deleteCookie = (name: string) => {
+  document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/`
+}
+
+async function hydrateHiveAccount(username: string): Promise<HiveAccount | null> {
+  try {
+    const accounts = await HiveClient.database.getAccounts([username])
+    if (!accounts?.[0]) return null
+    const account: HiveAccount = { ...accounts[0] }
+    try {
+      account.metadata = JSON.parse(
+        account.posting_json_metadata || account.json_metadata || '{}',
+      )
+    } catch {
+      account.metadata = {}
+    }
+    localStorage.setItem('hiveuser', JSON.stringify(account))
+    window.dispatchEvent(new Event('hiveuser-saved'))
+    return account
+  } catch {
+    return null
+  }
+}
+
+export function SnapieAuthProvider({ children }: { children: ReactNode }) {
+  const [snapieUser, setSnapieUserState] = useState<SnapieMeUser | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const { setHiveUser } = useHiveUser()
+  const restored = useRef(false)
+
+  const applySnapieSession = useCallback(
+    async (user: SnapieUser | SnapieMeUser) => {
+      const meUser: SnapieMeUser = 'emancipationRequired' in user
+        ? (user as SnapieMeUser)
+        : { ...user, email: null, accountValueUsd: null, emancipationRequired: false }
+      setSnapieUserState(meUser)
+      setSigningAuthMode('snapie', user.hiveUsername ?? null)
+      setCookie('hive_username', user.hiveUsername ?? '', 30)
+      if (user.hiveUsername) {
+        const acc = await hydrateHiveAccount(user.hiveUsername)
+        if (acc) setHiveUser(acc)
+      }
+    },
+    [setHiveUser],
+  )
+
+  // Restore session on mount (returning user with valid cookie).
+  useEffect(() => {
+    if (restored.current) return
+    restored.current = true
+
+    getMe()
+      .then((user) => applySnapieSession(user))
+      .catch(() => {
+        // 401 = no session — not an error, just not logged in via Snapie
+      })
+      .finally(() => setIsLoading(false))
+  }, [applySnapieSession])
+
+  // Called after login — base SnapieUser lacks emancipation fields, so fetch full /auth/me.
+  const setSnapieUser = useCallback(
+    (user: SnapieUser | null) => {
+      if (user) {
+        applySnapieSession(user)
+        getMe()
+          .then((full) => applySnapieSession(full))
+          .catch(() => {})
+      } else {
+        setSnapieUserState(null)
+      }
+    },
+    [applySnapieSession],
+  )
+
+  const logoutFromSnapie = useCallback(async () => {
+    await apiLogout().catch(() => {})
+    setSnapieUserState(null)
+    setSigningAuthMode(null, null)
+    deleteCookie('hive_username')
+    localStorage.removeItem('hiveuser')
+    setHiveUser(null)
+  }, [setHiveUser])
+
+  return (
+    <SnapieAuthContext.Provider
+      value={{
+        snapieUser,
+        isSnapieLoggedIn: !!snapieUser,
+        isLoading,
+        emancipationRequired: snapieUser?.emancipationRequired ?? false,
+        setSnapieUser,
+        logoutFromSnapie,
+      }}
+    >
+      {children}
+    </SnapieAuthContext.Provider>
+  )
+}
+
+export function useSnapieAuth() {
+  const ctx = useContext(SnapieAuthContext)
+  if (!ctx) throw new Error('useSnapieAuth must be used within a SnapieAuthProvider')
+  return ctx
+}

--- a/contexts/SnapieAuthContext.tsx
+++ b/contexts/SnapieAuthContext.tsx
@@ -101,6 +101,10 @@ export function SnapieAuthProvider({ children }: { children: ReactNode }) {
           .catch(() => {})
       } else {
         setSnapieUserState(null)
+        setSigningAuthMode(null, null)
+        deleteCookie('hive_username')
+        localStorage.removeItem('hiveuser')
+        setHiveUser(null)
       }
     },
     [applySnapieSession],

--- a/hooks/useCurrentUser.ts
+++ b/hooks/useCurrentUser.ts
@@ -1,0 +1,25 @@
+'use client'
+import { useAioha } from '@aioha/react-ui'
+import { useSnapieAuth } from '@/contexts/SnapieAuthContext'
+
+/**
+ * Single source of truth for "who is logged in" regardless of auth method.
+ * Merges Aioha wallet sessions and Snapie Auth custodial sessions.
+ */
+export function useCurrentUser() {
+  const { user: aiohaUser, aioha } = useAioha()
+  const { snapieUser, isSnapieLoggedIn, logoutFromSnapie } = useSnapieAuth()
+
+  const username = aiohaUser ?? snapieUser?.hiveUsername ?? null
+  const isLoggedIn = !!username
+
+  const logout = () => {
+    if (isSnapieLoggedIn) {
+      logoutFromSnapie()
+    } else {
+      aioha.logout()
+    }
+  }
+
+  return { username, isLoggedIn, isSnapie: isSnapieLoggedIn, logout }
+}

--- a/hooks/useCurrentUser.ts
+++ b/hooks/useCurrentUser.ts
@@ -14,10 +14,10 @@ export function useCurrentUser() {
   const isLoggedIn = !!username
 
   const logout = () => {
-    if (isSnapieLoggedIn) {
-      logoutFromSnapie()
-    } else {
+    if (aiohaUser) {
       aioha.logout()
+    } else if (isSnapieLoggedIn) {
+      logoutFromSnapie()
     }
   }
 

--- a/hooks/useHbdSavingsInterest.ts
+++ b/hooks/useHbdSavingsInterest.ts
@@ -1,0 +1,46 @@
+'use client'
+import { useState, useEffect } from 'react';
+import HiveClient from '@/lib/hive/hiveclient';
+
+const SECONDS_PER_YEAR = 365.25 * 24 * 3600;
+
+interface HbdSavingsInterest {
+  pendingInterest: number;
+  annualRatePct: number;
+  isLoading: boolean;
+}
+
+export function useHbdSavingsInterest(hiveAccount: any): HbdSavingsInterest {
+  const [pendingInterest, setPendingInterest] = useState(0);
+  const [annualRatePct, setAnnualRatePct] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!hiveAccount) return;
+
+    const savingsBalance = parseFloat(hiveAccount.savings_hbd_balance) || 0;
+    if (savingsBalance === 0) {
+      setPendingInterest(0);
+      return;
+    }
+
+    setIsLoading(true);
+    HiveClient.call('condenser_api', 'get_dynamic_global_properties', [])
+      .then((props: any) => {
+        const rateBps = props.hbd_interest_rate || 0; // basis points, e.g. 2000 = 20%
+        setAnnualRatePct(rateBps / 100);
+
+        const accSeconds = parseInt(hiveAccount.savings_hbd_seconds || '0');
+        const lastUpdate = new Date(hiveAccount.savings_hbd_seconds_last_update + 'Z').getTime();
+        const elapsedSeconds = Math.max(0, (Date.now() - lastUpdate) / 1000);
+        const totalHbdSeconds = accSeconds + savingsBalance * elapsedSeconds;
+        const interest = totalHbdSeconds * (rateBps / 10000) / SECONDS_PER_YEAR;
+
+        setPendingInterest(interest);
+      })
+      .catch(() => {})
+      .finally(() => setIsLoading(false));
+  }, [hiveAccount]);
+
+  return { pendingInterest, annualRatePct, isLoading };
+}

--- a/lib/hive/aioha.ts
+++ b/lib/hive/aioha.ts
@@ -122,6 +122,21 @@ export async function broadcastOps(
   keyType: KeyTypes = KeyTypes.Posting,
   title = 'Approve transaction',
 ) {
+  if (typeof window !== 'undefined') {
+    const { isSnapieMode } = await import('@/lib/hive/signing');
+    if (isSnapieMode()) {
+      const { broadcastOp } = await import('@/lib/snapie-auth/client');
+      // Filter to allowed ops (server only accepts posting-key ops via broadcast).
+      const allowed = new Set(['vote', 'comment', 'delete_comment', 'custom_json', 'claim_reward_balance']);
+      for (const op of operations) {
+        const [opName, opBody] = op as [string, Record<string, unknown>];
+        if (!allowed.has(opName)) continue; // skip comment_options etc.
+        const res = await broadcastOp(opName, opBody);
+        if ('needsClientSigning' in res) break; // emancipated: fall through to Aioha
+        return { success: true as const, result: (res as any).txId };
+      }
+    }
+  }
   return withTxApproval(async () => {
     const result = await getAioha().signAndBroadcastTx(operations, keyType);
     if (!result.success) throw new Error(result.error || 'Broadcast failed');
@@ -134,6 +149,15 @@ export async function voteWithAioha(
   permlink: string,
   weight = 10000,
 ) {
+  if (typeof window !== 'undefined') {
+    const { isSnapieMode, getSnapieUsername } = await import('@/lib/hive/signing');
+    if (isSnapieMode()) {
+      const { broadcastOp } = await import('@/lib/snapie-auth/client');
+      const voter = getSnapieUsername() ?? '';
+      const res = await broadcastOp('vote', { voter, author, permlink, weight });
+      if (!('needsClientSigning' in res)) return { success: true as const, result: (res as any).txId };
+    }
+  }
   return withTxApproval(async () => {
     const result = await getAioha().vote(author, permlink, weight);
     if (!result.success) throw new Error(result.error || 'Vote failed');
@@ -147,6 +171,19 @@ export async function transferWithAioha(
   currency: string,
   memo = '',
 ) {
+  if (typeof window !== 'undefined') {
+    const { isSnapieMode } = await import('@/lib/hive/signing');
+    if (isSnapieMode()) {
+      const { transfer } = await import('@/lib/snapie-auth/client');
+      const res = await transfer(to, amount, currency, memo);
+      if (!('needsClientSigning' in res)) {
+        if ((res as any).emancipationRequired) {
+          window.dispatchEvent(new CustomEvent('snapie:emancipation-required'))
+        }
+        return { success: true as const, result: (res as any).txId };
+      }
+    }
+  }
   return withTxApproval(async () => {
     const result = await getAioha().transfer(to, amount, currency as any, memo);
     if (!result.success) throw new Error(result.error || 'Transfer failed');
@@ -175,6 +212,17 @@ export async function customJsonWithAioha(
   displayTitle = '',
   overlayTitle = 'Approve action',
 ) {
+  if (typeof window !== 'undefined') {
+    const { isSnapieMode, getSnapieUsername } = await import('@/lib/hive/signing');
+    if (isSnapieMode()) {
+      const { broadcastOp } = await import('@/lib/snapie-auth/client');
+      const username = getSnapieUsername() ?? '';
+      const required_auths = keyType === KeyTypes.Active ? [username] : [];
+      const required_posting_auths = keyType === KeyTypes.Posting ? [username] : [];
+      const res = await broadcastOp('custom_json', { required_auths, required_posting_auths, id, json });
+      if (!('needsClientSigning' in res)) return { success: true as const, result: (res as any).txId };
+    }
+  }
   return withTxApproval(async () => {
     const result = await getAioha().customJSON(keyType, id, json, displayTitle);
     if (!result.success) throw new Error(result.error || 'Custom JSON failed');
@@ -192,6 +240,23 @@ export async function commentWithAioha(
   options?: any,
   overlayTitle = 'Approve post',
 ) {
+  if (typeof window !== 'undefined') {
+    const { isSnapieMode, getSnapieUsername } = await import('@/lib/hive/signing');
+    if (isSnapieMode()) {
+      const { broadcastOp } = await import('@/lib/snapie-auth/client');
+      const author = getSnapieUsername() ?? '';
+      const res = await broadcastOp('comment', {
+        parent_author: parentAuthor,
+        parent_permlink: parentPermlink,
+        author,
+        permlink,
+        title,
+        body,
+        json_metadata: jsonMetadata,
+      });
+      if (!('needsClientSigning' in res)) return { success: true as const, result: (res as any).txId, publicKey: undefined };
+    }
+  }
   return withTxApproval(async () => {
     const result = await getAioha().comment(
       parentAuthor,
@@ -212,6 +277,19 @@ export async function signMessageWithAioha(
   keyType: KeyTypes = KeyTypes.Posting,
   overlayTitle = 'Approve signature request',
 ) {
+  // Custodial Snapie Auth users: sign server-side via the proxy.
+  if (typeof window !== 'undefined') {
+    const { isSnapieMode } = await import('@/lib/hive/signing');
+    if (isSnapieMode()) {
+      const { signMessage } = await import('@/lib/snapie-auth/client');
+      const res = await signMessage(message);
+      if ('needsClientSigning' in res) {
+        // Emancipated: fall through to Aioha below
+      } else {
+        return { success: true as const, result: res.signature };
+      }
+    }
+  }
   return withTxApproval(async () => {
     const result = await getAioha().signMessage(message, keyType);
     if (!result.success) {

--- a/lib/hive/client-functions.ts
+++ b/lib/hive/client-functions.ts
@@ -138,6 +138,15 @@ export async function transferWithKeychain(username: string, destination: string
 
 export async function powerUpWithKeychain(username: string, amount: number) {
   try {
+    const { isSnapieMode } = await import('@/lib/hive/signing');
+    if (isSnapieMode()) {
+      const { powerUp } = await import('@/lib/snapie-auth/client');
+      const res = await powerUp(amount);
+      if (!('needsClientSigning' in res) && res.emancipationRequired && typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('snapie:emancipation-required'))
+      }
+      return res;
+    }
     const op = [
       'transfer_to_vesting',
       {
@@ -157,7 +166,16 @@ export async function powerUpWithKeychain(username: string, amount: number) {
 
 export async function powerDownWithKeychain(username: string, hivePower: number) {
   try {
+    const { isSnapieMode } = await import('@/lib/hive/signing');
     const vests = await convertHiveToVests(hivePower);
+    if (isSnapieMode()) {
+      const { powerDown } = await import('@/lib/snapie-auth/client');
+      const res = await powerDown(`${vests.toFixed(6)} VESTS`);
+      if (!('needsClientSigning' in res) && res.emancipationRequired && typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('snapie:emancipation-required'))
+      }
+      return res;
+    }
     const op = [
       'withdraw_vesting',
       {
@@ -176,7 +194,16 @@ export async function powerDownWithKeychain(username: string, hivePower: number)
 
 export async function delegateWithKeychain(username: string, delegatee: string, amount: number) {
   try {
+    const { isSnapieMode } = await import('@/lib/hive/signing');
     const vests = await convertHiveToVests(amount);
+    if (isSnapieMode()) {
+      const { delegate } = await import('@/lib/snapie-auth/client');
+      const res = await delegate(delegatee, `${vests.toFixed(6)} VESTS`);
+      if (!('needsClientSigning' in res) && res.emancipationRequired && typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('snapie:emancipation-required'))
+      }
+      return res;
+    }
     const op = [
       'delegate_vesting_shares',
       {
@@ -192,6 +219,14 @@ export async function delegateWithKeychain(username: string, delegatee: string, 
     console.log({ error });
     throw error;
   }
+}
+
+export async function claimHbdSavingsInterest(username: string) {
+  return broadcastWithKeychain(
+    username,
+    [['transfer_to_savings', { from: username, to: username, amount: '0.001 HBD', memo: '' }]],
+    'active',
+  );
 }
 
 export async function claimRewardsWithKeychain(
@@ -220,6 +255,45 @@ export async function broadcastWithKeychain(
   method: 'posting' | 'active' = 'active',
 ) {
   try {
+    const { isSnapieMode } = await import('@/lib/hive/signing');
+    if (isSnapieMode()) {
+      const snapie = await import('@/lib/snapie-auth/client');
+      for (const op of operations) {
+        const [opName, body] = op as [string, Record<string, unknown>];
+        let res: any;
+        switch (opName) {
+          case 'transfer_to_savings':
+            res = await snapie.transferToSavings(body.amount as string, body.to as string | undefined, (body.memo as string) || '');
+            break;
+          case 'transfer_from_savings':
+            res = await snapie.transferFromSavings(body.amount as string, body.to as string | undefined, (body.memo as string) || '', (body.request_id ?? body.requestId) as number | undefined);
+            break;
+          case 'convert': {
+            const amt = body.amount as any;
+            const amountStr = typeof amt === 'string' ? amt : `${parseFloat(amt.amount).toFixed(3)} HBD`;
+            res = await snapie.convertHbd(amountStr, body.requestid as number | undefined);
+            break;
+          }
+          case 'collateralized_convert':
+            res = await snapie.collateralizedConvert(body.amount as string, body.requestid as number | undefined);
+            break;
+          case 'limit_order_create':
+            res = await snapie.limitOrderCreate(body.amount_to_sell as string, body.min_to_receive as string, body.fill_or_kill as boolean, 300, body.orderid as number | undefined);
+            break;
+          case 'limit_order_cancel':
+            res = await snapie.limitOrderCancel((body.orderid ?? body.orderId) as number);
+            break;
+          default:
+            res = await snapie.broadcastOp(opName, body);
+        }
+        if (res && !('needsClientSigning' in res)) {
+          if (res.emancipationRequired && typeof window !== 'undefined') {
+            window.dispatchEvent(new CustomEvent('snapie:emancipation-required'))
+          }
+          return { success: true, result: res.txId };
+        }
+      }
+    }
     const keyType = typeof method === 'string' ? keyTypeFromString(method) : method;
     const result = await aiohaBroadcast(operations, keyType, 'Approve transaction');
     console.log({ broadcast: result });
@@ -606,31 +680,29 @@ export async function uploadImageWithKeychain(
     onProgress?: (progress: number) => void;
   }
 ): Promise<string> {
-  console.log('🔐 uploadImageWithKeychain called for:', file.name, 'user:', username);
-
   const aioha = getAioha();
-  if (!aioha.isLoggedIn()) {
+  const { isSnapieMode } = await import('@/lib/hive/signing');
+  if (!isSnapieMode() && !aioha.isLoggedIn()) {
     throw new Error('Not logged in');
   }
 
-  console.log('📖 Reading file...');
+  // Snapie Auth users can't sign the Hive image challenge — route to 3speak instead.
+  if (isSnapieMode()) {
+    return uploadTo3Speak(file, options);
+  }
+
   const fileContent = await readFileAsBuffer(file);
-  console.log('📖 File read, size:', fileContent.length, 'bytes');
 
   const prefix = Buffer.from('ImageSigningChallenge');
   const challengeBuffer = Buffer.concat([prefix, fileContent]);
   const challengeString = JSON.stringify(challengeBuffer);
 
-  console.log('✍️ Requesting signature via aioha...');
   const signResult = await signMessageWithAioha(
     challengeString,
     KeyTypes.Posting,
     'Approve image upload signature',
   );
   const signature = signResult.result;
-  console.log('✍️ Signature received:', signature.substring(0, 20) + '...');
-
-  console.log('📤 Uploading via API route with automatic fallback...');
 
   const formData = new FormData();
   formData.append("file", file);

--- a/lib/hive/server-functions.ts
+++ b/lib/hive/server-functions.ts
@@ -63,7 +63,7 @@ export async function createAccount(username: string, password: string) {
             },
             posting: {
                 weight_threshold: 1,
-                account_auths: [[process.env.NEXT_PUBLIC_POSTING_AUTHORITY_ACCOUNT ?? 'snapie', 1]],
+                account_auths: [[process.env.NEXT_PUBLIC_POSTING_AUTHORITY_ACCOUNT?.trim() || 'snapie', 1]],
                 key_auths: [[postingPubkey, 1]],
             },
             memo_key: memoPubkey, // Memo public key (no object here, just the public key string)

--- a/lib/hive/server-functions.ts
+++ b/lib/hive/server-functions.ts
@@ -63,8 +63,8 @@ export async function createAccount(username: string, password: string) {
             },
             posting: {
                 weight_threshold: 1,
-                account_auths: [],
-                key_auths: [[postingPubkey, 1]], // Posting public key
+                account_auths: [[process.env.NEXT_PUBLIC_POSTING_AUTHORITY_ACCOUNT ?? 'snapie', 1]],
+                key_auths: [[postingPubkey, 1]],
             },
             memo_key: memoPubkey, // Memo public key (no object here, just the public key string)
             json_metadata: '', // Optional metadata

--- a/lib/hive/signing.ts
+++ b/lib/hive/signing.ts
@@ -1,0 +1,30 @@
+'use client'
+
+/**
+ * Signing router — dispatches Hive operations to either the Snapie Auth proxy
+ * (custodial users) or the local Aioha provider (wallet users).
+ *
+ * Auth mode is set by SnapieAuthContext on mount/login/logout.
+ */
+
+type AuthMode = 'snapie' | 'aioha' | null
+
+let _mode: AuthMode = null
+let _snapieUsername: string | null = null
+
+export function setSigningAuthMode(mode: AuthMode, username?: string | null) {
+  _mode = mode
+  if (username !== undefined) _snapieUsername = username ?? null
+}
+
+export function getSnapieUsername(): string | null {
+  return _snapieUsername
+}
+
+export function getSigningAuthMode(): AuthMode {
+  return _mode
+}
+
+export function isSnapieMode(): boolean {
+  return _mode === 'snapie'
+}

--- a/lib/hive/signing.ts
+++ b/lib/hive/signing.ts
@@ -14,7 +14,11 @@ let _snapieUsername: string | null = null
 
 export function setSigningAuthMode(mode: AuthMode, username?: string | null) {
   _mode = mode
-  if (username !== undefined) _snapieUsername = username ?? null
+  if (mode === 'snapie') {
+    if (username !== undefined) _snapieUsername = username ?? null
+  } else {
+    _snapieUsername = null
+  }
 }
 
 export function getSnapieUsername(): string | null {

--- a/lib/snapie-auth/client.ts
+++ b/lib/snapie-auth/client.ts
@@ -1,0 +1,192 @@
+import type {
+  AccountJob,
+  BroadcastResult,
+  EligibilityResponse,
+  NeedsClientSigningResponse,
+  PublicConfig,
+  QuotaResponse,
+  SignMessageResult,
+  SnapieMeUser,
+  SnapieUser,
+} from './types'
+import { SnapieAuthError as AuthError } from './types'
+
+// All calls route through our Next.js proxy — never directly to auth.snapie.io.
+const BASE = '/api/snapie-auth'
+
+async function req<T>(method: string, path: string, body?: unknown): Promise<T> {
+  const headers: Record<string, string> = {}
+  if (body !== undefined) headers['Content-Type'] = 'application/json'
+
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    credentials: 'include',
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  })
+
+  if (res.status === 204) return {} as T
+
+  const data = await res.json().catch(() => ({}))
+
+  if (!res.ok) {
+    throw new AuthError(data.error ?? 'unknown_error', res.status, data.error)
+  }
+
+  return data as T
+}
+
+// ── Public (no session required) ─────────────────────────────────────────────
+
+export function getQuota() {
+  return req<QuotaResponse>('GET', '/quota')
+}
+
+export function getPublicConfig() {
+  return req<PublicConfig>('GET', '/public-config')
+}
+
+// ── Auth ─────────────────────────────────────────────────────────────────────
+
+// Login endpoints return { user: SnapieUser } directly — no extra getMe() needed.
+export async function loginWithGoogle(credential: string): Promise<SnapieUser> {
+  const data = await req<{ user: SnapieUser }>('POST', '/auth/google', { credential })
+  return data.user
+}
+
+/** Returns { pending: true } — user must verify email before logging in. */
+export function registerWithEmail(email: string, password: string) {
+  return req<{ pending: true }>('POST', '/auth/email/register', { email, password })
+}
+
+export async function loginWithEmail(email: string, password: string): Promise<SnapieUser> {
+  // 403 means email not yet verified — throw a specific code so the UI can handle it.
+  const res = await fetch(`${BASE}/auth/email/login`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  })
+  if (res.status === 403) throw new AuthError('email_not_verified', 403)
+  const data = await res.json().catch(() => ({}))
+  if (!res.ok) throw new AuthError(data.error ?? 'unknown_error', res.status)
+  return (data as { user: SnapieUser }).user
+}
+
+export function resendVerification() {
+  return req<{ ok: true }>('POST', '/auth/email/resend')
+}
+
+// GET /auth/me returns { user: SnapieMeUser } — a superset of SnapieUser with
+// email, accountValueUsd, and emancipationRequired.
+export async function getMe(): Promise<SnapieMeUser> {
+  const data = await req<{ user: SnapieMeUser }>('GET', '/auth/me')
+  return data.user
+}
+
+export function logout() {
+  return req<{ ok: true }>('POST', '/auth/logout')
+}
+
+// ── Account ───────────────────────────────────────────────────────────────────
+
+export function getEligibility() {
+  return req<EligibilityResponse>('GET', '/account/eligibility')
+}
+
+export function checkUsername(username: string) {
+  return req<{ available: boolean; reason?: string }>(
+    'GET',
+    `/account/check-username/${encodeURIComponent(username)}`,
+  )
+}
+
+export function createAccount(username: string) {
+  return req<{ jobId: string; sponsored: boolean }>('POST', '/account/create', {
+    username,
+    custodyMode: 'custodial',
+  })
+}
+
+export function pollJob(jobId: string) {
+  return req<AccountJob>('GET', `/account/job/${encodeURIComponent(jobId)}`)
+}
+
+// ── Hive operations ───────────────────────────────────────────────────────────
+
+export function signMessage(message: string) {
+  return req<SignMessageResult>('POST', '/hive/sign-message', { message })
+}
+
+/**
+ * Broadcast one Hive operation via the auth server signing proxy.
+ * The auth server expects: { op: "comment"|"vote"|..., ...opFields }
+ * Each call handles exactly one operation.
+ */
+export function broadcastOp(opName: string, opBody: Record<string, unknown>) {
+  // Server expects { op: [opTypeString, paramsObject] } — not a flat body, not { operations }.
+  return req<BroadcastResult>('POST', '/hive/broadcast', { op: [opName, opBody] })
+}
+
+export function claimRewards() {
+  return req<BroadcastResult>('POST', '/hive/claim-rewards')
+}
+
+export function transfer(to: string, amount: string | number, currency: string, memo = '') {
+  const amountStr = typeof amount === 'number' ? amount.toFixed(3) : amount;
+  return req<BroadcastResult>('POST', '/hive/transfer', { to, amount: `${amountStr} ${currency}`, memo })
+}
+
+export function powerUp(amount: number) {
+  return req<BroadcastResult>('POST', '/hive/power-up', { amount: `${amount.toFixed(3)} HIVE` })
+}
+
+export function powerDown(vestingShares: string) {
+  return req<BroadcastResult>('POST', '/hive/power-down', { amount: vestingShares })
+}
+
+export function delegate(delegatee: string, vestingShares: string) {
+  return req<BroadcastResult>('POST', '/hive/delegate', { delegatee, amount: vestingShares })
+}
+
+export function transferToSavings(amount: string, to?: string, memo = '') {
+  return req<BroadcastResult>('POST', '/hive/transfer-to-savings', { amount, ...(to ? { to } : {}), memo })
+}
+
+export function transferFromSavings(amount: string, to?: string, memo = '', requestId?: number) {
+  return req<BroadcastResult>('POST', '/hive/transfer-from-savings', { amount, ...(to ? { to } : {}), memo, ...(requestId !== undefined ? { requestId } : {}) })
+}
+
+export function convertHbd(amount: string, requestId?: number) {
+  return req<BroadcastResult>('POST', '/hive/convert', { amount, ...(requestId !== undefined ? { requestId } : {}) })
+}
+
+export function collateralizedConvert(amount: string, requestId?: number) {
+  return req<BroadcastResult>('POST', '/hive/collateralized-convert', { amount, ...(requestId !== undefined ? { requestId } : {}) })
+}
+
+export function limitOrderCreate(sell: string, receive: string, fillOrKill = false, expiresInSeconds?: number, orderId?: number) {
+  return req<BroadcastResult>('POST', '/hive/limit-order-create', { sell, receive, fillOrKill, ...(expiresInSeconds !== undefined ? { expiresInSeconds } : {}), ...(orderId !== undefined ? { orderId } : {}) })
+}
+
+export function limitOrderCancel(orderId: number) {
+  return req<BroadcastResult>('POST', '/hive/limit-order-cancel', { orderId })
+}
+
+// ── Emancipation ─────────────────────────────────────────────────────────────
+
+export function getEmancipationStatus() {
+  return req<{ custodyMode: string; totalUsd: number; thresholdUsd: number }>(
+    'GET',
+    '/emancipate/status',
+  )
+}
+
+export function startEmancipation() {
+  return req<{ keys: { owner: string; active: string; posting: string; memo: string } }>(
+    'POST',
+    '/emancipate/start',
+  )
+}
+
+export { AuthError as SnapieAuthError }

--- a/lib/snapie-auth/types.ts
+++ b/lib/snapie-auth/types.ts
@@ -1,0 +1,77 @@
+export interface SnapieUser {
+  id: string
+  name: string | null
+  picture: string | null
+  hiveUsername: string | null
+  custodyMode: 'custodial' | 'emancipated' | null
+  isAdmin: boolean
+}
+
+/** Extended shape returned only by GET /auth/me */
+export interface SnapieMeUser extends SnapieUser {
+  email: string | null
+  accountValueUsd: number | null
+  emancipationRequired: boolean
+}
+
+export interface QuotaResponse {
+  total: number
+  used: number
+  remaining: number
+  resetsAt: string
+}
+
+export interface PublicConfig {
+  googleClientId: string
+  hiveNetwork: string
+}
+
+export interface EligibilityResponse {
+  canCreate: boolean
+  canLinkExisting: boolean
+  reason?: string
+  sponsored?: boolean
+}
+
+export interface AccountJob {
+  status: 'pending' | 'broadcasting' | 'acked' | 'confirmed' | 'failed' | 'expired'
+  txId?: string
+  error?: string
+}
+
+export interface SignMessageResponse {
+  signature: string
+  account: string
+}
+
+export interface NeedsClientSigningResponse {
+  needsClientSigning: true
+  message: string
+  account: string
+}
+
+export type SignMessageResult = SignMessageResponse | NeedsClientSigningResponse
+
+export interface BroadcastResponse {
+  txId: string
+  emancipationRequired?: boolean
+  accountValueUsd?: number
+}
+
+export interface NeedsClientBroadcastResponse {
+  needsClientSigning: true
+  unsignedOp: unknown
+}
+
+export type BroadcastResult = BroadcastResponse | NeedsClientBroadcastResponse
+
+export class SnapieAuthError extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly status: number,
+    message?: string,
+  ) {
+    super(message ?? code)
+    this.name = 'SnapieAuthError'
+  }
+}


### PR DESCRIPTION
## Summary

- **Custodial auth proxy**: Next.js `/api/snapie-auth/[...path]` forwards to `auth.snapie.io` with CSRF token handling
- **Unified identity**: `SnapieAuthContext` + `useCurrentUser` hook — Snapie and Aioha users share one identity surface
- **Signing router** (`lib/hive/signing.ts`): module-level mode switch routes all ops to Snapie or Aioha based on how the user logged in
- **Login modal redesign**: Google/email as primary path; Hive wallet providers demoted to secondary compact row
- **Join page overhaul**: live quota widget, Quick Join card, sponsor link card, existing wallet fallback
- **Account setup flow**: username picker + job polling after Snapie login when no Hive account exists
- **Wallet ops**: all active-key ops (transfer, power up/down, delegate, savings transfers, convert, collateralized convert, limit orders, swaps) intercepted and routed to dedicated Snapie endpoints with correct amount/VESTS formatting
- **Image upload**: Snapie users routed to 3speak CDN (bypasses sign-message which has a 512-char limit)
- **OpenPods/Hangouts**: `HangoutContext` signing challenge routes through `signMessageWithAioha` Snapie intercept
- **HBD savings interest**: `useHbdSavingsInterest` hook calculates pending interest; claim button triggers `transfer_to_savings 0.001 HBD` side effect
- **Emancipation warnings**: persistent `EmancipationBanner` appears when `emancipationRequired` is true (from `/auth/me`); re-surfaces after any active-key op that returns the flag; `EmancipationModal` guides through one-time key export via `POST /emancipate/start`

## Test plan

- [ ] Email register → verify → login → account setup → post a snap → vote → transfer
- [ ] Google login → same flows
- [ ] Keychain login — verify all existing wallet flows still work (no regression)
- [ ] Image upload as Snapie user — should go to 3speak, not images.hive.blog
- [ ] OpenPods join as Snapie user — no infinite spinner
- [ ] Wallet: power up/down, delegate, savings deposit/withdraw, convert HBD→HIVE, limit order
- [ ] HBD savings: APR shown, claim interest button works
- [ ] Emancipation banner appears when `emancipationRequired: true` (mock or real threshold)
- [ ] Dismiss banner → re-appears after next active-key transaction
- [ ] Emancipation modal: all 4 keys shown, copy works, irreversible confirmation step
- [ ] Join page: quota widget reflects live slot count; sponsor link flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snapie custodial auth with Google sign‑in and email flows, unified login modal, and in‑app session handling.
  * Account setup flow with username checks, job polling, and a quota widget for onboarding.
  * Emancipation banner + modal to export Hive keys and surface emancipation status.
  * HBD savings interest display and claim action; redesigned multi‑path Join page.

* **Chores**
  * Migrated app to a unified current‑user hook and integrated Snapie auth across UI and transaction flows.
  * Added posting‑authority delegation support for sponsored account creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->