### PR TITLE
fix: mobile polish — wordmark, + compose focus, sidebar scroll, wallet overflow

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,6 +12,7 @@ import FeedTabFilter from '@/components/homepage/FeedTabFilter';
 import OpenPodsLiveStrip from '@/components/hangouts/OpenPodsLiveStrip';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { getCommunityInfo } from '@/lib/hive/client-functions';
+import { useSearchParams, useRouter } from 'next/navigation';
 
 interface CommunityInfo {
   title: string;
@@ -23,6 +24,8 @@ export default function Home() {
   const thread_author = 'peak.snaps';
   const thread_permlink = 'snaps';
   const communityTag = process.env.NEXT_PUBLIC_HIVE_COMMUNITY_TAG;
+  const searchParams = useSearchParams();
+  const router = useRouter();
 
   const [conversation, setConversation] = useState<Comment | undefined>();
   const [reply, setReply] = useState<Comment>();
@@ -56,6 +59,15 @@ export default function Home() {
 
     loadCommunityInfo();
   }, [communityTag]);
+
+  useEffect(() => {
+    if (searchParams.get('focus') !== 'composer') return;
+    router.replace('/');
+    document.getElementById('scrollableDiv')?.scrollTo({ top: 0, behavior: 'smooth' });
+    setTimeout(() => {
+      document.querySelector<HTMLTextAreaElement>('#snap-composer textarea')?.focus();
+    }, 400);
+  }, [searchParams, router]);
 
   const onOpen = () => setIsOpen(true);
   const onClose = () => setIsOpen(false);

--- a/components/homepage/SnapList.tsx
+++ b/components/homepage/SnapList.tsx
@@ -79,7 +79,7 @@ export default function SnapList(
             scrollableTarget="scrollableDiv"
         >
           <VStack spacing={0} align="stretch" mx="auto" pt={0} px={{ base: 0, md: 2 }}>
-          {!post && <SnapComposer pa={author} pp={permlink} onNewComment={handleNewComment} onClose={() => null} />}
+          {!post && <Box id="snap-composer"><SnapComposer pa={author} pp={permlink} onNewComment={handleNewComment} onClose={() => null} /></Box>}
           {comments.map((comment: ExtendedComment) => (
             <Snap
               key={comment.permlink}

--- a/components/layout/BottomTabBar.tsx
+++ b/components/layout/BottomTabBar.tsx
@@ -2,7 +2,7 @@
 import { Box, Flex, Text, Image, Icon } from '@chakra-ui/react';
 import { FiHome, FiBook, FiPlay, FiUser, FiPlus } from 'react-icons/fi';
 import NextLink from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { getHiveAvatarUrl } from '@/lib/utils/avatarUtils';
 
@@ -12,7 +12,20 @@ interface BottomTabBarProps {
 
 export default function BottomTabBar({ onMePress }: BottomTabBarProps) {
   const pathname = usePathname();
+  const router = useRouter();
   const { username: user } = useCurrentUser();
+
+  function handleComposeTap() {
+    if (pathname === '/') {
+      document.getElementById('scrollableDiv')?.scrollTo({ top: 0, behavior: 'smooth' });
+      setTimeout(() => {
+        const ta = document.querySelector<HTMLTextAreaElement>('#snap-composer textarea');
+        ta?.focus();
+      }, 300);
+    } else {
+      router.push('/?focus=composer');
+    }
+  }
 
   // Hide on immersive pages
   if (pathname === '/shorts') return null;
@@ -46,8 +59,8 @@ export default function BottomTabBar({ onMePress }: BottomTabBarProps) {
         {/* Compose — elevated center CTA */}
         <Flex flex={1} justify="center" align="center">
           <Box
-            as={NextLink}
-            href="/compose"
+            as="button"
+            onClick={handleComposeTap}
             display="flex"
             alignItems="center"
             justifyContent="center"

--- a/components/layout/MobileHeader.tsx
+++ b/components/layout/MobileHeader.tsx
@@ -49,7 +49,7 @@ export default function MobileHeader({ onMePress }: MobileHeaderProps) {
         bgClip="text"
         userSelect="none"
       >
-        snapie
+        snapie.io
       </Text>
 
       {/* Right: actions */}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -90,6 +90,7 @@ export default function Sidebar({ isChatOpen = false, setIsChatOpen, chatUnreadC
             p={3}
             w={forceCompact ? '72px' : { base: 'full', sm: '72px', md: '260px' }}
             h={{ base: "100vh", sm: "calc(100vh - 24px)" }}
+            overflowY="auto"
             position={{ base: 'relative', sm: 'sticky' }}
             top={{ base: 'auto', sm: '12px' }}
             mt={{ base: 0, sm: '12px' }}

--- a/components/wallet/WalletPage.tsx
+++ b/components/wallet/WalletPage.tsx
@@ -295,7 +295,7 @@ export default function WalletPage({ username }: WalletPageProps) {
     : 0;
 
   return (
-    <Box color="text" maxW="container.lg" mx="auto">
+    <Box color="text" maxW="container.lg" mx="auto" w="100%" overflowX="hidden">
       {/* Profile Header */}
       <Box position="relative" height="200px" borderTopRadius="xl" overflow="hidden">
         <Image
@@ -571,8 +571,8 @@ export default function WalletPage({ username }: WalletPageProps) {
                   <Text fontSize="xs" color={textMuted}>Liquid balance</Text>
                 </Box>
               </Flex>
-              <Box textAlign="right">
-                <Text fontSize="2xl" fontWeight="bold">{balance}</Text>
+              <Box textAlign="right" flexShrink={0}>
+                <Text fontSize={{ base: 'lg', md: '2xl' }} fontWeight="bold">{balance}</Text>
                 {prices && <Text fontSize="xs" color={textMuted}>≈ ${(parseFloat(balance) * prices.hive).toFixed(2)}</Text>}
               </Box>
             </Flex>
@@ -612,8 +612,8 @@ export default function WalletPage({ username }: WalletPageProps) {
                   <Text fontSize="xs" color={textMuted}>Staked HIVE for voting power</Text>
                 </Box>
               </Flex>
-              <Box textAlign="right">
-                <Text fontSize="2xl" fontWeight="bold">{hivePower || 'Loading...'}</Text>
+              <Box textAlign="right" flexShrink={0}>
+                <Text fontSize={{ base: 'lg', md: '2xl' }} fontWeight="bold">{hivePower || 'Loading...'}</Text>
                 {prices && hivePower && <Text fontSize="xs" color={textMuted}>≈ ${(parseFloat(hivePower) * prices.hive).toFixed(2)}</Text>}
               </Box>
             </Flex>
@@ -640,8 +640,8 @@ export default function WalletPage({ username }: WalletPageProps) {
                   <Text fontSize="xs" color={textMuted}>Stable coin pegged to USD</Text>
                 </Box>
               </Flex>
-              <Box textAlign="right">
-                <Text fontSize="2xl" fontWeight="bold">{hbdBalance}</Text>
+              <Box textAlign="right" flexShrink={0}>
+                <Text fontSize={{ base: 'lg', md: '2xl' }} fontWeight="bold">{hbdBalance}</Text>
                 {prices && <Text fontSize="xs" color={textMuted}>≈ ${(parseFloat(hbdBalance) * prices.hbd).toFixed(2)}</Text>}
               </Box>
             </Flex>


### PR DESCRIPTION
## Summary

- **Wordmark**: Header now reads `snapie.io` instead of `snapie`
- **+ button**: Scrolls home feed to top and focuses the snap composer textarea; if not on home page, navigates to `/?focus=composer` which triggers the same scroll+focus on arrival
- **Sidebar About overflow**: Added `overflowY: auto` (scrollbar hidden) so the nav list scrolls internally — the user identity card no longer kicks About off screen
- **Wallet horizontal scroll**: Added `w="100%"` + `overflowX="hidden"` to the wallet outer box; shrunk section-header balance fonts from `2xl` to `lg` on mobile so large HP values like `1,234,567.890 HP` no longer overflow the row

## Test plan

- [ ] Mobile header shows "snapie.io"
- [ ] Tap `+` on home page → feed jumps to top, snap composer textarea gets focus
- [ ] Tap `+` on another page (e.g. `/blog`) → navigates to `/` and same focus behavior fires
- [ ] Desktop sidebar: logged-in user identity card visible, About button still reachable by scrolling down
- [ ] Wallet on mobile: no horizontal scroll; HIVE / HP / HBD balances display on a single row without pushing content offscreen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compose functionality now operates inline on the homepage when accessed via compose button or URL parameter, with automatic focus and scroll-to-top behavior

* **Style**
  * Updated mobile header branding display
  * Improved wallet page responsive layout and balance sizing
  * Added vertical scrolling capability to sidebar content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->