### PR TITLE
feat: edit profile from wallet

### DIFF
--- a/components/wallet/EditProfileModal.tsx
+++ b/components/wallet/EditProfileModal.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import {
   Modal,
   ModalOverlay,
@@ -19,9 +19,12 @@ import {
   Box,
   Image,
   Text,
+  IconButton,
+  Progress,
   useToast,
 } from '@chakra-ui/react';
-import { updateProfile } from '@/lib/hive/client-functions';
+import { FaCamera } from 'react-icons/fa';
+import { updateProfile, uploadImageWithKeychain } from '@/lib/hive/client-functions';
 
 interface EditProfileModalProps {
   isOpen: boolean;
@@ -47,6 +50,8 @@ export default function EditProfileModal({
 }: EditProfileModalProps) {
   const toast = useToast();
   const [isSaving, setIsSaving] = useState(false);
+  const [avatarUploadProgress, setAvatarUploadProgress] = useState<number | null>(null);
+  const [coverUploadProgress, setCoverUploadProgress] = useState<number | null>(null);
 
   const [name, setName] = useState('');
   const [about, setAbout] = useState('');
@@ -54,6 +59,9 @@ export default function EditProfileModal({
   const [website, setWebsite] = useState('');
   const [profileImage, setProfileImage] = useState('');
   const [coverImage, setCoverImage] = useState('');
+
+  const avatarInputRef = useRef<HTMLInputElement>(null);
+  const coverInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (isOpen) {
@@ -63,8 +71,34 @@ export default function EditProfileModal({
       setWebsite(initialData.website);
       setProfileImage(initialData.profileImage);
       setCoverImage(initialData.coverImage);
+      setAvatarUploadProgress(null);
+      setCoverUploadProgress(null);
     }
   }, [isOpen, initialData]);
+
+  async function handleImageFile(
+    file: File,
+    setter: (url: string) => void,
+    setProgress: (p: number | null) => void,
+  ) {
+    setProgress(0);
+    try {
+      const url = await uploadImageWithKeychain(file, username, {
+        onProgress: (p) => setProgress(p),
+      });
+      setter(url);
+    } catch (err: unknown) {
+      toast({
+        title: 'Upload failed',
+        description: err instanceof Error ? err.message : 'Unknown error',
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setProgress(null);
+    }
+  }
 
   async function handleSave() {
     setIsSaving(true);
@@ -79,6 +113,8 @@ export default function EditProfileModal({
     }
   }
 
+  const isUploading = avatarUploadProgress !== null || coverUploadProgress !== null;
+
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="lg" scrollBehavior="inside">
       <ModalOverlay backdropFilter="blur(6px)" />
@@ -91,48 +127,113 @@ export default function EditProfileModal({
         <ModalBody py={6}>
           <VStack spacing={5} align="stretch">
 
-            {/* Avatar preview + URL */}
+            {/* Avatar */}
             <FormControl>
-              <FormLabel fontSize="sm" color="gray.400">Profile Image URL</FormLabel>
+              <FormLabel fontSize="sm" color="gray.400">Profile Photo</FormLabel>
               <HStack spacing={3} align="center">
-                <Avatar
-                  src={profileImage || undefined}
-                  name={username}
-                  boxSize="56px"
-                  borderRadius="full"
-                  border="2px solid"
-                  borderColor="primary"
-                  flexShrink={0}
-                />
-                <Input
-                  value={profileImage}
-                  onChange={(e) => setProfileImage(e.target.value)}
-                  placeholder="https://…"
-                  size="sm"
-                  bg="muted"
-                  border="none"
-                  _focus={{ boxShadow: '0 0 0 1px var(--chakra-colors-primary)' }}
-                />
+                <Box position="relative" flexShrink={0}>
+                  <Avatar
+                    src={profileImage || undefined}
+                    name={username}
+                    boxSize="64px"
+                    borderRadius="full"
+                    border="2px solid"
+                    borderColor="primary"
+                  />
+                  <IconButton
+                    aria-label="Upload avatar"
+                    icon={<FaCamera />}
+                    size="xs"
+                    borderRadius="full"
+                    position="absolute"
+                    bottom="-2px"
+                    right="-2px"
+                    colorScheme="blue"
+                    onClick={() => avatarInputRef.current?.click()}
+                    isLoading={avatarUploadProgress !== null}
+                  />
+                  <input
+                    ref={avatarInputRef}
+                    type="file"
+                    accept="image/*"
+                    style={{ display: 'none' }}
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) handleImageFile(file, setProfileImage, setAvatarUploadProgress);
+                      e.target.value = '';
+                    }}
+                  />
+                </Box>
+                <VStack spacing={1} align="stretch" flex={1}>
+                  {avatarUploadProgress !== null ? (
+                    <Progress value={avatarUploadProgress} size="xs" colorScheme="blue" borderRadius="full" />
+                  ) : null}
+                  <Input
+                    value={profileImage}
+                    onChange={(e) => setProfileImage(e.target.value)}
+                    placeholder="Or paste an image URL…"
+                    size="sm"
+                    bg="muted"
+                    border="none"
+                    _focus={{ boxShadow: '0 0 0 1px var(--chakra-colors-primary)' }}
+                  />
+                </VStack>
               </HStack>
             </FormControl>
 
-            {/* Cover preview + URL */}
+            {/* Cover image */}
             <FormControl>
-              <FormLabel fontSize="sm" color="gray.400">Cover Image URL</FormLabel>
+              <FormLabel fontSize="sm" color="gray.400">Cover Photo</FormLabel>
               <VStack spacing={2} align="stretch">
-                {coverImage ? (
-                  <Box borderRadius="md" overflow="hidden" height="80px">
-                    <Image src={coverImage} alt="cover preview" width="100%" height="100%" objectFit="cover" fallback={<Box bg="muted" height="80px" />} />
+                <Box
+                  position="relative"
+                  borderRadius="md"
+                  overflow="hidden"
+                  height="90px"
+                  bg="muted"
+                  cursor="pointer"
+                  onClick={() => coverInputRef.current?.click()}
+                  _hover={{ opacity: 0.85 }}
+                >
+                  {coverImage ? (
+                    <Image src={coverImage} alt="cover preview" width="100%" height="100%" objectFit="cover" fallback={<Box bg="muted" height="90px" />} />
+                  ) : (
+                    <Box display="flex" alignItems="center" justifyContent="center" height="90px" gap={2}>
+                      <FaCamera color="gray" />
+                      <Text fontSize="xs" color="gray.500">Click to upload cover photo</Text>
+                    </Box>
+                  )}
+                  <Box
+                    position="absolute" inset={0}
+                    display="flex" alignItems="center" justifyContent="center"
+                    bg="blackAlpha.500"
+                    opacity={0}
+                    _groupHover={{ opacity: 1 }}
+                    transition="opacity 0.15s"
+                  >
+                    <FaCamera color="white" size={20} />
                   </Box>
-                ) : (
-                  <Box bg="muted" borderRadius="md" height="80px" display="flex" alignItems="center" justifyContent="center">
-                    <Text fontSize="xs" color="gray.500">No cover image</Text>
-                  </Box>
-                )}
+                  {coverUploadProgress !== null && (
+                    <Box position="absolute" bottom={0} left={0} right={0}>
+                      <Progress value={coverUploadProgress} size="xs" colorScheme="blue" borderRadius={0} />
+                    </Box>
+                  )}
+                  <input
+                    ref={coverInputRef}
+                    type="file"
+                    accept="image/*"
+                    style={{ display: 'none' }}
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) handleImageFile(file, setCoverImage, setCoverUploadProgress);
+                      e.target.value = '';
+                    }}
+                  />
+                </Box>
                 <Input
                   value={coverImage}
                   onChange={(e) => setCoverImage(e.target.value)}
-                  placeholder="https://…"
+                  placeholder="Or paste an image URL…"
                   size="sm"
                   bg="muted"
                   border="none"
@@ -195,8 +296,14 @@ export default function EditProfileModal({
         </ModalBody>
 
         <ModalFooter borderTopWidth="1px" borderColor="rgba(255,255,255,0.08)" gap={2}>
-          <Button variant="ghost" onClick={onClose} isDisabled={isSaving}>Cancel</Button>
-          <Button colorScheme="blue" onClick={handleSave} isLoading={isSaving} loadingText="Saving…">
+          <Button variant="ghost" onClick={onClose} isDisabled={isSaving || isUploading}>Cancel</Button>
+          <Button
+            colorScheme="blue"
+            onClick={handleSave}
+            isLoading={isSaving}
+            isDisabled={isUploading}
+            loadingText="Saving…"
+          >
             Save Profile
           </Button>
         </ModalFooter>

--- a/components/wallet/EditProfileModal.tsx
+++ b/components/wallet/EditProfileModal.tsx
@@ -1,0 +1,206 @@
+'use client';
+import { useState, useEffect } from 'react';
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+  VStack,
+  HStack,
+  Avatar,
+  Box,
+  Image,
+  Text,
+  useToast,
+} from '@chakra-ui/react';
+import { updateProfile } from '@/lib/hive/client-functions';
+
+interface EditProfileModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  username: string;
+  initialData: {
+    name: string;
+    about: string;
+    location: string;
+    website: string;
+    profileImage: string;
+    coverImage: string;
+  };
+  onSaved: () => void;
+}
+
+export default function EditProfileModal({
+  isOpen,
+  onClose,
+  username,
+  initialData,
+  onSaved,
+}: EditProfileModalProps) {
+  const toast = useToast();
+  const [isSaving, setIsSaving] = useState(false);
+
+  const [name, setName] = useState('');
+  const [about, setAbout] = useState('');
+  const [location, setLocation] = useState('');
+  const [website, setWebsite] = useState('');
+  const [profileImage, setProfileImage] = useState('');
+  const [coverImage, setCoverImage] = useState('');
+
+  useEffect(() => {
+    if (isOpen) {
+      setName(initialData.name);
+      setAbout(initialData.about);
+      setLocation(initialData.location);
+      setWebsite(initialData.website);
+      setProfileImage(initialData.profileImage);
+      setCoverImage(initialData.coverImage);
+    }
+  }, [isOpen, initialData]);
+
+  async function handleSave() {
+    setIsSaving(true);
+    const res = await updateProfile(username, name, about, location, coverImage, profileImage, website);
+    setIsSaving(false);
+    if (res.success) {
+      toast({ title: 'Profile updated', status: 'success', duration: 3000 });
+      onSaved();
+      onClose();
+    } else {
+      toast({ title: 'Update failed', description: res.error, status: 'error', duration: 6000, isClosable: true });
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="lg" scrollBehavior="inside">
+      <ModalOverlay backdropFilter="blur(6px)" />
+      <ModalContent bg="background" color="text" borderColor="rgba(255,255,255,0.08)" borderWidth="1px">
+        <ModalHeader borderBottomWidth="1px" borderColor="rgba(255,255,255,0.08)">
+          Edit Profile
+        </ModalHeader>
+        <ModalCloseButton />
+
+        <ModalBody py={6}>
+          <VStack spacing={5} align="stretch">
+
+            {/* Avatar preview + URL */}
+            <FormControl>
+              <FormLabel fontSize="sm" color="gray.400">Profile Image URL</FormLabel>
+              <HStack spacing={3} align="center">
+                <Avatar
+                  src={profileImage || undefined}
+                  name={username}
+                  boxSize="56px"
+                  borderRadius="full"
+                  border="2px solid"
+                  borderColor="primary"
+                  flexShrink={0}
+                />
+                <Input
+                  value={profileImage}
+                  onChange={(e) => setProfileImage(e.target.value)}
+                  placeholder="https://…"
+                  size="sm"
+                  bg="muted"
+                  border="none"
+                  _focus={{ boxShadow: '0 0 0 1px var(--chakra-colors-primary)' }}
+                />
+              </HStack>
+            </FormControl>
+
+            {/* Cover preview + URL */}
+            <FormControl>
+              <FormLabel fontSize="sm" color="gray.400">Cover Image URL</FormLabel>
+              <VStack spacing={2} align="stretch">
+                {coverImage ? (
+                  <Box borderRadius="md" overflow="hidden" height="80px">
+                    <Image src={coverImage} alt="cover preview" width="100%" height="100%" objectFit="cover" fallback={<Box bg="muted" height="80px" />} />
+                  </Box>
+                ) : (
+                  <Box bg="muted" borderRadius="md" height="80px" display="flex" alignItems="center" justifyContent="center">
+                    <Text fontSize="xs" color="gray.500">No cover image</Text>
+                  </Box>
+                )}
+                <Input
+                  value={coverImage}
+                  onChange={(e) => setCoverImage(e.target.value)}
+                  placeholder="https://…"
+                  size="sm"
+                  bg="muted"
+                  border="none"
+                  _focus={{ boxShadow: '0 0 0 1px var(--chakra-colors-primary)' }}
+                />
+              </VStack>
+            </FormControl>
+
+            <FormControl>
+              <FormLabel fontSize="sm" color="gray.400">Display Name</FormLabel>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Your name"
+                bg="muted"
+                border="none"
+                _focus={{ boxShadow: '0 0 0 1px var(--chakra-colors-primary)' }}
+              />
+            </FormControl>
+
+            <FormControl>
+              <FormLabel fontSize="sm" color="gray.400">About</FormLabel>
+              <Textarea
+                value={about}
+                onChange={(e) => setAbout(e.target.value)}
+                placeholder="Tell the world about yourself…"
+                bg="muted"
+                border="none"
+                rows={3}
+                resize="vertical"
+                _focus={{ boxShadow: '0 0 0 1px var(--chakra-colors-primary)' }}
+              />
+            </FormControl>
+
+            <FormControl>
+              <FormLabel fontSize="sm" color="gray.400">Location</FormLabel>
+              <Input
+                value={location}
+                onChange={(e) => setLocation(e.target.value)}
+                placeholder="City, Country"
+                bg="muted"
+                border="none"
+                _focus={{ boxShadow: '0 0 0 1px var(--chakra-colors-primary)' }}
+              />
+            </FormControl>
+
+            <FormControl>
+              <FormLabel fontSize="sm" color="gray.400">Website</FormLabel>
+              <Input
+                value={website}
+                onChange={(e) => setWebsite(e.target.value)}
+                placeholder="https://yoursite.com"
+                bg="muted"
+                border="none"
+                _focus={{ boxShadow: '0 0 0 1px var(--chakra-colors-primary)' }}
+              />
+            </FormControl>
+
+          </VStack>
+        </ModalBody>
+
+        <ModalFooter borderTopWidth="1px" borderColor="rgba(255,255,255,0.08)" gap={2}>
+          <Button variant="ghost" onClick={onClose} isDisabled={isSaving}>Cancel</Button>
+          <Button colorScheme="blue" onClick={handleSave} isLoading={isSaving} loadingText="Saving…">
+            Save Profile
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/components/wallet/WalletPage.tsx
+++ b/components/wallet/WalletPage.tsx
@@ -19,7 +19,7 @@ import {
   Badge,
   useDisclosure,
 } from '@chakra-ui/react';
-import { FaGlobe, FaExchangeAlt, FaPiggyBank, FaShoppingCart, FaArrowDown, FaShareAlt, FaDollarSign, FaArrowUp, FaPaperPlane, FaCoins, FaChartLine, FaGift } from 'react-icons/fa';
+import { FaGlobe, FaExchangeAlt, FaPiggyBank, FaShoppingCart, FaArrowDown, FaShareAlt, FaDollarSign, FaArrowUp, FaPaperPlane, FaCoins, FaChartLine, FaGift, FaEdit } from 'react-icons/fa';
 import useHiveAccount from '@/hooks/useHiveAccount';
 import {
   getProfile,
@@ -37,6 +37,7 @@ import {
   claimHbdSavingsInterest,
   type SwapDirection,
 } from '@/lib/hive/client-functions';
+import EditProfileModal from '@/components/wallet/EditProfileModal';
 import { useHbdSavingsInterest } from '@/hooks/useHbdSavingsInterest';
 import { extractNumber } from '@/lib/utils/extractNumber';
 import WalletModal from '@/components/wallet/WalletModal';
@@ -62,12 +63,16 @@ export default function WalletPage({ username }: WalletPageProps) {
   const { username: user } = useCurrentUser();
   const { hiveAccount, isLoading, error, refetch } = useHiveAccount(username);
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const { isOpen: isEditOpen, onOpen: onEditOpen, onClose: onEditClose } = useDisclosure();
 
   const [prices, setPrices] = useState<{ hive: number; hbd: number } | null>(null);
-  const [profileMetadata, setProfileMetadata] = useState<{ profileImage: string; coverImage: string; website: string }>({
+  const [profileMetadata, setProfileMetadata] = useState<{ profileImage: string; coverImage: string; website: string; name: string; about: string; location: string }>({
     profileImage: '',
     coverImage: '',
     website: '',
+    name: '',
+    about: '',
+    location: '',
   });
   const [profileInfo, setProfileInfo] = useState<any>(null);
   const [modalContent, setModalContent] = useState<WalletModalContent | null>(null);
@@ -83,7 +88,7 @@ export default function WalletPage({ username }: WalletPageProps) {
   const accentColor = 'accent';
 
   useEffect(() => {
-    const empty = { profileImage: '', coverImage: '', website: '' };
+    const empty = { profileImage: '', coverImage: '', website: '', name: '', about: '', location: '' };
     const raw = hiveAccount?.posting_json_metadata;
     if (!raw) { setProfileMetadata(empty); return; }
     try {
@@ -93,6 +98,9 @@ export default function WalletPage({ username }: WalletPageProps) {
         profileImage: profile.profile_image || '',
         coverImage: profile.cover_image || '',
         website: profile.website || '',
+        name: profile.name || '',
+        about: profile.about || '',
+        location: profile.location || '',
       });
     } catch (err) {
       console.error('Failed to parse profile metadata', err);
@@ -341,16 +349,31 @@ export default function WalletPage({ username }: WalletPageProps) {
           </Box>
         </Flex>
 
-        <Flex
-          zIndex={2} position="relative"
-          alignItems="center" gap={2}
-          bg="rgba(24, 168, 255, 0.1)"
-          border="1px solid" borderColor="rgba(24, 168, 255, 0.3)"
-          borderRadius="full" px={4} py={2}
-        >
-          <Icon as={FaCoins} color="primary" boxSize={4} />
-          <Text fontSize="sm" fontWeight="bold" color="primary">Wallet</Text>
-        </Flex>
+        <HStack zIndex={2} position="relative" spacing={2}>
+          {isOwnWallet && (
+            <Button
+              size="sm"
+              variant="ghost"
+              leftIcon={<Icon as={FaEdit} boxSize={3} />}
+              onClick={onEditOpen}
+              color="gray.400"
+              _hover={{ color: 'primary', bg: 'rgba(24,168,255,0.08)' }}
+              borderRadius="full"
+              px={3}
+            >
+              Edit Profile
+            </Button>
+          )}
+          <Flex
+            alignItems="center" gap={2}
+            bg="rgba(24, 168, 255, 0.1)"
+            border="1px solid" borderColor="rgba(24, 168, 255, 0.3)"
+            borderRadius="full" px={4} py={2}
+          >
+            <Icon as={FaCoins} color="primary" boxSize={4} />
+            <Text fontSize="sm" fontWeight="bold" color="primary">Wallet</Text>
+          </Flex>
+        </HStack>
       </Flex>
 
       {/* Wallet Content */}
@@ -735,6 +758,14 @@ export default function WalletPage({ username }: WalletPageProps) {
           slippagePercent: 0.5,
         }}
         onConfirm={handleConfirm}
+      />
+
+      <EditProfileModal
+        isOpen={isEditOpen}
+        onClose={onEditClose}
+        username={username}
+        initialData={profileMetadata}
+        onSaved={refetch}
       />
     </Box>
   );

--- a/lib/hive/aioha.ts
+++ b/lib/hive/aioha.ts
@@ -127,7 +127,7 @@ export async function broadcastOps(
     if (isSnapieMode()) {
       const { broadcastOp } = await import('@/lib/snapie-auth/client');
       // Filter to allowed ops (server only accepts posting-key ops via broadcast).
-      const allowed = new Set(['vote', 'comment', 'delete_comment', 'custom_json', 'claim_reward_balance']);
+      const allowed = new Set(['vote', 'comment', 'delete_comment', 'custom_json', 'claim_reward_balance', 'account_update2']);
       for (const op of operations) {
         const [opName, opBody] = op as [string, Record<string, unknown>];
         if (!allowed.has(opName)) continue; // skip comment_options etc.

--- a/lib/hive/client-functions.ts
+++ b/lib/hive/client-functions.ts
@@ -317,31 +317,32 @@ export async function updateProfile(
   coverImageUrl: string,
   avatarUrl: string,
   website: string,
-) {
+): Promise<{ success: boolean; error?: string }> {
+  const profileMetadata = {
+    profile: {
+      name,
+      about,
+      location,
+      cover_image: coverImageUrl,
+      profile_image: avatarUrl,
+      website,
+      version: 2,
+    },
+  };
+  const op = [
+    'account_update2',
+    {
+      account: username,
+      posting_json_metadata: JSON.stringify(profileMetadata),
+      extensions: [],
+    },
+  ];
   try {
-    const profileMetadata = {
-      profile: {
-        name,
-        about,
-        location,
-        cover_image: coverImageUrl,
-        profile_image: avatarUrl,
-        website,
-        version: 2,
-      },
-    };
-    const op = [
-      'account_update2',
-      {
-        account: username,
-        posting_json_metadata: JSON.stringify(profileMetadata),
-        extensions: [],
-      },
-    ];
-    const result = await aiohaBroadcast([op], KeyTypes.Active, 'Approve profile update');
-    console.log('Broadcast success:', result);
-  } catch (error) {
-    console.error('Profile update failed:', error);
+    await broadcastOps([op], KeyTypes.Posting, 'Approve profile update');
+    return { success: true };
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { success: false, error: message };
   }
 }
 

--- a/lib/hive/client-functions.ts
+++ b/lib/hive/client-functions.ts
@@ -333,6 +333,7 @@ export async function updateProfile(
     'account_update2',
     {
       account: username,
+      json_metadata: '',
       posting_json_metadata: JSON.stringify(profileMetadata),
       extensions: [],
     },


### PR DESCRIPTION
## Summary

- Adds an **Edit Profile** button to the wallet page header (own wallet only)
- Opens a modal with file upload + URL fallback for avatar and cover photo
- Fields: display name, bio, location, website
- Image uploads use the existing `uploadImageWithKeychain` routing — Snapie custodial users go direct to `images.3speak.tv`, wallet users go through `/api/upload-image` with Hive signing
- Broadcasts `account_update2` with posting key (only `posting_json_metadata` is written)
- Added `account_update2` to the Snapie broadcast allowed-ops set
- Fixed Hive serializer requirement: `json_metadata: ''` must be present even when unused

## Test plan

- [ ] Own wallet → "Edit Profile" button visible in header
- [ ] Other user's wallet → button not shown
- [ ] Upload avatar photo → progress bar → URL populates → avatar preview updates
- [ ] Upload cover photo → progress bar → cover preview updates
- [ ] Paste a URL directly → preview updates immediately
- [ ] Save → profile updated on-chain → wallet page refreshes
- [ ] Snapie custodial user → image upload goes to images.3speak.tv (no signing prompt)
- [ ] Wallet user → image upload triggers signing via Aioha provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile editing from your wallet page with support for updating name, bio, location, website, and profile/cover images via upload or direct URL pasting. Edit functionality is available when viewing your own wallet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->