### PR TITLE
feat: mobile navigation redesign — header bar, 5-tab nav, Me sheet, desktop identity card

### DIFF
--- a/app/LayoutContent.tsx
+++ b/app/LayoutContent.tsx
@@ -4,7 +4,9 @@ import { usePathname, useSearchParams } from 'next/navigation';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import Sidebar from '@/components/layout/Sidebar';
-import FooterNavigation from '@/components/layout/FooterNavigation';
+import MobileHeader from '@/components/layout/MobileHeader';
+import BottomTabBar from '@/components/layout/BottomTabBar';
+import MeSheet from '@/components/layout/MeSheet';
 import ChatPanel from '@/components/chat/ChatPanel';
 import { chatService } from '@/lib/chat/ChatService';
 import { useHangout } from '@/contexts/HangoutContext';
@@ -17,6 +19,7 @@ export default function LayoutContent({ children }: { children: React.ReactNode 
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const isComposePage = pathname === '/compose';
+  const isShortsPage = pathname === '/shorts';
   const isEmbedMode = searchParams.get('embed') === 'true';
   const isChatPopoutMode = searchParams.get('chat_popout') === '1';
   const { activeRoom, closeRoom } = useHangout();
@@ -24,6 +27,7 @@ export default function LayoutContent({ children }: { children: React.ReactNode 
   const [isChatOpen, setIsChatOpen] = useState(false);
   const [isChatMinimized, setIsChatMinimized] = useState(false);
   const [chatUnreadCount, setChatUnreadCount] = useState(0);
+  const [isMeSheetOpen, setIsMeSheetOpen] = useState(false);
   const popoutRef = useRef<Window | null>(null);
 
   useEffect(() => {
@@ -35,7 +39,6 @@ export default function LayoutContent({ children }: { children: React.ReactNode 
     return () => { document.body.classList.remove('embed-mode'); };
   }, [isEmbedMode]);
 
-  // Poll unread count when chat is closed
   useEffect(() => {
     if (isEmbedMode || isChatOpen) return;
     const poll = async () => { setChatUnreadCount(await chatService.getUnreadCount()); };
@@ -51,6 +54,9 @@ export default function LayoutContent({ children }: { children: React.ReactNode 
     setIsChatOpen(true);
     setIsChatMinimized(false);
   }, [isChatPopoutMode]);
+
+  // Close MeSheet when navigating
+  useEffect(() => { setIsMeSheetOpen(false); }, [pathname]);
 
   const handlePopoutChat = useCallback(() => {
     if (typeof window === 'undefined') return;
@@ -78,6 +84,11 @@ export default function LayoutContent({ children }: { children: React.ReactNode 
     });
   }, []);
 
+  // On mobile, pad content away from the fixed header and tab bar.
+  // Skip padding on shorts (full-screen immersive) and embed/popout modes.
+  const mobilePaddingTop = !isEmbedMode && !isChatPopoutMode && !isShortsPage ? { base: '56px', sm: '0' } : undefined;
+  const mobilePaddingBottom = !isEmbedMode && !isChatPopoutMode && !isShortsPage ? { base: '64px', sm: '0' } : undefined;
+
   return (
     <Box
       bg="background"
@@ -96,6 +107,8 @@ export default function LayoutContent({ children }: { children: React.ReactNode 
             overflowY="auto"
             display="flex"
             flexDirection="column"
+            pt={mobilePaddingTop}
+            pb={mobilePaddingBottom}
           >
             <EmancipationBanner />
             {!isChatPopoutMode && children}
@@ -103,9 +116,20 @@ export default function LayoutContent({ children }: { children: React.ReactNode 
           </Box>
         </Flex>
       </Box>
+
       {!isEmbedMode && !isChatPopoutMode && (
         <>
-          <FooterNavigation isChatOpen={isChatOpen} setIsChatOpen={setIsChatOpen} chatUnreadCount={chatUnreadCount} />
+          {/* Mobile chrome */}
+          <MobileHeader onMePress={() => setIsMeSheetOpen(true)} />
+          <BottomTabBar onMePress={() => setIsMeSheetOpen(true)} />
+          <MeSheet
+            isOpen={isMeSheetOpen}
+            onClose={() => setIsMeSheetOpen(false)}
+            onToggleChat={() => setIsChatOpen(c => !c)}
+            chatUnreadCount={chatUnreadCount}
+          />
+
+          {/* Chat panel (all screen sizes) */}
           <ChatPanel
             isOpen={isChatOpen}
             onClose={() => setIsChatOpen(false)}

--- a/components/layout/BottomTabBar.tsx
+++ b/components/layout/BottomTabBar.tsx
@@ -1,0 +1,134 @@
+'use client';
+import { Box, Flex, Text, Image, Icon } from '@chakra-ui/react';
+import { FiHome, FiBook, FiPlay, FiUser, FiPlus } from 'react-icons/fi';
+import NextLink from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { getHiveAvatarUrl } from '@/lib/utils/avatarUtils';
+
+interface BottomTabBarProps {
+  onMePress: () => void;
+}
+
+export default function BottomTabBar({ onMePress }: BottomTabBarProps) {
+  const pathname = usePathname();
+  const { username: user } = useCurrentUser();
+
+  // Hide on immersive pages
+  if (pathname === '/shorts') return null;
+
+  const isActive = (path: string) =>
+    path === '/' ? pathname === '/' : pathname.startsWith(path);
+
+  return (
+    <Box
+      as="nav"
+      position="fixed"
+      bottom={0}
+      left={0}
+      right={0}
+      h="60px"
+      bg="rgba(8, 24, 40, 0.95)"
+      borderTop="1px solid rgba(102, 228, 255, 0.14)"
+      backdropFilter="blur(20px)"
+      display={{ base: 'flex', sm: 'none' }}
+      alignItems="center"
+      zIndex={999}
+      boxShadow="0 -4px 24px rgba(0,0,0,0.4)"
+    >
+      <Flex w="full" h="full" align="center">
+        {/* Home */}
+        <Tab href="/" icon={FiHome} label="Home" active={isActive('/')} />
+
+        {/* Blog */}
+        <Tab href="/blog" icon={FiBook} label="Blog" active={isActive('/blog')} />
+
+        {/* Compose — elevated center CTA */}
+        <Flex flex={1} justify="center" align="center">
+          <Box
+            as={NextLink}
+            href="/compose"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            w="50px"
+            h="50px"
+            borderRadius="full"
+            bgGradient="linear(135deg, #18a8ff, #66e4ff)"
+            boxShadow="0 4px 22px rgba(24, 168, 255, 0.55)"
+            color="white"
+            mb="10px"
+            transition="transform 0.15s, box-shadow 0.15s"
+            _hover={{ transform: 'scale(1.08)', boxShadow: '0 6px 28px rgba(24, 168, 255, 0.7)' }}
+            _active={{ transform: 'scale(0.94)' }}
+          >
+            <Icon as={FiPlus} boxSize={6} strokeWidth={2.5} />
+          </Box>
+        </Flex>
+
+        {/* Shorts */}
+        <Tab href="/shorts" icon={FiPlay} label="Shorts" active={isActive('/shorts')} />
+
+        {/* Me — opens MeSheet, not a page link */}
+        <Flex
+          flex={1}
+          direction="column"
+          align="center"
+          justify="center"
+          h="full"
+          cursor="pointer"
+          onClick={onMePress}
+          color="white"
+          opacity={0.65}
+          transition="opacity 0.15s"
+          _hover={{ opacity: 1 }}
+          gap="2px"
+        >
+          {user ? (
+            <Image
+              src={getHiveAvatarUrl(user, 'small')}
+              alt={user}
+              boxSize="26px"
+              borderRadius="full"
+              border="2px solid rgba(102, 228, 255, 0.45)"
+            />
+          ) : (
+            <Icon as={FiUser} boxSize={5} />
+          )}
+          <Text fontSize="9px" letterSpacing="0.02em">Me</Text>
+        </Flex>
+      </Flex>
+    </Box>
+  );
+}
+
+// ─── Tab item ─────────────────────────────────────────────────────────────────
+
+interface TabProps {
+  href: string;
+  icon: React.ElementType;
+  label: string;
+  active: boolean;
+}
+
+function Tab({ href, icon, label, active }: TabProps) {
+  return (
+    <Flex
+      as={NextLink}
+      href={href}
+      flex={1}
+      direction="column"
+      align="center"
+      justify="center"
+      h="full"
+      color={active ? 'cyan.300' : 'white'}
+      opacity={active ? 1 : 0.55}
+      transition="opacity 0.15s, color 0.15s"
+      _hover={{ opacity: 1 }}
+      gap="2px"
+    >
+      <Icon as={icon} boxSize={5} />
+      <Text fontSize="9px" letterSpacing="0.02em">{label}</Text>
+    </Flex>
+  );
+}

--- a/components/layout/MeSheet.tsx
+++ b/components/layout/MeSheet.tsx
@@ -1,0 +1,204 @@
+'use client';
+import {
+  Drawer, DrawerOverlay, DrawerContent, DrawerBody,
+  Flex, Box, Text, Image, Icon, Button, VStack, Divider, Badge,
+} from '@chakra-ui/react';
+import {
+  FiUser, FiCreditCard, FiBell, FiRadio, FiMessageSquare,
+  FiLogIn, FiUserPlus, FiLogOut, FiInfo,
+} from 'react-icons/fi';
+import NextLink from 'next/link';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { useLoginModal } from '@/contexts/LoginModalContext';
+import { useHiveNotifications } from '@/hooks/useHiveNotifications';
+import { useOpenPodsCount } from '@/hooks/useOpenPodsCount';
+import { getHiveAvatarUrl } from '@/lib/utils/avatarUtils';
+
+interface MeSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onToggleChat: () => void;
+  chatUnreadCount: number;
+}
+
+export default function MeSheet({ isOpen, onClose, onToggleChat, chatUnreadCount }: MeSheetProps) {
+  const { username: user, isLoggedIn, logout } = useCurrentUser();
+  const { openLoginModal } = useLoginModal();
+  const { unreadCount } = useHiveNotifications(user, { limit: 1, poll: false });
+  const openPodsCount = useOpenPodsCount();
+
+  return (
+    <Drawer isOpen={isOpen} onClose={onClose} placement="bottom">
+      <DrawerOverlay bg="blackAlpha.600" backdropFilter="blur(6px)" />
+      <DrawerContent
+        bg="rgba(7, 20, 36, 0.98)"
+        borderTopRadius="24px"
+        backdropFilter="blur(24px)"
+        border="1px solid rgba(102, 228, 255, 0.12)"
+        maxH="82dvh"
+      >
+        <DrawerBody p={0} overflowY="auto">
+          {/* Drag handle */}
+          <Flex justify="center" pt={3} pb={2} flexShrink={0}>
+            <Box w="36px" h="4px" borderRadius="full" bg="whiteAlpha.300" />
+          </Flex>
+
+          {isLoggedIn && user ? (
+            <>
+              {/* Identity card */}
+              <Flex align="center" gap={3} px={5} pt={2} pb={4}>
+                <Image
+                  src={getHiveAvatarUrl(user, 'medium')}
+                  alt={user}
+                  boxSize="60px"
+                  borderRadius="full"
+                  border="2px solid rgba(102, 228, 255, 0.4)"
+                  boxShadow="0 0 20px rgba(24, 168, 255, 0.22)"
+                  flexShrink={0}
+                />
+                <Box overflow="hidden">
+                  <Text color="white" fontWeight="bold" fontSize="lg" noOfLines={1}>
+                    @{user}
+                  </Text>
+                  <Text color="whiteAlpha.500" fontSize="xs">Logged in</Text>
+                </Box>
+              </Flex>
+
+              <Divider borderColor="rgba(102, 228, 255, 0.08)" />
+
+              {/* Navigation links */}
+              <VStack spacing={0} py={2}>
+                <SheetLink href={`/@${user}`}           icon={FiUser}         label="My Profile"     onClose={onClose} />
+                <SheetLink href={`/@${user}/wallet`}    icon={FiCreditCard}   label="Wallet"         onClose={onClose} />
+                <SheetLink href={`/@${user}/notifications`} icon={FiBell}     label="Notifications"  badge={unreadCount} onClose={onClose} />
+                <SheetLink href="/hangouts"              icon={FiRadio}        label="OpenPods"       badge={openPodsCount} onClose={onClose} />
+                <SheetButton
+                  icon={FiMessageSquare}
+                  label="Chat"
+                  badge={chatUnreadCount}
+                  onClick={() => { onClose(); onToggleChat(); }}
+                />
+                <SheetLink href="https://about.snapie.io" icon={FiInfo} label="About Snapie" external onClose={onClose} />
+              </VStack>
+
+              <Divider borderColor="rgba(102, 228, 255, 0.08)" />
+
+              {/* Logout */}
+              <Box px={4} py={4}>
+                <Button
+                  w="full"
+                  variant="ghost"
+                  color="red.400"
+                  leftIcon={<Icon as={FiLogOut} />}
+                  borderRadius="12px"
+                  _hover={{ bg: 'rgba(255, 80, 80, 0.08)' }}
+                  onClick={() => { logout(); onClose(); }}
+                >
+                  Log out
+                </Button>
+              </Box>
+            </>
+          ) : (
+            /* Not logged in */
+            <Box px={5} py={6}>
+              <Text color="white" fontWeight="bold" fontSize="lg" mb={1}>
+                Welcome to Snapie
+              </Text>
+              <Text color="whiteAlpha.500" fontSize="sm" mb={6}>
+                Log in to post, vote, and connect with the community.
+              </Text>
+              <VStack spacing={3}>
+                <Button
+                  w="full"
+                  colorScheme="blue"
+                  borderRadius="12px"
+                  leftIcon={<Icon as={FiLogIn} />}
+                  onClick={() => { openLoginModal(); onClose(); }}
+                >
+                  Log in
+                </Button>
+                <Button
+                  w="full"
+                  variant="outline"
+                  color="white"
+                  borderColor="rgba(102, 228, 255, 0.25)"
+                  borderRadius="12px"
+                  leftIcon={<Icon as={FiUserPlus} />}
+                  as={NextLink}
+                  href="/join"
+                  onClick={onClose}
+                >
+                  Create account
+                </Button>
+              </VStack>
+            </Box>
+          )}
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+// ─── Row helpers ─────────────────────────────────────────────────────────────
+
+interface SheetLinkProps {
+  href: string;
+  icon: React.ElementType;
+  label: string;
+  badge?: number;
+  external?: boolean;
+  onClose: () => void;
+}
+
+function SheetLink({ href, icon, label, badge = 0, external, onClose }: SheetLinkProps) {
+  return (
+    <Flex
+      as={external ? 'a' : NextLink}
+      href={href}
+      target={external ? '_blank' : undefined}
+      rel={external ? 'noopener noreferrer' : undefined}
+      align="center"
+      gap={3}
+      px={5}
+      py={3}
+      w="full"
+      cursor="pointer"
+      color="white"
+      _hover={{ bg: 'whiteAlpha.50' }}
+      transition="background 0.12s"
+      onClick={onClose}
+    >
+      <Icon as={icon} boxSize={5} color="whiteAlpha.600" />
+      <Text fontSize="sm" flex={1}>{label}</Text>
+      {badge > 0 && <Badge colorScheme="red" borderRadius="full" fontSize="xs" px={2}>{badge}</Badge>}
+    </Flex>
+  );
+}
+
+interface SheetButtonProps {
+  icon: React.ElementType;
+  label: string;
+  badge?: number;
+  onClick: () => void;
+}
+
+function SheetButton({ icon, label, badge = 0, onClick }: SheetButtonProps) {
+  return (
+    <Flex
+      align="center"
+      gap={3}
+      px={5}
+      py={3}
+      w="full"
+      cursor="pointer"
+      color="white"
+      _hover={{ bg: 'whiteAlpha.50' }}
+      transition="background 0.12s"
+      onClick={onClick}
+    >
+      <Icon as={icon} boxSize={5} color="whiteAlpha.600" />
+      <Text fontSize="sm" flex={1}>{label}</Text>
+      {badge > 0 && <Badge colorScheme="red" borderRadius="full" fontSize="xs" px={2}>{badge}</Badge>}
+    </Flex>
+  );
+}

--- a/components/layout/MobileHeader.tsx
+++ b/components/layout/MobileHeader.tsx
@@ -1,0 +1,105 @@
+'use client';
+import { Box, Flex, Text, Image, Icon, IconButton, Button } from '@chakra-ui/react';
+import { FiBell } from 'react-icons/fi';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { useLoginModal } from '@/contexts/LoginModalContext';
+import { useHiveNotifications } from '@/hooks/useHiveNotifications';
+import { usePathname } from 'next/navigation';
+import { getHiveAvatarUrl } from '@/lib/utils/avatarUtils';
+import NextLink from 'next/link';
+import { CountBadge } from '@/components/ui/CountBadge';
+
+interface MobileHeaderProps {
+  onMePress: () => void;
+}
+
+export default function MobileHeader({ onMePress }: MobileHeaderProps) {
+  const { username: user, isLoggedIn } = useCurrentUser();
+  const { openLoginModal } = useLoginModal();
+  const { unreadCount } = useHiveNotifications(user, { limit: 1, poll: false });
+  const pathname = usePathname();
+
+  // Immersive pages manage their own chrome
+  if (pathname === '/shorts') return null;
+
+  return (
+    <Box
+      as="header"
+      position="fixed"
+      top={0}
+      left={0}
+      right={0}
+      h="56px"
+      bg="rgba(8, 24, 40, 0.93)"
+      borderBottom="1px solid rgba(102, 228, 255, 0.10)"
+      backdropFilter="blur(20px)"
+      display={{ base: 'flex', sm: 'none' }}
+      alignItems="center"
+      justifyContent="space-between"
+      px={4}
+      zIndex={998}
+      boxShadow="0 2px 24px rgba(0,0,0,0.35)"
+    >
+      {/* Wordmark */}
+      <Text
+        fontSize="2xl"
+        fontWeight="extrabold"
+        letterSpacing="-0.04em"
+        bgGradient="linear(to-r, #18a8ff, #66e4ff)"
+        bgClip="text"
+        userSelect="none"
+      >
+        snapie
+      </Text>
+
+      {/* Right: actions */}
+      <Flex align="center" gap={1}>
+        {isLoggedIn && user ? (
+          <>
+            {/* Notifications */}
+            <Box position="relative">
+              <IconButton
+                as={NextLink}
+                href={`/@${user}/notifications`}
+                aria-label="Notifications"
+                icon={<Icon as={FiBell} boxSize={5} />}
+                variant="ghost"
+                color={unreadCount > 0 ? 'red.300' : 'whiteAlpha.700'}
+                size="sm"
+                borderRadius="full"
+                _hover={{ bg: 'whiteAlpha.100' }}
+              />
+              <CountBadge count={unreadCount} colorScheme="red" top="-2px" right="-2px" />
+            </Box>
+
+            {/* Avatar → opens MeSheet */}
+            <Box
+              as="button"
+              onClick={onMePress}
+              borderRadius="full"
+              overflow="hidden"
+              boxSize="34px"
+              border="2px solid rgba(102, 228, 255, 0.35)"
+              boxShadow="0 0 12px rgba(24, 168, 255, 0.2)"
+              flexShrink={0}
+              transition="box-shadow 0.15s"
+              _hover={{ boxShadow: '0 0 16px rgba(24, 168, 255, 0.4)' }}
+            >
+              <Image src={getHiveAvatarUrl(user, 'small')} alt={user} w="full" h="full" objectFit="cover" />
+            </Box>
+          </>
+        ) : (
+          <Button
+            size="sm"
+            colorScheme="blue"
+            borderRadius="full"
+            px={4}
+            onClick={openLoginModal}
+          >
+            Log in
+          </Button>
+        )}
+      </Flex>
+    </Box>
+  );
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -142,6 +142,34 @@ export default function Sidebar({ isChatOpen = false, setIsChatOpen, chatUnreadC
                         </>
                     )}
 
+                    {/* Desktop user identity card */}
+                    {user && (
+                        <Box
+                            display={fullBreakpoint}
+                            w="full"
+                            mb={2}
+                            p={3}
+                            bg="rgba(24, 168, 255, 0.06)"
+                            borderRadius="10px"
+                            border="1px solid rgba(102, 228, 255, 0.12)"
+                        >
+                            <Flex align="center" gap={2} overflow="hidden">
+                                <Image
+                                    src={getHiveAvatarUrl(user, 'small')}
+                                    alt={user}
+                                    boxSize="32px"
+                                    borderRadius="full"
+                                    flexShrink={0}
+                                    border="1px solid rgba(102, 228, 255, 0.3)"
+                                />
+                                <Box overflow="hidden">
+                                    <Text fontSize="10px" color="whiteAlpha.500" lineHeight={1} mb="2px">Logged in as</Text>
+                                    <Text fontSize="sm" fontWeight="semibold" color="white" noOfLines={1}>@{user}</Text>
+                                </Box>
+                            </Flex>
+                        </Box>
+                    )}
+
                     <Tooltip label="Home" placement="right" hasArrow isDisabled={!isCompactMode}>
                         <Box w="full">
                             <Button


### PR DESCRIPTION
## Summary

Three new mobile-first layout components that replace the old horizontal-scroll footer.

### `MobileHeader`
Fixed 56 px top bar (mobile only, hidden on `/shorts`). Gradient **snapie** wordmark on the left. Right side shows notification bell (with unread badge) + user avatar when logged in, or a **Log in** button when not. Tapping the avatar opens the Me sheet — the user instantly knows who they're logged in as.

### `BottomTabBar` (replaces `FooterNavigation`)
Clean 5-tab fixed bar — no horizontal scrolling, no hidden items:
| Home | Blog | **⊕** | Shorts | Me |
The centre **Compose** button is elevated above the bar with a cyan gradient glow. The **Me** tab renders the user's real avatar when logged in (identity at a glance) and a generic icon when logged out. Both the header avatar and the Me tab open the Me sheet. Hidden on `/shorts` for immersive full-screen mode.

### `MeSheet`
Slide-up bottom drawer triggered by the Me tab or header avatar:
- **Logged in:** 60 px avatar + `@username` identity card, then Profile / Wallet / Notifications / OpenPods / Chat / About links with live badges, and a Logout button at the bottom.
- **Logged out:** welcoming copy + prominent **Log in** and **Create account** CTAs.
- Closes automatically on route change.

### Desktop sidebar improvement
A subtle "Logged in as @username" card (avatar + handle) is inserted below the community logo on the full `md+` sidebar, so desktop users also have clear persistent identity.

### `LayoutContent` wiring
- Swaps `FooterNavigation` → `BottomTabBar` + `MobileHeader` + `MeSheet`
- Adds responsive `pt: 56px / pb: 64px` on mobile to keep content clear of fixed chrome (omitted on `/shorts`)
- Me sheet state managed here so both header avatar and tab Me button share the same sheet

## Test plan

- [ ] Mobile: snapie wordmark + notification bell + avatar visible in top bar
- [ ] Mobile: 5 tabs visible without scrolling — Home, Blog, +, Shorts, Me
- [ ] Mobile: avatar shown in Me tab when logged in; generic icon when not
- [ ] Mobile: tapping Me tab / header avatar opens the Me sheet
- [ ] Me sheet logged-in: shows correct username, working links, notification/pods badges
- [ ] Me sheet logged-out: shows Login + Create Account CTAs
- [ ] Me sheet closes when navigating to any link
- [ ] `/shorts` page: header and tab bar both hidden for full-screen experience
- [ ] Desktop (`sm+`): old sidebar unchanged except for new identity card below logo
- [ ] Desktop identity card: shows avatar + "Logged in as @username"
- [ ] Content not hidden behind fixed bars on any page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mobile bottom navigation bar with Home, Blog, Shorts, Compose, and account buttons
  * Mobile header displaying notifications and user menu access
  * Account drawer with profile links, notifications, wallet, and logout functionality
  * User identity card added to desktop sidebar
  * Responsive mobile layout with optimized header and navigation spacing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->