### PR TITLE
fix: reset chat session on account switch or logout

### DIFF
--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -657,23 +657,22 @@ export default function ChatPanel({
     if (!exists) setActiveConversationId(conversations[0]._id);
   }, [conversations, activeConversationId]);
 
-  // Reset chat session whenever the logged-in user changes (logout or account
-  // switch). The JWT is issued per-username, so an old token must never carry
-  // over to a new account.
+  // Reset chat session on logout or account switch. The JWT is issued per-username
+  // so an old token must never carry over to a different account.
+  // Only fires when the previous value was a real username — null→username is a
+  // normal page-load/initial-login transition and must not clear the token.
   const prevUserRef = useRef<string | null | undefined>(undefined);
   useEffect(() => {
-    if (prevUserRef.current === undefined) {
-      prevUserRef.current = user;
-      return;
-    }
-    if (prevUserRef.current !== user) {
-      prevUserRef.current = user;
-      chatService.logout();
-      setAuthState('idle');
-      setAuthError('');
-      setMessages([]);
-      setConversations([]);
-    }
+    const prev = prevUserRef.current;
+    prevUserRef.current = user;
+    if (prev === undefined || prev === null) return; // mount or initial login
+    if (prev === user) return;
+    // prev was a real username and it changed — logout or account switch
+    chatService.logout();
+    setAuthState('idle');
+    setAuthError('');
+    setMessages([]);
+    setConversations([]);
   }, [user]);
 
   useEffect(() => {


### PR DESCRIPTION
## Problem

Switching between Snapie Auth accounts left the chat panel showing the first account's session. The chat JWT (issued per-username) persisted in `localStorage`, so the new account was never prompted to sign in and account A's conversations/messages stayed visible.

## Root cause

`ChatPanel` had no effect watching the `user` value from `useCurrentUser()`. `chatService.isAuthenticated()` returned `true` (old JWT still in localStorage), `authState` was still `'done'`, and nothing triggered a reset.

## Fix

Track the previous username in a `ref`. When `user` transitions from a real username to something different (logout or account switch), call `chatService.logout()` to clear the JWT and reset `authState`, `messages`, and `conversations`.

The `null → username` transition (page load / initial login) is explicitly skipped — it is not an account switch and must not clear an existing valid token.

| prev | current | action |
|------|---------|--------|
| `undefined` | anything | mount — skip |
| `null` | username | initial load/login — skip |
| username | `null` | logout — reset |
| username A | username B | switch — reset |

## Test plan

- [ ] Logged in as A → connect chat → log out → chat resets to sign-in state
- [ ] Log in as B → chat prompts sign-in for B, not A's messages
- [ ] Refresh page while logged in → chat token preserved, messages load normally
- [ ] Fresh page load → unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)