### PR TITLE
fix: prevent stale fetchUnread() from overwriting mark-as-read state

### DIFF
--- a/hooks/useHiveNotifications.ts
+++ b/hooks/useHiveNotifications.ts
@@ -47,14 +47,21 @@ export function useHiveNotifications(
   const accountRef = useRef(account);
   accountRef.current = account;
 
+  const lastReadRef = useRef(lastRead);
+  lastReadRef.current = lastRead;
+
   const fetchUnread = useCallback(async () => {
     if (!account) return;
 
     try {
       const state = await fetchUnreadState(account);
       if (accountRef.current === account) {
-        setLastRead(state.lastread || '1970-01-01T00:00:00');
-        setUnreadCount(state.unread || 0);
+        const newLastRead = parseHiveDate(state.lastread || '1970-01-01T00:00:00');
+        // Never regress lastRead — guards against stale responses arriving after markAllAsRead
+        if (newLastRead >= parseHiveDate(lastReadRef.current)) {
+          setLastRead(state.lastread || '1970-01-01T00:00:00');
+          setUnreadCount(state.unread || 0);
+        }
       }
     } catch {
       // Notification unread state is nice-to-have; the list can still render.
@@ -86,7 +93,7 @@ export function useHiveNotifications(
       if (accountRef.current === account) setLoading(false);
     }
 
-    fetchUnread();
+    await fetchUnread();
   }, [account, fetchUnread, limit]);
 
   const loadMore = useCallback(async () => {


### PR DESCRIPTION
## Summary

- `fetchUnread()` was called fire-and-forget inside `refetch`, so a stale API response could land after `markAllAsRead` had already zeroed the unread count — causing notifications to flip back to unread at random
- Added `await` to `fetchUnread()` in `refetch` to eliminate the basic race
- Added a timestamp regression guard in `fetchUnread`: incoming unread state is only applied if its `lastread` value is >= the current one, so a concurrent `markAllAsRead` can never be overwritten by a stale in-flight response
- Added `lastReadRef` to read current `lastRead` inside the `useCallback` without a stale closure

## Test plan

- [ ] Mark all notifications as read immediately after opening the notifications page (while the initial `fetchUnread` may still be in-flight) — unread count should stay at 0
- [ ] Leave the tab open for 60s+ so the polling cycle fires, then mark all as read — count should not revert
- [ ] Switch away and back to the tab (triggers `visibilitychange` refetch) right after marking as read — count should stay at 0
- [ ] Verify unread count still increments correctly when new notifications arrive after the next poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notification state inconsistency by preventing stale response data from reverting to older values.
  * Improved notification refresh logic to properly handle asynchronous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->