### PR TITLE
fix: reset chat session on account switch or logout

### DIFF
--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -657,6 +657,25 @@ export default function ChatPanel({
     if (!exists) setActiveConversationId(conversations[0]._id);
   }, [conversations, activeConversationId]);
 
+  // Reset chat session whenever the logged-in user changes (logout or account
+  // switch). The JWT is issued per-username, so an old token must never carry
+  // over to a new account.
+  const prevUserRef = useRef<string | null | undefined>(undefined);
+  useEffect(() => {
+    if (prevUserRef.current === undefined) {
+      prevUserRef.current = user;
+      return;
+    }
+    if (prevUserRef.current !== user) {
+      prevUserRef.current = user;
+      chatService.logout();
+      setAuthState('idle');
+      setAuthError('');
+      setMessages([]);
+      setConversations([]);
+    }
+  }, [user]);
+
   useEffect(() => {
     if (isMobile || isPopoutWindow) return;
     try {


### PR DESCRIPTION
## Problem

Logging out of a Snapie Auth account and logging in as a different Snapie account left the chat panel showing the first account's session. The chat JWT is issued per-username but was persisting in `localStorage`, so the new account was never prompted to sign in and all of account A's conversations/messages remained visible.

## Root cause

`ChatPanel` had no effect watching the `user` value from `useCurrentUser()`. `chatService.isAuthenticated()` returned `true` (old JWT still in localStorage), `authState` was still `'done'`, and nothing triggered a reset.

## Fix

Track the previous username in a `ref`. Whenever `user` changes — whether to `null` (logout) or a different string (account switch) — call `chatService.logout()` to clear the JWT and reset `authState`, `messages`, and `conversations` so the new account starts from a clean state and sees the sign-in prompt.

## Test plan

- [ ] Log in as account A → connect to chat → log out → chat shows sign-in state (not A's messages)
- [ ] Log in as account A → connect → log out → log in as account B → chat prompts sign-in for B
- [ ] Normal page load with no prior session → unaffected
- [ ] Wallet user (Keychain) → same behavior on logout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where chat sessions and authentication data would incorrectly persist when switching between user accounts. Chat history, authentication tokens, and conversation data now properly clear when switching accounts, preventing unintended cross-account data exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->