### PR TITLE
fix: contain profile page horizontal overflow on mobile

### DIFF
--- a/components/homepage/Snap.tsx
+++ b/components/homepage/Snap.tsx
@@ -211,19 +211,21 @@ const Snap = memo(({ comment, onOpen, setReply, setConversation, level = 0 }: Sn
                 {renderedText && (
                     <Box
                         px={3}
+                        overflowX="hidden"
+                        wordBreak="break-word"
                         dangerouslySetInnerHTML={{ __html: renderedText }}
                         onClick={setConversation ? handleConversation : undefined}
                         cursor={setConversation ? "pointer" : "default"}
                         sx={{
                             "& p": { marginBottom: 2 },
-                            "& a": { 
-                                color: "primary", 
+                            "& a": {
+                                color: "primary",
                                 textDecoration: "underline",
                                 cursor: "pointer",
-                                _hover: {
-                                    color: "accent"
-                                }
-                            }
+                                _hover: { color: "accent" }
+                            },
+                            "& pre, & table": { overflowX: "auto", maxWidth: "100%" },
+                            "& img": { maxWidth: "100%", height: "auto" },
                         }}
                     />
                 )}

--- a/components/homepage/SnapComposer.tsx
+++ b/components/homepage/SnapComposer.tsx
@@ -409,7 +409,7 @@ export default function SnapComposer ({ pa, pp, onNewComment, post = false, onCl
                     </Box>
                 )}
                 {selectedVideo && (
-                    <Box position="relative" bg="muted" p={3} borderRadius="base" border="1px solid" borderColor="gray.600" minW="250px">
+                    <Box position="relative" bg="muted" p={3} borderRadius="base" border="1px solid" borderColor="gray.600" w="100%">
                         <VStack align="start" spacing={2}>
                             <HStack justify="space-between" w="100%">
                                 <Text fontSize="sm" fontWeight="bold" color="text">📹 {selectedVideo.name}</Text>
@@ -441,7 +441,7 @@ export default function SnapComposer ({ pa, pp, onNewComment, post = false, onCl
                     </Box>
                 )}
                 {audioEmbedUrl && (
-                    <Box position="relative" bg="muted" p={3} borderRadius="base" border="1px solid" borderColor="gray.600" minW="250px">
+                    <Box position="relative" bg="muted" p={3} borderRadius="base" border="1px solid" borderColor="gray.600" w="100%">
                         <VStack align="start" spacing={2}>
                             <HStack justify="space-between" w="100%">
                                 <Text fontSize="sm" fontWeight="bold" color="text">🎤 Audio Snap</Text>

--- a/components/profile/ProfilePage.tsx
+++ b/components/profile/ProfilePage.tsx
@@ -150,7 +150,7 @@ export default function ProfilePage({ username }: ProfilePageProps) {
   }
 
   return (
-    <Box color="text" maxW="container.lg" mx="auto">
+    <Box color="text" maxW="container.lg" mx="auto" w="100%" overflowX="hidden">
       {/* Cover image */}
       <Box position="relative" height="200px">
         <Container id="cover" maxW="container.lg" p={0} overflow="hidden" position="relative" height="100%">


### PR DESCRIPTION
## Summary

Three root causes of the sideways-scroll bug on profile pages:

- **`ProfilePage.tsx`** — root `Box` was missing `w="100%"` and `overflowX="hidden"`, so any child wider than the viewport (images, embeds, code blocks) could push the entire page horizontally. Pattern already used correctly in `WalletPage`.
- **`Snap.tsx`** — the `dangerouslySetInnerHTML` markdown box had no overflow guard. Posts with `<pre>` blocks, tables, or unsized images would bleed out. Fixed with `overflowX="hidden"` + `wordBreak="break-word"` on the container, and `overflowX: auto` on `pre`/`table` children so code still scrolls within its own box.
- **`SnapComposer.tsx`** — video and audio attachment preview boxes had `minW="250px"`, which forces the composer wider than a phone screen. Replaced with `w="100%"` so they fill their container instead.

## Test plan

- [ ] Visit any profile on mobile (e.g. `/@mantequilla`) — no horizontal scrollbar, snaps and posts stay within screen width
- [ ] Tap a snap with a code block — the code block scrolls horizontally within its own card, page doesn't move
- [ ] Open the snap composer, attach a video or audio — preview box fits within the screen
- [ ] Desktop is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)