### PR TITLE
fix: shorts comments — top-level reply composer + desktop side panel

### DIFF
--- a/components/shorts/ShortCard.tsx
+++ b/components/shorts/ShortCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 import {
-  Box, Flex, Text, Image, VStack, HStack, IconButton, useDisclosure, useToast,
+  Box, Flex, Text, Image, VStack, HStack, IconButton, useToast,
   Slider, SliderTrack, SliderFilledTrack, SliderThumb,
   Menu, MenuButton, MenuList, MenuItem, Spinner,
 } from '@chakra-ui/react';
@@ -17,7 +17,6 @@ import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { vote, getPost } from '@/lib/hive/client-functions';
 import { useUserRelationship } from '@/hooks/useUserRelationship';
 import { useRouter } from 'next/navigation';
-import ShortsCommentSheet from './ShortsCommentSheet';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -154,10 +153,10 @@ interface ShortCardProps {
   isPreload: boolean;
   muted: boolean;
   onToggleMute: () => void;
+  onOpenComments: () => void;
 }
 
-export default function ShortCard({ short, isActive, isPreload, muted, onToggleMute }: ShortCardProps) {
-  const { isOpen: commentsOpen, onOpen: openComments, onClose: closeComments } = useDisclosure();
+export default function ShortCard({ short, isActive, isPreload, muted, onToggleMute, onOpenComments }: ShortCardProps) {
   const [liked, setLiked] = useState(false);
   const [likeCount, setLikeCount] = useState(short.stats.likes);
   const [showVoteSlider, setShowVoteSlider] = useState(false);
@@ -447,7 +446,7 @@ export default function ShortCard({ short, isActive, isPreload, muted, onToggleM
           icon={<FaComment />}
           label="Comments"
           count={short.stats.comments}
-          onClick={openComments}
+          onClick={onOpenComments}
         />
 
         {/* Share */}
@@ -516,14 +515,6 @@ export default function ShortCard({ short, isActive, isPreload, muted, onToggleM
         )}
       </VStack>
 
-      {/* Comments sheet */}
-      <ShortsCommentSheet
-        isOpen={commentsOpen}
-        onClose={closeComments}
-        author={short.author}
-        permlink={short.hivePermlink}
-        commentCount={short.stats.comments}
-      />
     </Box>
   );
 }

--- a/components/shorts/ShortsCommentContent.tsx
+++ b/components/shorts/ShortsCommentContent.tsx
@@ -1,0 +1,105 @@
+'use client';
+import {
+  Box, VStack, Text, Spinner, Flex, IconButton, useDisclosure,
+} from '@chakra-ui/react';
+import { CloseIcon } from '@chakra-ui/icons';
+import { useComments, ExtendedComment } from '@/hooks/useComments';
+import { useHiveUser } from '@/contexts/UserContext';
+import Snap from '@/components/homepage/Snap';
+import SnapReplyModal from '@/components/homepage/SnapReplyModal';
+import SnapComposer from '@/components/homepage/SnapComposer';
+import { useState } from 'react';
+import { Comment } from '@hiveio/dhive';
+
+interface ShortsCommentContentProps {
+  author: string;
+  permlink: string;
+  commentCount: number;
+  onClose: () => void;
+}
+
+export default function ShortsCommentContent({ author, permlink, commentCount, onClose }: ShortsCommentContentProps) {
+  const { hiveUser } = useHiveUser();
+  const { comments, isLoading, addComment } = useComments(author, permlink, true, hiveUser?.name);
+  const [reply, setReply] = useState<Comment | null>(null);
+  const { isOpen: replyOpen, onOpen: openReply, onClose: closeReply } = useDisclosure();
+
+  return (
+    <Flex direction="column" h="100%" overflow="hidden">
+      {/* Header */}
+      <Flex
+        px={4}
+        py={3}
+        align="center"
+        justify="space-between"
+        borderBottom="1px solid"
+        borderColor="rgba(102, 228, 255, 0.12)"
+        flexShrink={0}
+      >
+        <Text fontSize="md" fontWeight="semibold" color="white">
+          {commentCount} Comments
+        </Text>
+        <IconButton
+          aria-label="Close comments"
+          icon={<CloseIcon boxSize="10px" />}
+          size="sm"
+          variant="ghost"
+          color="white"
+          _hover={{ bg: 'whiteAlpha.100' }}
+          onClick={onClose}
+        />
+      </Flex>
+
+      {/* Comment list */}
+      <Box flex={1} overflowY="auto" px={2} py={2}>
+        {isLoading ? (
+          <Box textAlign="center" py={10}>
+            <Spinner color="blue.300" size="lg" />
+          </Box>
+        ) : comments.length === 0 ? (
+          <Text color="gray.500" textAlign="center" py={10} fontSize="sm">
+            No comments yet. Be the first!
+          </Text>
+        ) : (
+          <VStack spacing={1} align="stretch">
+            {(comments as ExtendedComment[]).map((c) => (
+              <Snap
+                key={`${c.author}/${c.permlink}`}
+                comment={c}
+                onOpen={openReply}
+                setReply={(r) => setReply(r as Comment)}
+              />
+            ))}
+          </VStack>
+        )}
+      </Box>
+
+      {/* Compose — posts a top-level comment on the short */}
+      <Box
+        flexShrink={0}
+        borderTop="1px solid"
+        borderColor="rgba(102, 228, 255, 0.12)"
+        px={3}
+        py={3}
+      >
+        <SnapComposer
+          pa={author}
+          pp={permlink}
+          onNewComment={(c) => addComment(c as Comment)}
+          post={false}
+          onClose={() => {}}
+        />
+      </Box>
+
+      {/* Reply-to-comment modal */}
+      {reply && (
+        <SnapReplyModal
+          isOpen={replyOpen}
+          onClose={closeReply}
+          comment={reply}
+          onNewReply={(c) => addComment(c as Comment)}
+        />
+      )}
+    </Flex>
+  );
+}

--- a/components/shorts/ShortsCommentSheet.tsx
+++ b/components/shorts/ShortsCommentSheet.tsx
@@ -1,14 +1,6 @@
 'use client';
-import {
-  Drawer, DrawerOverlay, DrawerContent, DrawerHeader,
-  DrawerBody, DrawerCloseButton, Spinner, Text, VStack, Box, useDisclosure,
-} from '@chakra-ui/react';
-import { useComments, ExtendedComment } from '@/hooks/useComments';
-import { useHiveUser } from '@/contexts/UserContext';
-import Snap from '@/components/homepage/Snap';
-import { useState } from 'react';
-import SnapReplyModal from '@/components/homepage/SnapReplyModal';
-import { Comment } from '@hiveio/dhive';
+import { Drawer, DrawerOverlay, DrawerContent, DrawerBody } from '@chakra-ui/react';
+import ShortsCommentContent from './ShortsCommentContent';
 
 interface ShortsCommentSheetProps {
   isOpen: boolean;
@@ -18,70 +10,25 @@ interface ShortsCommentSheetProps {
   commentCount: number;
 }
 
-export default function ShortsCommentSheet({
-  isOpen,
-  onClose,
-  author,
-  permlink,
-  commentCount,
-}: ShortsCommentSheetProps) {
-  const { hiveUser } = useHiveUser();
-  const { comments, isLoading, addComment } = useComments(author, permlink, true, hiveUser?.name);
-  const [reply, setReply] = useState<Comment | null>(null);
-  const { isOpen: replyOpen, onOpen: openReply, onClose: closeReply } = useDisclosure();
-
+export default function ShortsCommentSheet({ isOpen, onClose, author, permlink, commentCount }: ShortsCommentSheetProps) {
   return (
-    <>
-      <Drawer isOpen={isOpen} onClose={onClose} placement="bottom" size="full">
-        <DrawerOverlay bg="blackAlpha.700" />
-        <DrawerContent
-          bg="rgba(8, 24, 40, 0.97)"
-          borderTopRadius="16px"
-          backdropFilter="blur(18px)"
-          maxH="75dvh"
-        >
-          <DrawerCloseButton color="white" />
-          <DrawerHeader
-            fontSize="md"
-            fontWeight="semibold"
-            borderBottom="1px solid"
-            borderColor="rgba(102, 228, 255, 0.12)"
-            color="white"
-          >
-            {commentCount} Comments
-          </DrawerHeader>
-          <DrawerBody overflowY="auto" pb={8} px={2}>
-            {isLoading ? (
-              <Box textAlign="center" py={10}>
-                <Spinner color="blue.300" size="lg" />
-              </Box>
-            ) : comments.length === 0 ? (
-              <Text color="gray.500" textAlign="center" py={10} fontSize="sm">
-                No comments yet. Be the first!
-              </Text>
-            ) : (
-              <VStack spacing={1} align="stretch">
-                {(comments as ExtendedComment[]).map((c) => (
-                  <Snap
-                    key={`${c.author}/${c.permlink}`}
-                    comment={c}
-                    onOpen={openReply}
-                    setReply={(r) => setReply(r as Comment)}
-                  />
-                ))}
-              </VStack>
-            )}
-          </DrawerBody>
-          {reply && (
-            <SnapReplyModal
-              isOpen={replyOpen}
-              onClose={closeReply}
-              comment={reply}
-              onNewReply={(newComment) => addComment(newComment as Comment)}
-            />
-          )}
-        </DrawerContent>
-      </Drawer>
-    </>
+    <Drawer isOpen={isOpen} onClose={onClose} placement="bottom" size="full">
+      <DrawerOverlay bg="blackAlpha.700" />
+      <DrawerContent
+        bg="rgba(8, 24, 40, 0.97)"
+        borderTopRadius="16px"
+        backdropFilter="blur(18px)"
+        maxH="80dvh"
+      >
+        <DrawerBody p={0} display="flex" flexDirection="column" h="100%">
+          <ShortsCommentContent
+            author={author}
+            permlink={permlink}
+            commentCount={commentCount}
+            onClose={onClose}
+          />
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
   );
 }

--- a/components/shorts/ShortsPlayer.tsx
+++ b/components/shorts/ShortsPlayer.tsx
@@ -1,16 +1,27 @@
 'use client';
-import { Box, Center, Spinner, Text, Button } from '@chakra-ui/react';
+import { Box, Center, Spinner, Text, Button, useBreakpointValue } from '@chakra-ui/react';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Mousewheel, Keyboard } from 'swiper/modules';
 import 'swiper/css';
 import { useEffect, useState, useCallback } from 'react';
 import { useShorts } from '@/hooks/useShorts';
 import ShortCard from './ShortCard';
+import ShortsCommentSheet from './ShortsCommentSheet';
+import ShortsCommentContent from './ShortsCommentContent';
+
+interface ActiveComment {
+  author: string;
+  permlink: string;
+  commentCount: number;
+}
 
 export default function ShortsPlayer() {
   const { shorts, loading, error, hasMore, load } = useShorts();
   const [activeIndex, setActiveIndex] = useState(0);
   const [muted, setMuted] = useState(true);
+  const [activeComment, setActiveComment] = useState<ActiveComment | null>(null);
+
+  const isDesktop = useBreakpointValue({ base: false, md: true }, { ssr: false });
 
   useEffect(() => {
     load(true);
@@ -19,6 +30,7 @@ export default function ShortsPlayer() {
   const onSlideChange = useCallback(
     (swiper: any) => {
       setActiveIndex(swiper.activeIndex);
+      setActiveComment(null);
       if (swiper.activeIndex >= shorts.length - 3 && hasMore && !loading) {
         load();
       }
@@ -47,37 +59,74 @@ export default function ShortsPlayer() {
 
   return (
     <Box h="100dvh" overflow="hidden" bg="black" display="flex" justifyContent="center">
-      <Box w={{ base: '100%', md: '420px' }} h="100dvh" position="relative" overflow="hidden">
-      <Swiper
-        direction="vertical"
-        slidesPerView={1}
-        modules={[Mousewheel, Keyboard]}
-        mousewheel={{ sensitivity: 1, thresholdDelta: 10 }}
-        keyboard={{ enabled: true }}
-        onSlideChange={onSlideChange}
-        style={{ height: '100%', width: '100%' }}
-      >
-        {shorts.map((short, i) => (
-          <SwiperSlide key={short.id} style={{ height: '100%' }}>
-            <ShortCard
-              short={short}
-              isActive={i === activeIndex}
-              isPreload={i === activeIndex - 1 || i === activeIndex + 1}
-              muted={muted}
-              onToggleMute={() => setMuted(m => !m)}
-            />
-          </SwiperSlide>
-        ))}
+      {/* Video column */}
+      <Box w={{ base: '100%', md: '420px' }} h="100dvh" position="relative" overflow="hidden" flexShrink={0}>
+        <Swiper
+          direction="vertical"
+          slidesPerView={1}
+          modules={[Mousewheel, Keyboard]}
+          mousewheel={{ sensitivity: 1, thresholdDelta: 10 }}
+          keyboard={{ enabled: true }}
+          onSlideChange={onSlideChange}
+          style={{ height: '100%', width: '100%' }}
+        >
+          {shorts.map((short, i) => (
+            <SwiperSlide key={short.id} style={{ height: '100%' }}>
+              <ShortCard
+                short={short}
+                isActive={i === activeIndex}
+                isPreload={i === activeIndex - 1 || i === activeIndex + 1}
+                muted={muted}
+                onToggleMute={() => setMuted(m => !m)}
+                onOpenComments={() => setActiveComment({
+                  author: short.author,
+                  permlink: short.hivePermlink,
+                  commentCount: short.stats.comments,
+                })}
+              />
+            </SwiperSlide>
+          ))}
 
-        {(loading || hasMore) && (
-          <SwiperSlide style={{ height: '100%' }}>
-            <Center h="100%" bg="black">
-              <Spinner color="blue.400" thickness="2px" />
-            </Center>
-          </SwiperSlide>
-        )}
-      </Swiper>
+          {(loading || hasMore) && (
+            <SwiperSlide style={{ height: '100%' }}>
+              <Center h="100%" bg="black">
+                <Spinner color="blue.400" thickness="2px" />
+              </Center>
+            </SwiperSlide>
+          )}
+        </Swiper>
       </Box>
+
+      {/* Desktop: side-by-side comment panel */}
+      {isDesktop && activeComment && (
+        <Box
+          w="380px"
+          h="100dvh"
+          bg="rgba(8, 24, 40, 0.97)"
+          borderLeft="1px solid rgba(102, 228, 255, 0.12)"
+          backdropFilter="blur(18px)"
+          flexShrink={0}
+          overflow="hidden"
+        >
+          <ShortsCommentContent
+            author={activeComment.author}
+            permlink={activeComment.permlink}
+            commentCount={activeComment.commentCount}
+            onClose={() => setActiveComment(null)}
+          />
+        </Box>
+      )}
+
+      {/* Mobile: bottom-sheet drawer */}
+      {!isDesktop && (
+        <ShortsCommentSheet
+          isOpen={!!activeComment}
+          onClose={() => setActiveComment(null)}
+          author={activeComment?.author ?? ''}
+          permlink={activeComment?.permlink ?? ''}
+          commentCount={activeComment?.commentCount ?? 0}
+        />
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary

- **Bug fix:** Users could only reply to existing comments on a short, not post a new top-level comment. The comment sheet had no composer wired to the short itself — only `SnapReplyModal` for comment-to-comment replies.
- **New `ShortsCommentContent` component:** Extracts the comment UI (list + `SnapReplyModal`) and adds a `SnapComposer` at the bottom with `pa=shortAuthor / pp=shortPermlink` so users can post directly on the short.
- **`ShortsCommentSheet` simplified** to a thin Drawer wrapper around `ShortsCommentContent` (mobile).
- **Comment state lifted** from `ShortCard` → `ShortsPlayer`. `ShortCard` now receives `onOpenComments()` prop.
- **Desktop side-by-side layout:** On `md+`, opening comments renders a **380 px panel to the right** of the video column using the same `ShortsCommentContent` — no duplication. Swiping to a new short closes the panel automatically.
- Mobile bottom-sheet drawer behaviour is unchanged.

## Test plan

- [ ] Open comments on a short — verify a compose input appears at the bottom
- [ ] Post a new top-level comment — it should appear in the list
- [ ] Reply to an existing comment via the reply button — `SnapReplyModal` still works
- [ ] Desktop (≥768 px): comments open in a side panel to the right of the video
- [ ] Desktop: swiping to a new short closes the panel
- [ ] Mobile: bottom-sheet drawer opens and closes as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comments are now seamlessly integrated into the shorts player with responsive, device-specific layouts.
  * On desktop, comments appear in a dedicated side panel for easy browsing and interaction.
  * On mobile, comments are displayed in a sliding bottom drawer for space-efficient viewing.
  * The comment composer enables you to post top-level comments and replies directly on shorts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->