### PR TITLE
feat: surface wallet prompt when emancipated Snapie user hits active-key op

### DIFF
--- a/app/LayoutContent.tsx
+++ b/app/LayoutContent.tsx
@@ -11,6 +11,7 @@ import { useHangout } from '@/contexts/HangoutContext';
 
 const HangoutModal = dynamic(() => import('@/components/hangouts/HangoutModal'), { ssr: false });
 const EmancipationBanner = dynamic(() => import('@/components/auth/EmancipationBanner'), { ssr: false });
+const NeedsWalletHandler = dynamic(() => import('@/components/auth/NeedsWalletHandler'), { ssr: false });
 
 export default function LayoutContent({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
@@ -98,6 +99,7 @@ export default function LayoutContent({ children }: { children: React.ReactNode 
           >
             <EmancipationBanner />
             {!isChatPopoutMode && children}
+            <NeedsWalletHandler />
           </Box>
         </Flex>
       </Box>

--- a/components/auth/LoginModal.tsx
+++ b/components/auth/LoginModal.tsx
@@ -48,6 +48,7 @@ const EMAIL_ERRORS: Record<string, string> = {
 
 interface Props {
   displayed: boolean
+  initialView?: 'providers' | 'hive-wallet'
   onSnapieLoginSuccess: (user: SnapieUser) => void
   onAiohaLogin: (result: any) => void
   onClose: () => void
@@ -57,6 +58,7 @@ interface Props {
 
 export default function LoginModal({
   displayed,
+  initialView = 'providers',
   onSnapieLoginSuccess,
   onAiohaLogin,
   onClose,
@@ -74,15 +76,15 @@ export default function LoginModal({
   const [resending, setResending] = useState(false)
   const [resent, setResent] = useState(false)
 
-  // Reset to default view whenever the modal reopens.
+  // Reset to requested view whenever the modal reopens.
   useEffect(() => {
     if (displayed) {
-      setView('providers')
+      setView(initialView)
       setError('')
       setEmail('')
       setPassword('')
     }
-  }, [displayed])
+  }, [displayed, initialView])
 
   const clearError = useCallback(() => setError(''), [])
 

--- a/components/auth/NeedsWalletHandler.tsx
+++ b/components/auth/NeedsWalletHandler.tsx
@@ -1,0 +1,58 @@
+'use client'
+import { useEffect } from 'react'
+import { useToast, Button } from '@chakra-ui/react'
+import { useLoginModal } from '@/contexts/LoginModalContext'
+
+/**
+ * Invisible component that listens for `snapie:needs-wallet` events dispatched
+ * when an emancipated Snapie user attempts an active-key operation.
+ * Surfaces a toast explaining what happened and offers a direct path to connect
+ * their Hive wallet (Keychain, HiveAuth, etc.).
+ */
+export default function NeedsWalletHandler() {
+  const toast = useToast()
+  const { openLoginModalToWallets } = useLoginModal()
+
+  useEffect(() => {
+    const handler = () => {
+      toast.closeAll()
+      toast({
+        title: 'Active key required',
+        description: 'Your keys are self-custodied. Connect your Hive wallet (Keychain, HiveAuth) to sign this action.',
+        status: 'warning',
+        duration: null,
+        isClosable: true,
+        position: 'top',
+        render: ({ onClose }) => (
+          <Button
+            display="flex"
+            flexDirection="column"
+            alignItems="flex-start"
+            bg="orange.600"
+            color="white"
+            px={4}
+            py={3}
+            borderRadius="md"
+            gap={1}
+            onClick={() => { onClose(); openLoginModalToWallets() }}
+            _hover={{ bg: 'orange.500' }}
+            width="auto"
+            height="auto"
+            whiteSpace="normal"
+            textAlign="left"
+          >
+            <strong style={{ fontSize: '0.9rem' }}>Active key required</strong>
+            <span style={{ fontSize: '0.8rem', fontWeight: 'normal' }}>
+              Your keys are self-custodied. Tap to connect your Hive wallet and retry.
+            </span>
+          </Button>
+        ),
+      })
+    }
+
+    window.addEventListener('snapie:needs-wallet', handler)
+    return () => window.removeEventListener('snapie:needs-wallet', handler)
+  }, [toast, openLoginModalToWallets])
+
+  return null
+}

--- a/contexts/LoginModalContext.tsx
+++ b/contexts/LoginModalContext.tsx
@@ -22,6 +22,7 @@ import { getLoginProviders } from '@/lib/hive/aioha'
 interface LoginModalContextValue {
   isOpen: boolean
   openLoginModal: () => void
+  openLoginModalToWallets: () => void
   closeLoginModal: () => void
 }
 
@@ -60,6 +61,7 @@ export async function fetchAndStoreAccount(username: string): Promise<HiveAccoun
 
 export function LoginModalProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false)
+  const [initialView, setInitialView] = useState<'providers' | 'hive-wallet'>('providers')
   const [mounted, setMounted] = useState(false)
   const [loginProof] = useState(() => Math.floor(Date.now() / 1000).toString())
   const { user: aiohaUser } = useAioha()
@@ -68,7 +70,8 @@ export function LoginModalProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => { setMounted(true) }, [])
 
-  const openLoginModal = useCallback(() => setIsOpen(true), [])
+  const openLoginModal = useCallback(() => { setInitialView('providers'); setIsOpen(true) }, [])
+  const openLoginModalToWallets = useCallback(() => { setInitialView('hive-wallet'); setIsOpen(true) }, [])
   const closeLoginModal = useCallback(() => setIsOpen(false), [])
 
   // Sync Aioha session into app-wide storage (only when not in Snapie mode).
@@ -123,8 +126,8 @@ export function LoginModalProvider({ children }: { children: ReactNode }) {
   )
 
   const value = useMemo<LoginModalContextValue>(
-    () => ({ isOpen, openLoginModal, closeLoginModal }),
-    [isOpen, openLoginModal, closeLoginModal],
+    () => ({ isOpen, openLoginModal, openLoginModalToWallets, closeLoginModal }),
+    [isOpen, openLoginModal, openLoginModalToWallets, closeLoginModal],
   )
 
   return (
@@ -133,6 +136,7 @@ export function LoginModalProvider({ children }: { children: ReactNode }) {
       {mounted && (
         <LoginModal
           displayed={isOpen}
+          initialView={initialView}
           onSnapieLoginSuccess={handleSnapieLoginSuccess}
           onAiohaLogin={handleAiohaLogin}
           onClose={closeLoginModal}

--- a/lib/hive/aioha.ts
+++ b/lib/hive/aioha.ts
@@ -175,13 +175,14 @@ export async function transferWithAioha(
     const { isSnapieMode } = await import('@/lib/hive/signing');
     if (isSnapieMode()) {
       const { transfer } = await import('@/lib/snapie-auth/client');
+      const { emitNeedsWallet } = await import('@/lib/hive/signing');
       const res = await transfer(to, amount, currency, memo);
-      if (!('needsClientSigning' in res)) {
-        if ((res as any).emancipationRequired) {
-          window.dispatchEvent(new CustomEvent('snapie:emancipation-required'))
-        }
-        return { success: true as const, result: (res as any).txId };
+      if ('needsClientSigning' in res) {
+        emitNeedsWallet();
+        throw Object.assign(new Error('Connect your Hive wallet to complete this transfer'), { code: 'needs_client_signing' });
       }
+      if ((res as any).emancipationRequired) window.dispatchEvent(new CustomEvent('snapie:emancipation-required'))
+      return { success: true as const, result: (res as any).txId };
     }
   }
   return withTxApproval(async () => {

--- a/lib/hive/client-functions.ts
+++ b/lib/hive/client-functions.ts
@@ -141,10 +141,10 @@ export async function powerUpWithKeychain(username: string, amount: number) {
     const { isSnapieMode } = await import('@/lib/hive/signing');
     if (isSnapieMode()) {
       const { powerUp } = await import('@/lib/snapie-auth/client');
+      const { emitNeedsWallet } = await import('@/lib/hive/signing');
       const res = await powerUp(amount);
-      if (!('needsClientSigning' in res) && res.emancipationRequired && typeof window !== 'undefined') {
-        window.dispatchEvent(new CustomEvent('snapie:emancipation-required'))
-      }
+      if ('needsClientSigning' in res) { emitNeedsWallet(); throw Object.assign(new Error('Connect your Hive wallet to power up'), { code: 'needs_client_signing' }); }
+      if (res.emancipationRequired && typeof window !== 'undefined') window.dispatchEvent(new CustomEvent('snapie:emancipation-required'))
       return res;
     }
     const op = [
@@ -170,10 +170,10 @@ export async function powerDownWithKeychain(username: string, hivePower: number)
     const vests = await convertHiveToVests(hivePower);
     if (isSnapieMode()) {
       const { powerDown } = await import('@/lib/snapie-auth/client');
+      const { emitNeedsWallet } = await import('@/lib/hive/signing');
       const res = await powerDown(`${vests.toFixed(6)} VESTS`);
-      if (!('needsClientSigning' in res) && res.emancipationRequired && typeof window !== 'undefined') {
-        window.dispatchEvent(new CustomEvent('snapie:emancipation-required'))
-      }
+      if ('needsClientSigning' in res) { emitNeedsWallet(); throw Object.assign(new Error('Connect your Hive wallet to power down'), { code: 'needs_client_signing' }); }
+      if (res.emancipationRequired && typeof window !== 'undefined') window.dispatchEvent(new CustomEvent('snapie:emancipation-required'))
       return res;
     }
     const op = [
@@ -198,10 +198,10 @@ export async function delegateWithKeychain(username: string, delegatee: string, 
     const vests = await convertHiveToVests(amount);
     if (isSnapieMode()) {
       const { delegate } = await import('@/lib/snapie-auth/client');
+      const { emitNeedsWallet } = await import('@/lib/hive/signing');
       const res = await delegate(delegatee, `${vests.toFixed(6)} VESTS`);
-      if (!('needsClientSigning' in res) && res.emancipationRequired && typeof window !== 'undefined') {
-        window.dispatchEvent(new CustomEvent('snapie:emancipation-required'))
-      }
+      if ('needsClientSigning' in res) { emitNeedsWallet(); throw Object.assign(new Error('Connect your Hive wallet to delegate'), { code: 'needs_client_signing' }); }
+      if (res.emancipationRequired && typeof window !== 'undefined') window.dispatchEvent(new CustomEvent('snapie:emancipation-required'))
       return res;
     }
     const op = [
@@ -286,7 +286,12 @@ export async function broadcastWithKeychain(
           default:
             res = await snapie.broadcastOp(opName, body);
         }
-        if (res && !('needsClientSigning' in res)) {
+        if (res && 'needsClientSigning' in res) {
+          const { emitNeedsWallet } = await import('@/lib/hive/signing');
+          emitNeedsWallet();
+          throw Object.assign(new Error('Connect your Hive wallet to complete this action'), { code: 'needs_client_signing' });
+        }
+        if (res) {
           if (res.emancipationRequired && typeof window !== 'undefined') {
             window.dispatchEvent(new CustomEvent('snapie:emancipation-required'))
           }

--- a/lib/hive/signing.ts
+++ b/lib/hive/signing.ts
@@ -32,3 +32,14 @@ export function getSigningAuthMode(): AuthMode {
 export function isSnapieMode(): boolean {
   return _mode === 'snapie'
 }
+
+/**
+ * Fired when an emancipated Snapie user attempts an active-key operation.
+ * The server responds with needsClientSigning: true — we surface this to the UI
+ * instead of silently failing so the user knows to connect their Hive wallet.
+ */
+export function emitNeedsWallet(): void {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('snapie:needs-wallet'))
+  }
+}


### PR DESCRIPTION
## Summary

- **Root cause**: Emancipated accounts have posting authority only. Active-key Snapie endpoints return `{ needsClientSigning: true }`. The old code fell through to an Aioha call with no logged-in wallet → silent failure.
- **Fix**: All five active-key Snapie interceptors (`transferWithAioha`, `powerUpWithKeychain`, `powerDownWithKeychain`, `delegateWithKeychain`, `broadcastWithKeychain`) now detect `needsClientSigning: true`, fire a `snapie:needs-wallet` DOM event, and throw a typed error.
- **UI**: `NeedsWalletHandler` listens to the event and shows a tappable toast: "Active key required — tap to connect your Hive wallet." The toast opens `LoginModal` directly to the Hive wallet view (Keychain / HiveAuth / Peak).
- **`openLoginModalToWallets()`**: New function on `LoginModalContext` that bypasses the email/Google flow and drops the user straight onto the wallet provider buttons.
- Posting-key ops (vote, comment, custom_json) are unaffected — they already fall through to Aioha correctly.

## Test plan

- [ ] Log in with email (custodial) → all wallet ops work normally, no toast
- [ ] Log in as emancipated account → attempt Transfer → toast appears with "Active key required"
- [ ] Tap toast → LoginModal opens on the Hive wallet tab (Keychain / HiveAuth)
- [ ] Connect Keychain → wallet ops work via Aioha
- [ ] Posting ops (vote, post snap) still work for emancipated users via Snapie posting authority
- [ ] `openLoginModal()` still opens to the providers (email/Google) view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a notification alert that prompts users to connect a Hive wallet when active key operations require wallet signing.
  * Improved login modal to support opening directly to the wallet connection view.

* **Bug Fixes**
  * Enhanced transaction functions to properly detect and notify users when client-side wallet signing is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->