### PR TITLE
feat: support Ctrl+V image paste in compose editor and snap composer

### DIFF
--- a/app/compose/Editor.tsx
+++ b/app/compose/Editor.tsx
@@ -322,6 +322,16 @@ const Editor: FC<EditorProps> = ({ markdown, setMarkdown, title, setTitle, hasht
         }
     }, [toast, toolbar, user]); // markdown and setMarkdown excluded - using functional update pattern
 
+    const handlePaste = useCallback((e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+        const files = Array.from(e.clipboardData?.items ?? [])
+            .filter(item => item.type.startsWith('image/'))
+            .map(item => item.getAsFile())
+            .filter((f): f is File => f !== null);
+        if (files.length === 0) return;
+        e.preventDefault();
+        onDrop(files);
+    }, [onDrop]);
+
     const { getRootProps, getInputProps, isDragActive } = useDropzone({
         onDrop,
         accept: {
@@ -902,6 +912,7 @@ const Editor: FC<EditorProps> = ({ markdown, setMarkdown, title, setTitle, hasht
                                 ref={textareaRef}
                                 value={markdown}
                                 onChange={(e) => setMarkdown(e.target.value)}
+                                onPaste={handlePaste}
                                 placeholder="Write your markdown here... (or drag & drop images)"
                                 className="markdown-editor"
                                 border="none"

--- a/components/homepage/SnapComposer.tsx
+++ b/components/homepage/SnapComposer.tsx
@@ -284,6 +284,16 @@ export default function SnapComposer ({ pa, pp, onNewComment, post = false, onCl
         }
     }
 
+    function handlePaste(event: React.ClipboardEvent<HTMLTextAreaElement>) {
+        const files = Array.from(event.clipboardData?.items ?? [])
+            .filter(item => item.type.startsWith('image/'))
+            .map(item => item.getAsFile())
+            .filter((f): f is File => f !== null);
+        if (files.length === 0) return;
+        event.preventDefault();
+        handleImageSelection(files);
+    }
+
     return (
         <Box
             bg="rgba(8, 24, 40, 0.76)"
@@ -306,7 +316,8 @@ export default function SnapComposer ({ pa, pp, onNewComment, post = false, onCl
                 _placeholder={{ color: 'rgba(232, 244, 255, 0.68)' }}
                 _focus={{ borderColor: 'primary', boxShadow: '0 0 0 1px rgba(24, 168, 255, 0.42), 0 0 34px rgba(24, 168, 255, 0.16)' }}
                 isDisabled={!user || isLoading}
-                onKeyDown={handleKeyDown} // Attach the keydown handler
+                onKeyDown={handleKeyDown}
+                onPaste={handlePaste}
             />
             <HStack justify="space-between" mb={3} flexWrap="wrap" gap={2}>
                 <HStack flexShrink={1} minW={0}>


### PR DESCRIPTION
## Summary

- Both textareas now handle `onPaste` — users can paste screenshots (Win+Shift+S, browser copy-image) directly into the editor with Ctrl+V
- Uses `clipboardData.items` (not `.files`) which is the correct API for clipboard screenshots that don't produce a File entry
- Non-image pastes (plain text, etc.) pass through untouched — `e.preventDefault()` is only called when image items are found

## Implementation

**`Editor.tsx`** — delegates straight to the existing `onDrop` callback, so compression, upload toasts, `isUploading` state, and `toolbar.image()` insertion are all reused with zero duplication.

**`SnapComposer.tsx`** — delegates to `handleImageSelection`, so pasted images join the `uploadingImages` preview queue exactly like clicking the image button.

Both paths route through `uploadImageWithKeychain`, so:
- Snapie-auth accounts still go to `images.3speak.tv`
- The `/api/upload-image` fallback is unchanged

## Test plan

- [ ] Win+Shift+S screenshot → Ctrl+V in compose editor — image uploads and inserts as markdown
- [ ] Copy image from browser → Ctrl+V in compose editor — same
- [ ] Ctrl+V in snap composer — image appears in preview queue and is included on submit
- [ ] Ctrl+V plain text — passes through normally, no interference
- [ ] Snapie-auth account paste — upload goes to `images.3speak.tv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)