### PR TITLE
feat: route hangouts boost transfers through Snapie Auth

### DIFF
--- a/components/hangouts/HangoutModal.tsx
+++ b/components/hangouts/HangoutModal.tsx
@@ -6,6 +6,7 @@ import { Center, Spinner, Text, VStack, Button, Box } from '@chakra-ui/react';
 import { HangoutsProvider, HangoutsRoom, useHangoutsRoom, HangoutsApiClient } from '@snapie/hangouts-react';
 import { useAioha } from '@aioha/react-ui';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { useHangoutsAiohaAdapter } from '@/hooks/useHangoutsAiohaAdapter';
 import { useHangout } from '@/contexts/HangoutContext';
 import { useWakeLock } from '@/hooks/useWakeLock';
 import { providerSignPrompt } from '@/lib/utils/aiohaProviderUi';
@@ -135,7 +136,8 @@ function RoomBody({ roomName, onClose }: RoomBodyProps) {
 export default function HangoutModal({ isOpen, onClose, roomName }: HangoutModalProps) {
   useWakeLock(isOpen);
   const { aioha } = useAioha();
-  const { username: user } = useCurrentUser();
+  const { username: user, isSnapie } = useCurrentUser();
+  const aiohaAdapter = useHangoutsAiohaAdapter();
   const { sessionToken, sessionLoading, error, retryLogin } = useHangout();
 
   useEffect(() => {
@@ -146,7 +148,7 @@ export default function HangoutModal({ isOpen, onClose, roomName }: HangoutModal
 
   const needsTokenWait = !!user && !sessionToken && !error;
   const currentProvider = aioha?.getCurrentProvider?.() ?? null;
-  const signPrompt = providerSignPrompt(currentProvider);
+  const signPrompt = isSnapie ? 'Signing in with Snapie…' : providerSignPrompt(currentProvider);
 
   if (!isOpen) return null;
 
@@ -256,6 +258,7 @@ export default function HangoutModal({ isOpen, onClose, roomName }: HangoutModal
                 sessionToken={sessionToken ?? undefined}
                 username={user ?? undefined}
                 imageServerApiKey={IMAGE_SERVER_API_KEY}
+                aioha={aiohaAdapter}
               >
                 <RoomBody roomName={roomName} onClose={onClose} />
               </HangoutsProvider>

--- a/components/hangouts/HangoutsLobbyView.tsx
+++ b/components/hangouts/HangoutsLobbyView.tsx
@@ -6,6 +6,7 @@ import '@/app/hangouts/overrides.css';
 import { useHangout } from '@/contexts/HangoutContext';
 import { useAioha } from '@aioha/react-ui';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { useHangoutsAiohaAdapter } from '@/hooks/useHangoutsAiohaAdapter';
 import { snapieHangoutComposer } from '@/lib/utils/composerSdk';
 import { getLastSnapsContainer, signAndBroadcastWithKeychain } from '@/lib/hive/client-functions';
 import { providerSignPrompt } from '@/lib/utils/aiohaProviderUi';
@@ -106,7 +107,8 @@ function GuestLobby() {
 
 export default function HangoutsLobbyView({ roomName }: HangoutsLobbyViewProps) {
   const { aioha } = useAioha();
-  const { username: user } = useCurrentUser();
+  const { username: user, isSnapie } = useCurrentUser();
+  const aiohaAdapter = useHangoutsAiohaAdapter();
   const { openRoom, sessionToken, sessionLoading, error, retryLogin } = useHangout();
 
   // Lazy-sign on landing — the context no longer auto-signs on user change.
@@ -136,6 +138,7 @@ export default function HangoutsLobbyView({ roomName }: HangoutsLobbyViewProps) 
           apiBaseUrl={API_URL}
           livekitServerUrl={LK_URL}
           imageServerApiKey={IMAGE_SERVER_API_KEY}
+          aioha={aiohaAdapter}
         >
           <GuestLobby />
         </HangoutsProvider>
@@ -164,7 +167,7 @@ export default function HangoutsLobbyView({ roomName }: HangoutsLobbyViewProps) 
   // HiveAuth in particular silently waits on a phone push otherwise.
   if (sessionLoading || !sessionToken) {
     const currentProvider = aioha?.getCurrentProvider?.() ?? null;
-    const signPrompt = providerSignPrompt(currentProvider);
+    const signPrompt = isSnapie ? 'Signing in with Snapie…' : providerSignPrompt(currentProvider);
     return (
       <Center p={12}>
         <VStack spacing={3}>
@@ -183,6 +186,7 @@ export default function HangoutsLobbyView({ roomName }: HangoutsLobbyViewProps) 
         sessionToken={sessionToken}
         username={user}
         imageServerApiKey={IMAGE_SERVER_API_KEY}
+        aioha={aiohaAdapter}
       >
         <AuthLobby user={user} />
       </HangoutsProvider>

--- a/hooks/useHangoutsAiohaAdapter.ts
+++ b/hooks/useHangoutsAiohaAdapter.ts
@@ -1,0 +1,37 @@
+'use client'
+import { useMemo } from 'react'
+import { KeyTypes } from '@aioha/aioha'
+import type { AiohaLike } from '@snapie/hangouts-core'
+import { signMessageWithAioha, transferWithAioha } from '@/lib/hive/aioha'
+import { useCurrentUser } from './useCurrentUser'
+
+/**
+ * Returns an AiohaLike adapter for HangoutsProvider that routes signing and
+ * boost transfers through our unified Snapie / Aioha signing layer.
+ *
+ * Passing this as `aioha={adapter}` ensures custodial Snapie users never hit
+ * Keychain for in-room boost transfers — the transfer goes through the Snapie
+ * proxy instead.
+ */
+export function useHangoutsAiohaAdapter(): AiohaLike {
+  const { username, isLoggedIn } = useCurrentUser()
+
+  return useMemo<AiohaLike>(() => ({
+    async signMessage(msg: string) {
+      try {
+        return await signMessageWithAioha(msg, KeyTypes.Posting)
+      } catch (err: unknown) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+    getCurrentUser: () => username,
+    isLoggedIn: () => isLoggedIn,
+    async transfer(to, amount, currency, memo) {
+      try {
+        return await transferWithAioha(to, amount, currency, memo)
+      } catch (err: unknown) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+  }), [username, isLoggedIn])
+}


### PR DESCRIPTION
## Summary

- Custodial Snapie users boosting a host in OpenPods/Hangouts hit Keychain — root cause: no `aioha` adapter wired to `HangoutsProvider`
- New `useHangoutsAiohaAdapter` hook returns an `AiohaLike` delegating `signMessage` → `signMessageWithAioha` and `transfer` → `transferWithAioha` (both already route through Snapie proxy for custodial users)
- Adapter passed as `aioha={adapter}` to every `HangoutsProvider` in `HangoutModal` and `HangoutsLobbyView`
- Fixed spinner text: Snapie users see "Signing in with Snapie…" instead of "Waiting for your wallet to sign…"

## Test plan

- [ ] Custodial Snapie login → join OpenPod → boost host → no Keychain popup, transfer via proxy
- [ ] Keychain login → boost host → Keychain popup appears normally
- [ ] Guest browse → no errors
- [ ] Snapie login → hangouts page → spinner shows "Signing in with Snapie…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Snapie authentication support for hangouts.
  * Updated sign-in prompts to display Snapie-specific messaging when applicable.

* **Refactor**
  * Improved authentication integration for hangouts functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->