### PR TITLE
fix: forward client IP through snapie-auth proxy

### DIFF
--- a/app/api/snapie-auth/[...path]/route.ts
+++ b/app/api/snapie-auth/[...path]/route.ts
@@ -32,6 +32,8 @@ async function proxy(req: NextRequest, path: string[]): Promise<NextResponse> {
 
   const fwdHeaders: Record<string, string> = {}
   if (filteredCookies) fwdHeaders['Cookie'] = filteredCookies
+  const clientIp = req.headers.get('x-forwarded-for') ?? req.headers.get('x-real-ip')
+  if (clientIp) fwdHeaders['X-Forwarded-For'] = clientIp
   if (isMutating) {
     const ct = req.headers.get('content-type')
     if (ct) fwdHeaders['Content-Type'] = ct


### PR DESCRIPTION
## Summary

- The snapie-auth proxy route was not forwarding `X-Forwarded-For` / `X-Real-IP` to the upstream service
- Every proxied request arrived at snapie-auth from the server's own IP (51.81.209.112)
- Two signups exhausted the per-IP daily quota, blocking account creation for **all users** for the rest of the day

## Fix

Two lines after `fwdHeaders` is initialised (line 33):

```ts
const clientIp = req.headers.get('x-forwarded-for') ?? req.headers.get('x-real-ip')
if (clientIp) fwdHeaders['X-Forwarded-For'] = clientIp
```

Reads the real client IP from the incoming Next.js request headers and passes it upstream so snapie-auth applies rate limits per actual user, not per server.

## Post-merge action required

Clear today's poisoned quota record from MongoDB so legitimate users aren't still blocked:

```js
db.snapieauth_free_quotas.deleteOne({ type: 'ip', key: '51.81.209.112', date: '2026-06-10' })
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved handling of client IP information in the authentication API proxy to better track request origins when forwarding to upstream services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->