### PR TITLE
feat: Curation Quality Score card on profiles and articles

### DIFF
--- a/components/blog/PostSidebar.tsx
+++ b/components/blog/PostSidebar.tsx
@@ -9,6 +9,7 @@ import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { getProfile, getAccountPosts, getSimilarPosts } from '@/lib/hive/client-functions';
 import { getHiveAvatarUrl } from '@/lib/utils/avatarUtils';
 import UserActionButtons from '@/components/profile/UserActionButtons';
+import CurationQualityCard from '@/components/profile/CurationQualityCard';
 
 interface PostSidebarProps {
   author: string;
@@ -204,6 +205,9 @@ export default function PostSidebar({ author, permlink }: PostSidebarProps) {
           showBlacklist={false}
         />
       </SidebarBlock>
+
+      {/* Curation score */}
+      <CurationQualityCard username={author} />
 
       {/* Block 2 — Recent Posts */}
       {recentPosts.length > 0 && (

--- a/components/profile/CurationQualityCard.tsx
+++ b/components/profile/CurationQualityCard.tsx
@@ -1,0 +1,149 @@
+'use client';
+import React, { useState } from 'react';
+import {
+  Box, Flex, Text, Collapse, Progress, Link, HStack, Spinner, VStack,
+} from '@chakra-ui/react';
+import { FaChevronDown, FaChevronUp, FaExternalLinkAlt } from 'react-icons/fa';
+import { useCurationScore } from '@/hooks/useCurationScore';
+
+function scoreColorScheme(score: number) {
+  if (score >= 86) return { bg: 'purple.500', bar: 'purple' };
+  if (score >= 66) return { bg: 'green.500', bar: 'green' };
+  if (score >= 41) return { bg: 'yellow.500', bar: 'yellow' };
+  return { bg: 'red.500', bar: 'red' };
+}
+
+function scoreLabel(score: number): string {
+  if (score >= 86) return 'Excellent';
+  if (score >= 66) return 'Good';
+  if (score >= 41) return 'Fair';
+  return 'Poor';
+}
+
+function subScoreColorScheme(value: number): string {
+  if (value >= 0.66) return 'green';
+  if (value >= 0.41) return 'yellow';
+  return 'red';
+}
+
+function SubScoreBar({ label, value, tooltip }: { label: string; value: number; tooltip: string }) {
+  const pct = Math.round(value * 100);
+  return (
+    <Box>
+      <Flex justify="space-between" mb={1}>
+        <Text fontSize="xs" color="gray.400" title={tooltip}>{label}</Text>
+        <Text fontSize="xs" fontWeight="bold" color="text">{pct}%</Text>
+      </Flex>
+      <Progress
+        value={pct}
+        size="sm"
+        borderRadius="full"
+        colorScheme={subScoreColorScheme(value)}
+        bg="muted"
+      />
+    </Box>
+  );
+}
+
+export default function CurationQualityCard({ username }: { username: string }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const { data, isLoading, error } = useCurationScore(username);
+
+  if (isLoading) {
+    return (
+      <Box border="1px solid" borderColor="muted" borderRadius="10px" p={3}>
+        <Flex align="center" gap={2}>
+          <Spinner size="xs" color="primary" />
+          <Text fontSize="xs" color="gray.500">Loading curation score…</Text>
+        </Flex>
+      </Box>
+    );
+  }
+
+  if (!data || error) return null;
+
+  const { bg, bar } = scoreColorScheme(data.score);
+  const label = scoreLabel(data.score);
+
+  return (
+    <Box border="1px solid" borderColor="muted" borderRadius="10px" overflow="hidden">
+      <Flex
+        px={4}
+        py={3}
+        align="center"
+        justify="space-between"
+        cursor="pointer"
+        onClick={() => setIsOpen(v => !v)}
+        _hover={{ bg: 'muted' }}
+        transition="background 0.15s"
+        userSelect="none"
+      >
+        <HStack spacing={2}>
+          <Text fontSize="xs" fontWeight="bold" textTransform="uppercase" letterSpacing="wider" color="gray.500">
+            Curation Score
+          </Text>
+          <Flex align="center" bg={bg} color="white" borderRadius="md" px={2} py="2px" gap={1}>
+            <Text fontSize="xs" fontWeight="bold" lineHeight="1">{data.score}</Text>
+            <Text fontSize="xs" opacity={0.7} lineHeight="1">·</Text>
+            <Text fontSize="xs" lineHeight="1">{label}</Text>
+          </Flex>
+        </HStack>
+        <Box color="gray.500" fontSize="10px">
+          {isOpen ? <FaChevronUp /> : <FaChevronDown />}
+        </Box>
+      </Flex>
+
+      <Collapse in={isOpen} animateOpacity>
+        <Box px={4} pb={4} borderTop="1px solid" borderColor="muted">
+          <VStack spacing={2} align="stretch" mt={3} mb={4}>
+            <SubScoreBar
+              label="Author Diversity"
+              value={data.subScores.breadth}
+              tooltip="How many different authors this account votes for"
+            />
+            <SubScoreBar
+              label="Vote Distribution"
+              value={data.subScores.distribution}
+              tooltip="How evenly vote weight is spread — lower Gini coefficient is better"
+            />
+            <SubScoreBar
+              label="Anti Self-Vote"
+              value={data.subScores.antiSelf}
+              tooltip="Penalises self-voting; 100% means no self-votes cast"
+            />
+          </VStack>
+
+          <HStack spacing={4} mb={3} flexWrap="wrap">
+            <Box textAlign="center">
+              <Text fontSize="sm" fontWeight="bold" color="text">{data.metrics.voteCount}</Text>
+              <Text fontSize="xs" color="gray.500">Votes (7d)</Text>
+            </Box>
+            <Box textAlign="center">
+              <Text fontSize="sm" fontWeight="bold" color="text">{data.metrics.uniqueAuthors}</Text>
+              <Text fontSize="xs" color="gray.500">Authors</Text>
+            </Box>
+            <Box textAlign="center">
+              <Text fontSize="sm" fontWeight="bold" color="text">
+                {(data.metrics.giniCoefficient * 100).toFixed(0)}%
+              </Text>
+              <Text fontSize="xs" color="gray.500">Gini</Text>
+            </Box>
+          </HStack>
+
+          <Link
+            href={`https://mantecurated.3speak.tv/@${username}`}
+            isExternal
+            fontSize="xs"
+            color="primary"
+            _hover={{ textDecoration: 'underline' }}
+          >
+            <Flex align="center" gap={1}>
+              <Text>View full curator profile</Text>
+              <FaExternalLinkAlt size={10} />
+            </Flex>
+          </Link>
+        </Box>
+      </Collapse>
+    </Box>
+  );
+}

--- a/components/profile/ProfilePage.tsx
+++ b/components/profile/ProfilePage.tsx
@@ -19,6 +19,7 @@ import { useCurrentUser } from '@/hooks/useCurrentUser';
 import { getHiveAvatarUrl } from '@/lib/utils/avatarUtils';
 import { useProfileSnaps } from '@/hooks/useProfileSnaps';
 import { ExtendedComment } from '@/hooks/useComments';
+import CurationQualityCard from './CurationQualityCard';
 
 interface ProfilePageProps {
   username: string;
@@ -232,8 +233,13 @@ export default function ProfilePage({ username }: ProfilePageProps) {
         </Box>
       </Flex>
 
+      {/* Curation score */}
+      <Container maxW="container.lg" mt={4} px={4}>
+        <CurationQualityCard username={username} />
+      </Container>
+
       {/* Tabs */}
-      <Container maxW="container.lg" mt={4} px={0}>
+      <Container maxW="container.lg" mt={3} px={0}>
         <Tabs defaultIndex={0} colorScheme="blue" isLazy>
           <TabList px={4}>
             <Tab>Snaps</Tab>

--- a/hooks/useCurationScore.ts
+++ b/hooks/useCurationScore.ts
@@ -1,0 +1,73 @@
+import { useState, useEffect } from 'react';
+
+const CQS_BASE = 'https://mantecurated.3speak.tv';
+const TTL_MS = 15 * 60 * 1000;
+
+export interface CurationScore {
+  account: string;
+  score: number;
+  rawScore: number;
+  subScores: {
+    breadth: number;
+    distribution: number;
+    antiSelf: number;
+  };
+  metrics: {
+    totalVoteWeight: number;
+    uniqueAuthors: number;
+    selfVoteWeight: number;
+    voteCount: number;
+    giniCoefficient: number;
+    timeWindow: {
+      startDate: string;
+      endDate: string;
+      daysIncluded: number;
+    };
+  };
+  topAuthors: { author: string; voteCount: number; totalWeight: number }[];
+}
+
+interface CacheEntry {
+  data: CurationScore;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+export function useCurationScore(username: string) {
+  const [data, setData] = useState<CurationScore | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!username) return;
+
+    const cached = cache.get(username);
+    if (cached && cached.expiresAt > Date.now()) {
+      setData(cached.data);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    fetch(`${CQS_BASE}/api/cqs?account=${encodeURIComponent(username)}`)
+      .then(res => {
+        if (res.status === 404) throw new Error('no-score');
+        if (!res.ok) throw new Error('fetch-failed');
+        return res.json();
+      })
+      .then((json: CurationScore) => {
+        cache.set(username, { data: json, expiresAt: Date.now() + TTL_MS });
+        setData(json);
+        setIsLoading(false);
+      })
+      .catch(err => {
+        setError(err.message);
+        setIsLoading(false);
+      });
+  }, [username]);
+
+  return { data, isLoading, error };
+}


### PR DESCRIPTION
## Summary

- New `useCurationScore` hook fetches CQS data lazily from `mantecurated.3speak.tv/api/cqs` with a 15-min module-level cache matching the API's own TTL
- New `CurationQualityCard` component — collapsed by default, shows a color-coded score badge (red/yellow/green/purple tiers). Expand to see three sub-score progress bars (Author Diversity, Vote Distribution, Anti Self-Vote), key metrics (votes in 7d, unique authors, Gini coefficient), and a link out to the full mantecurated curator profile
- Mounted on **profile pages** (between header and tabs) and **post sidebars** (between About the Author and More from this Author)
- Fully silent on errors — 404s (no score) and network failures render nothing, no broken UI

## Test plan

- [ ] Visit any active curator's profile (e.g. `/@mantequilla`) — card should appear collapsed below the header
- [ ] Click to expand — sub-scores, metrics, and external link should render
- [ ] Open any blog post — card should appear in the sidebar under About the Author
- [ ] Visit a new/inactive account — card should not render at all
- [ ] Revisit a profile within 15 min — confirm no duplicate network request (cache hit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Curation score" section to user profiles displaying an overall score with expandable details including subscores (author diversity, vote distribution, anti self-vote), summary metrics, and a link to the full curator profile.
  * Curation score cards now visible in post sidebars to highlight author curation quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->