### PR TITLE
feat: paid account creation via HIVE and Lightning

### DIFF
--- a/components/auth/AccountSetupPanel.tsx
+++ b/components/auth/AccountSetupPanel.tsx
@@ -79,7 +79,7 @@ export default function AccountSetupPanel({ onComplete }: Props) {
     getEligibility()
       .then((r) => {
         setEligibility(r)
-        if (!r.canCreate && r.reason && PAYABLE_REASONS.has(r.reason)) {
+        if (!r.canCreate && r.reason && PAYABLE_REASONS.has(r.reason) && !r.sponsored) {
           setPaymentRequired(true)
         }
       })
@@ -160,9 +160,11 @@ export default function AccountSetupPanel({ onComplete }: Props) {
       }
     } catch (e: any) {
       const code = e?.code ?? ''
-      if (PAYABLE_REASONS.has(code)) {
+      if (PAYABLE_REASONS.has(code) && !eligibility?.sponsored) {
         // Quota block — offer paid path instead of showing an error
         setPaymentRequired(true)
+        setPaymentConfirmed(false)
+        setShowPaymentFlow(true)
         setSubmitting(false)
         setJobStatus(null)
         return
@@ -171,7 +173,7 @@ export default function AccountSetupPanel({ onComplete }: Props) {
       setSubmitting(false)
       setJobStatus(null)
     }
-  }, [available, usernameError, submitting, username, onComplete])
+  }, [available, usernameError, submitting, username, onComplete, eligibility])
 
   const jobProgress: Record<string, number> = {
     pending: 20,

--- a/components/auth/AccountSetupPanel.tsx
+++ b/components/auth/AccountSetupPanel.tsx
@@ -26,8 +26,9 @@ import { validateAccountName } from '@/lib/hive/account-create-client'
 import type { SnapieUser } from '@/lib/snapie-auth/types'
 import PaidAccountFlow from '@/components/join/PaidAccountFlow'
 
-// Quota errors where paying bypasses the restriction
-const PAYABLE_REASONS = new Set(['global_daily_limit', 'ip_daily_limit', 'previously_had_account'])
+// Quota errors where paying bypasses the restriction.
+// previously_had_account is intentionally excluded — one email, one account, no exceptions.
+const PAYABLE_REASONS = new Set(['global_daily_limit', 'ip_daily_limit'])
 
 const JOB_STATUS_LABEL: Record<string, string> = {
   pending: 'Queued…',

--- a/components/auth/AccountSetupPanel.tsx
+++ b/components/auth/AccountSetupPanel.tsx
@@ -24,6 +24,10 @@ import {
 import { SnapieAuthError } from '@/lib/snapie-auth/types'
 import { validateAccountName } from '@/lib/hive/account-create-client'
 import type { SnapieUser } from '@/lib/snapie-auth/types'
+import PaidAccountFlow from '@/components/join/PaidAccountFlow'
+
+// Quota errors where paying bypasses the restriction
+const PAYABLE_REASONS = new Set(['global_daily_limit', 'ip_daily_limit', 'previously_had_account'])
 
 const JOB_STATUS_LABEL: Record<string, string> = {
   pending: 'Queued…',
@@ -61,6 +65,9 @@ export default function AccountSetupPanel({ onComplete }: Props) {
     sponsored?: boolean
   } | null>(null)
   const [eligibilityError, setEligibilityError] = useState('')
+  const [paymentRequired, setPaymentRequired] = useState(false)
+  const [paymentConfirmed, setPaymentConfirmed] = useState(false)
+  const [showPaymentFlow, setShowPaymentFlow] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [jobStatus, setJobStatus] = useState<string | null>(null)
   const [submitError, setSubmitError] = useState('')
@@ -69,7 +76,12 @@ export default function AccountSetupPanel({ onComplete }: Props) {
 
   useEffect(() => {
     getEligibility()
-      .then((r) => setEligibility(r))
+      .then((r) => {
+        setEligibility(r)
+        if (!r.canCreate && r.reason && PAYABLE_REASONS.has(r.reason)) {
+          setPaymentRequired(true)
+        }
+      })
       .catch((e: SnapieAuthError) => {
         setEligibilityError(ERROR_MESSAGES[e.code] ?? 'Could not check eligibility.')
       })
@@ -147,6 +159,13 @@ export default function AccountSetupPanel({ onComplete }: Props) {
       }
     } catch (e: any) {
       const code = e?.code ?? ''
+      if (PAYABLE_REASONS.has(code)) {
+        // Quota block — offer paid path instead of showing an error
+        setPaymentRequired(true)
+        setSubmitting(false)
+        setJobStatus(null)
+        return
+      }
       setSubmitError(ERROR_MESSAGES[code] ?? 'Something went wrong. Please try again.')
       setSubmitting(false)
       setJobStatus(null)
@@ -168,6 +187,8 @@ export default function AccountSetupPanel({ onComplete }: Props) {
       </Alert>
     )
   }
+
+  const canSubmit = available === true && !usernameError && !checking && !!username
 
   return (
     <VStack spacing={4} align="stretch">
@@ -192,7 +213,7 @@ export default function AccountSetupPanel({ onComplete }: Props) {
           placeholder="e.g. alice"
           value={username}
           onChange={(e) => handleUsernameChange(e.target.value)}
-          isDisabled={submitting}
+          isDisabled={submitting || showPaymentFlow}
           autoComplete="off"
           autoCapitalize="none"
         />
@@ -232,16 +253,51 @@ export default function AccountSetupPanel({ onComplete }: Props) {
       )}
 
       {!jobStatus && (
-        <Button
-          colorScheme="blue"
-          onClick={handleSubmit}
-          isLoading={submitting}
-          isDisabled={!available || !!usernameError || checking || !username}
-          size="lg"
-          width="full"
-        >
-          Create My Account
-        </Button>
+        <>
+          {paymentRequired && !paymentConfirmed ? (
+            showPaymentFlow ? (
+              <>
+                <Divider />
+                <PaidAccountFlow
+                  onConfirmed={() => {
+                    setPaymentConfirmed(true)
+                    setShowPaymentFlow(false)
+                  }}
+                  onCancel={() => setShowPaymentFlow(false)}
+                />
+              </>
+            ) : (
+              <VStack spacing={2} align="stretch">
+                <Alert status="info" borderRadius="md">
+                  <AlertIcon />
+                  <Text fontSize="sm">
+                    No free slots available today. You can pay to create your account instantly.
+                  </Text>
+                </Alert>
+                <Button
+                  colorScheme="orange"
+                  onClick={() => setShowPaymentFlow(true)}
+                  isDisabled={!canSubmit}
+                  size="lg"
+                  width="full"
+                >
+                  Pay for my account →
+                </Button>
+              </VStack>
+            )
+          ) : (
+            <Button
+              colorScheme={paymentConfirmed ? 'green' : 'blue'}
+              onClick={handleSubmit}
+              isLoading={submitting}
+              isDisabled={!canSubmit}
+              size="lg"
+              width="full"
+            >
+              {paymentConfirmed ? 'Create my account (paid) →' : 'Create My Account'}
+            </Button>
+          )}
+        </>
       )}
     </VStack>
   )

--- a/components/join/PaidAccountFlow.tsx
+++ b/components/join/PaidAccountFlow.tsx
@@ -45,6 +45,7 @@ export default function PaidAccountFlow({ onConfirmed, onCancel }: Props) {
   const [copiedField, setCopiedField] = useState<string | null>(null)
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const pollInFlightRef = useRef(false)
 
   useEffect(() => {
     getPaymentFee().then(setFee).catch(() => setFeeError(true))
@@ -67,6 +68,8 @@ export default function PaidAccountFlow({ onConfirmed, onCancel }: Props) {
   useEffect(() => {
     if (!memo) return
     pollRef.current = setInterval(async () => {
+      if (pollInFlightRef.current) return
+      pollInFlightRef.current = true
       try {
         const result = await pollPaymentIntent(memo)
         if (result.status === 'confirmed') {
@@ -78,6 +81,8 @@ export default function PaidAccountFlow({ onConfirmed, onCancel }: Props) {
         }
       } catch {
         // ignore transient errors
+      } finally {
+        pollInFlightRef.current = false
       }
     }, 4000)
     return () => { if (pollRef.current) clearInterval(pollRef.current) }
@@ -113,8 +118,13 @@ export default function PaidAccountFlow({ onConfirmed, onCancel }: Props) {
 
   const copy = useCallback((text: string, field: string) => {
     navigator.clipboard.writeText(text)
-    setCopiedField(field)
-    setTimeout(() => setCopiedField(null), 2000)
+      .then(() => {
+        setCopiedField(field)
+        setTimeout(() => setCopiedField(null), 2000)
+      })
+      .catch(() => {
+        setCreateError('Clipboard access failed. Please copy manually.')
+      })
   }, [])
 
   const reset = useCallback(() => {

--- a/components/join/PaidAccountFlow.tsx
+++ b/components/join/PaidAccountFlow.tsx
@@ -1,0 +1,276 @@
+'use client'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  Alert,
+  AlertIcon,
+  Badge,
+  Box,
+  Button,
+  Code,
+  HStack,
+  Spinner,
+  Text,
+  VStack,
+} from '@chakra-ui/react'
+import QRCode from 'react-qr-code'
+import {
+  createHiveIntent,
+  createLightningIntent,
+  getPaymentFee,
+  pollPaymentIntent,
+} from '@/lib/snapie-auth/client'
+import type {
+  HiveIntentResponse,
+  LightningIntentResponse,
+  PaymentFeeResponse,
+} from '@/lib/snapie-auth/types'
+
+type Step = 'choose' | 'hive' | 'lightning'
+
+interface Props {
+  onConfirmed: () => void
+  onCancel: () => void
+}
+
+export default function PaidAccountFlow({ onConfirmed, onCancel }: Props) {
+  const [fee, setFee] = useState<PaymentFeeResponse | null>(null)
+  const [feeError, setFeeError] = useState(false)
+  const [step, setStep] = useState<Step>('choose')
+  const [hiveIntent, setHiveIntent] = useState<HiveIntentResponse | null>(null)
+  const [lightningIntent, setLightningIntent] = useState<LightningIntentResponse | null>(null)
+  const [expired, setExpired] = useState(false)
+  const [creating, setCreating] = useState(false)
+  const [createError, setCreateError] = useState('')
+  const [secsLeft, setSecsLeft] = useState<number | null>(null)
+  const [copiedField, setCopiedField] = useState<string | null>(null)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  useEffect(() => {
+    getPaymentFee().then(setFee).catch(() => setFeeError(true))
+  }, [])
+
+  const expiresAt = hiveIntent?.expiresAt ?? lightningIntent?.expiresAt
+  const memo = hiveIntent?.memo ?? lightningIntent?.memo
+
+  // Countdown timer
+  useEffect(() => {
+    if (!expiresAt) return
+    const tick = () =>
+      setSecsLeft(Math.max(0, Math.floor((new Date(expiresAt).getTime() - Date.now()) / 1000)))
+    tick()
+    timerRef.current = setInterval(tick, 1000)
+    return () => { if (timerRef.current) clearInterval(timerRef.current) }
+  }, [expiresAt])
+
+  // Payment polling
+  useEffect(() => {
+    if (!memo) return
+    pollRef.current = setInterval(async () => {
+      try {
+        const result = await pollPaymentIntent(memo)
+        if (result.status === 'confirmed') {
+          clearInterval(pollRef.current!)
+          onConfirmed()
+        } else if (result.status === 'expired') {
+          clearInterval(pollRef.current!)
+          setExpired(true)
+        }
+      } catch {
+        // ignore transient errors
+      }
+    }, 4000)
+    return () => { if (pollRef.current) clearInterval(pollRef.current) }
+  }, [memo, onConfirmed])
+
+  const goHive = useCallback(async () => {
+    setCreating(true)
+    setCreateError('')
+    try {
+      const intent = await createHiveIntent()
+      setHiveIntent(intent)
+      setStep('hive')
+    } catch {
+      setCreateError('Could not create payment request. Please try again.')
+    } finally {
+      setCreating(false)
+    }
+  }, [])
+
+  const goLightning = useCallback(async () => {
+    setCreating(true)
+    setCreateError('')
+    try {
+      const intent = await createLightningIntent()
+      setLightningIntent(intent)
+      setStep('lightning')
+    } catch {
+      setCreateError('Could not create payment request. Please try again.')
+    } finally {
+      setCreating(false)
+    }
+  }, [])
+
+  const copy = useCallback((text: string, field: string) => {
+    navigator.clipboard.writeText(text)
+    setCopiedField(field)
+    setTimeout(() => setCopiedField(null), 2000)
+  }, [])
+
+  const reset = useCallback(() => {
+    if (pollRef.current) clearInterval(pollRef.current)
+    if (timerRef.current) clearInterval(timerRef.current)
+    setStep('choose')
+    setHiveIntent(null)
+    setLightningIntent(null)
+    setExpired(false)
+    setSecsLeft(null)
+  }, [])
+
+  const countdown =
+    secsLeft !== null
+      ? `${Math.floor(secsLeft / 60).toString().padStart(2, '0')}:${(secsLeft % 60).toString().padStart(2, '0')}`
+      : null
+
+  if (feeError) {
+    return (
+      <Alert status="error" borderRadius="md">
+        <AlertIcon />
+        <Text fontSize="sm">Could not load account fee. Please refresh and try again.</Text>
+      </Alert>
+    )
+  }
+
+  if (!fee) {
+    return (
+      <HStack justify="center" py={2}>
+        <Spinner size="sm" />
+        <Text fontSize="sm" color="gray.500">Loading fee…</Text>
+      </HStack>
+    )
+  }
+
+  if (expired) {
+    return (
+      <Alert status="warning" borderRadius="md">
+        <AlertIcon />
+        <VStack align="start" spacing={1} flex={1}>
+          <Text fontSize="sm">Payment window expired.</Text>
+          <Button size="xs" variant="link" colorScheme="orange" onClick={reset}>
+            Try again
+          </Button>
+        </VStack>
+      </Alert>
+    )
+  }
+
+  if (step === 'choose') {
+    return (
+      <VStack spacing={3} align="stretch">
+        <Box>
+          <Text fontSize="sm" fontWeight="semibold">Pay for your account</Text>
+          <Text fontSize="xs" color="gray.500" mt={0.5}>
+            Current fee: <strong>{fee.amountHive}</strong> (≈${fee.amountUsd.toFixed(2)} USD)
+          </Text>
+        </Box>
+        {createError && (
+          <Alert status="error" borderRadius="md" py={2}>
+            <AlertIcon />
+            <Text fontSize="xs">{createError}</Text>
+          </Alert>
+        )}
+        <HStack spacing={3}>
+          <Button flex={1} variant="outline" colorScheme="orange" isLoading={creating} onClick={goHive}>
+            Pay with HIVE
+          </Button>
+          <Button flex={1} variant="outline" colorScheme="yellow" isLoading={creating} onClick={goLightning}>
+            ⚡ Lightning
+          </Button>
+        </HStack>
+        <Button variant="ghost" size="xs" color="gray.400" onClick={onCancel}>
+          Cancel
+        </Button>
+      </VStack>
+    )
+  }
+
+  const expiryBadge = countdown ? (
+    <Badge colorScheme={secsLeft! < 300 ? 'red' : 'gray'} fontSize="xs" fontFamily="mono">
+      {countdown}
+    </Badge>
+  ) : null
+
+  const pollSpinner = (
+    <HStack spacing={2} color="gray.400">
+      <Spinner size="xs" />
+      <Text fontSize="xs">Watching for payment…</Text>
+    </HStack>
+  )
+
+  if (step === 'hive' && hiveIntent) {
+    const fields = [
+      { label: 'To', value: hiveIntent.receivingAccount, field: 'account' },
+      { label: 'Amount', value: hiveIntent.amount, field: 'amount' },
+      { label: 'Memo', value: hiveIntent.memo, field: 'memo' },
+    ]
+    return (
+      <VStack spacing={3} align="stretch">
+        <HStack justify="space-between">
+          <Text fontSize="sm" fontWeight="semibold">Send HIVE transfer</Text>
+          {expiryBadge}
+        </HStack>
+        <Text fontSize="xs" color="gray.500">
+          Send exactly this amount with the memo. The memo links the payment to your session.
+        </Text>
+        {fields.map(({ label, value, field }) => (
+          <Box key={field}>
+            <Text fontSize="xs" color="gray.500" mb={1}>{label}</Text>
+            <HStack>
+              <Code flex={1} fontSize="sm" px={2} py={1} borderRadius="md" wordBreak="break-all">
+                {value}
+              </Code>
+              <Button size="xs" variant="outline" minW="60px" onClick={() => copy(value, field)}>
+                {copiedField === field ? '✓ Done' : 'Copy'}
+              </Button>
+            </HStack>
+          </Box>
+        ))}
+        {pollSpinner}
+        <Button variant="ghost" size="xs" color="gray.400" onClick={reset}>
+          ← Different payment method
+        </Button>
+      </VStack>
+    )
+  }
+
+  if (step === 'lightning' && lightningIntent) {
+    return (
+      <VStack spacing={3} align="stretch">
+        <HStack justify="space-between">
+          <Text fontSize="sm" fontWeight="semibold">⚡ Lightning invoice</Text>
+          {expiryBadge}
+        </HStack>
+        <Text fontSize="xs" color="gray.500">
+          Scan with any Lightning wallet. Amount: ≈${lightningIntent.amountUsd.toFixed(2)} USD.
+        </Text>
+        <Box bg="white" p={3} borderRadius="lg" alignSelf="center">
+          <QRCode value={lightningIntent.invoice} size={176} />
+        </Box>
+        <HStack>
+          <Code flex={1} fontSize="xs" px={2} py={1} borderRadius="md" noOfLines={2} wordBreak="break-all">
+            {lightningIntent.invoice}
+          </Code>
+          <Button size="xs" variant="outline" minW="60px" onClick={() => copy(lightningIntent.invoice, 'invoice')}>
+            {copiedField === 'invoice' ? '✓ Done' : 'Copy'}
+          </Button>
+        </HStack>
+        {pollSpinner}
+        <Button variant="ghost" size="xs" color="gray.400" onClick={reset}>
+          ← Different payment method
+        </Button>
+      </VStack>
+    )
+  }
+
+  return null
+}

--- a/components/join/QuotaWidget.tsx
+++ b/components/join/QuotaWidget.tsx
@@ -34,7 +34,10 @@ export default function QuotaWidget() {
 
   return (
     <Tooltip
-      label={`Resets at ${resetStr} UTC. Use a sponsor link to bypass this limit.`}
+      label={quota.remaining === 0
+        ? `Resets at ${resetStr} UTC. Use a sponsor link or pay to create your account.`
+        : `Resets at ${resetStr} UTC. Use a sponsor link to bypass this limit.`
+      }
       placement="bottom"
     >
       <Box display="inline-flex" alignItems="center" gap={2} cursor="default">

--- a/lib/snapie-auth/client.ts
+++ b/lib/snapie-auth/client.ts
@@ -2,7 +2,11 @@ import type {
   AccountJob,
   BroadcastResult,
   EligibilityResponse,
+  HiveIntentResponse,
+  LightningIntentResponse,
   NeedsClientSigningResponse,
+  PaymentFeeResponse,
+  PaymentIntentStatus,
   PublicConfig,
   QuotaResponse,
   SignMessageResult,
@@ -110,6 +114,24 @@ export function createAccount(username: string) {
 
 export function pollJob(jobId: string) {
   return req<AccountJob>('GET', `/account/job/${encodeURIComponent(jobId)}`)
+}
+
+// ── Payments ──────────────────────────────────────────────────────────────────
+
+export function getPaymentFee() {
+  return req<PaymentFeeResponse>('GET', '/payment/fee')
+}
+
+export function createHiveIntent() {
+  return req<HiveIntentResponse>('POST', '/payment/hive-intent')
+}
+
+export function createLightningIntent() {
+  return req<LightningIntentResponse>('POST', '/payment/lightning-intent')
+}
+
+export function pollPaymentIntent(memo: string) {
+  return req<PaymentIntentStatus>('GET', `/payment/intent/${encodeURIComponent(memo)}`)
 }
 
 // ── Hive operations ───────────────────────────────────────────────────────────

--- a/lib/snapie-auth/types.ts
+++ b/lib/snapie-auth/types.ts
@@ -65,6 +65,36 @@ export interface NeedsClientBroadcastResponse {
 
 export type BroadcastResult = BroadcastResponse | NeedsClientBroadcastResponse
 
+export interface PaymentFeeResponse {
+  amountHive: string
+  amountUsd: number
+}
+
+export interface HiveIntentResponse {
+  memo: string
+  receivingAccount: string
+  amount: string
+  amountUsd: number
+  expiresAt: string
+}
+
+export interface LightningIntentResponse {
+  memo: string
+  invoice: string
+  amountUsd: number
+  expiresAt: string
+}
+
+export interface PaymentIntentStatus {
+  memo: string
+  type: 'hive' | 'lightning'
+  status: 'pending' | 'confirmed' | 'expired'
+  txId?: string
+  amountHive?: string
+  amountUsd?: number
+  expiresAt: string
+}
+
 export class SnapieAuthError extends Error {
   constructor(
     public readonly code: string,


### PR DESCRIPTION
## Summary

- When free daily slots are exhausted, `AccountSetupPanel` now detects the quota block and offers a paid path instead of a dead-end error
- User picks a valid, available username first — then chooses to pay with a **HIVE transfer** or a **Lightning invoice**
- `PaidAccountFlow` fetches the live witness-median fee, creates a payment intent, shows details (copy buttons, countdown timer, QR for Lightning), and polls every 4s until confirmed
- On confirmation, `createAccount()` is called normally — the server sees the confirmed payment intent and bypasses the daily quota
- `global_daily_limit` and `ip_daily_limit` are caught at eligibility check time AND at submit time
- `previously_had_account` is **not** a payable reason — one email, one account, no exceptions

## Files changed

- `lib/snapie-auth/types.ts` — `PaymentFeeResponse`, `HiveIntentResponse`, `LightningIntentResponse`, `PaymentIntentStatus`
- `lib/snapie-auth/client.ts` — `getPaymentFee`, `createHiveIntent`, `createLightningIntent`, `pollPaymentIntent`
- `components/join/PaidAccountFlow.tsx` — new self-contained payment UI (choose → pay → poll → confirm)
- `components/auth/AccountSetupPanel.tsx` — quota detection + paid flow integration
- `components/join/QuotaWidget.tsx` — tooltip mentions paid option when slots are full

## Test plan

- [ ] Free slot available → normal "Create My Account" flow unchanged
- [ ] `global_daily_limit` / `ip_daily_limit` from eligibility → "Pay for my account" button appears (disabled until username is valid and available)
- [ ] `previously_had_account` → error message shown, no paid option offered
- [ ] HIVE path → copy account/amount/memo → send transfer → confirm polls and resolves → account created
- [ ] Lightning path → QR renders, invoice copies, payment confirms → account created
- [ ] Expired intent (30 min TTL) → "Payment window expired / Try again" resets to method select
- [ ] Sponsor token user → sponsored badge still shows, paid path not triggered
- [ ] Mobile: layout, QR (176px), copy buttons all usable on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a paid account creation fallback when quota restrictions apply.
  * Introduced a step-based payment flow with Hive and Lightning options.
  * Added real-time payment status tracking with a countdown and automated polling.

* **Improvements**
  * Updated quota tooltip messaging when remaining quota is zero, guiding users to pay or use a bypass link.
  * Enhanced payment flow instructions with copy-to-clipboard actions for payment details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->