### PR TITLE
fix: reset chat session on account switch (v2)

### DIFF
--- a/components/chat/ChatPanel.tsx
+++ b/components/chat/ChatPanel.tsx
@@ -657,22 +657,20 @@ export default function ChatPanel({
     if (!exists) setActiveConversationId(conversations[0]._id);
   }, [conversations, activeConversationId]);
 
-  // Reset chat session on logout or account switch. The JWT is issued per-username
-  // so an old token must never carry over to a different account.
-  // Only fires when the previous value was a real username — null→username is a
-  // normal page-load/initial-login transition and must not clear the token.
-  const prevUserRef = useRef<string | null | undefined>(undefined);
+  // If the current user differs from whoever the stored chat token was issued
+  // for, clear it so the new account authenticates fresh. Intentionally skipped
+  // when user is null (logout) — the same user logging back in should reuse
+  // their existing valid token without triggering a re-authenticate.
   useEffect(() => {
-    const prev = prevUserRef.current;
-    prevUserRef.current = user;
-    if (prev === undefined || prev === null) return; // mount or initial login
-    if (prev === user) return;
-    // prev was a real username and it changed — logout or account switch
-    chatService.logout();
-    setAuthState('idle');
-    setAuthError('');
-    setMessages([]);
-    setConversations([]);
+    if (!user) return;
+    const tokenOwner = chatService.getTokenUsername();
+    if (tokenOwner && tokenOwner !== user) {
+      chatService.logout();
+      setAuthState('idle');
+      setAuthError('');
+      setMessages([]);
+      setConversations([]);
+    }
   }, [user]);
 
   useEffect(() => {

--- a/lib/chat/ChatService.ts
+++ b/lib/chat/ChatService.ts
@@ -59,19 +59,26 @@ export interface ChatPreferences {
 }
 
 const TOKEN_KEY = 'hive-chat-token';
+const TOKEN_USER_KEY = 'hive-chat-token-user';
 const BASE = '/api/chat';
 
 class ChatService {
   private token: string | null = null;
+  private tokenUsername: string | null = null;
 
   constructor() {
     if (typeof window !== 'undefined') {
       this.token = localStorage.getItem(TOKEN_KEY);
+      this.tokenUsername = localStorage.getItem(TOKEN_USER_KEY);
     }
   }
 
   isAuthenticated(): boolean {
     return !!this.token;
+  }
+
+  getTokenUsername(): string | null {
+    return this.tokenUsername;
   }
 
   async authenticate(
@@ -90,12 +97,16 @@ class ChatService {
       false
     );
     this.token = token;
+    this.tokenUsername = username;
     localStorage.setItem(TOKEN_KEY, token);
+    localStorage.setItem(TOKEN_USER_KEY, username);
   }
 
   logout(): void {
     this.token = null;
+    this.tokenUsername = null;
     localStorage.removeItem(TOKEN_KEY);
+    localStorage.removeItem(TOKEN_USER_KEY);
   }
 
   async getChannels(): Promise<Channel[]> {


### PR DESCRIPTION
## Problem

When switching from account A to account B, the chat panel kept showing account A's session.

## What went wrong with the previous fix (PR #122)

PR #122 tracked `user` transitions via a `useRef` and cleared the token whenever the value changed. This correctly handled account switches but also cleared on **logout** (`user → null`), forcing re-authentication when the same user logged back in. That re-auth hit a pre-existing 500 from `/api/chat/auth/verify` when signing via the Snapie proxy — a bug that was previously hidden because the token was never invalidated.

## This fix

Store the issued-for username alongside the JWT in localStorage (`hive-chat-token-user`). When a logged-in user is present, compare them to the token owner:

- **Same user** → token is valid, no action (handles same-account re-login and page refresh)  
- **Different user** → clear token and reset to idle so the new account authenticates fresh
- **No user (logout)** → skip entirely, token preserved for when they log back in

This avoids the forced re-auth entirely for the same-account case and only triggers it when truly necessary.

## Test plan

- [ ] Log in as A → connect chat → log out → log back in as A → chat works, no re-auth prompt
- [ ] Log in as A → connect chat → log out → log in as B → chat resets and prompts sign-in for B
- [ ] Hard refresh while logged in → token preserved, messages load normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)