### PR TITLE
fix: cap recurring HBD support within Hive's 730-day limit

### DIFF
--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -9,6 +9,10 @@ import { useCurrentUser } from '@/hooks/useCurrentUser'
 import { useLoginModal } from '@/contexts/LoginModalContext'
 import { recurrentTransferWithAioha } from '@/lib/hive/aioha'
 import { delegateWithKeychain, getCryptoPrices, witnessVoteWithKeychain } from '@/lib/hive/client-functions'
+import {
+  PATRON_MAX_EXECUTIONS,
+  PATRON_RECURRENCE_HOURS,
+} from '@/lib/hive/patronRecurrentTransfer'
 import useHiveAccount from '@/hooks/useHiveAccount'
 import PatronBadge from '@/components/shared/PatronBadge'
 import WitnessBadge from '@/components/shared/WitnessBadge'
@@ -20,13 +24,11 @@ import SupportersSection from '@/components/support/SupportersSection'
 const PATRON_MEMO_TAG = 'snapiepatron'
 const PATRON_ACCOUNT = 'snapie'
 
-// Monthly cadence: recurrence is in hours, executions is how many times it
-// repeats. Hive rejects recurrent transfers whose final trigger is more than
-// HIVE_MAX_RECURRENT_TRANSFER_END_DATE (730 days) out — so at ~30-day
-// recurrence the safe max is 24 executions (~720 days). Renew before then,
-// or cancel anytime by sending another recurrent_transfer for 0.
-const RECURRENCE_HOURS = 24 * 30
-const MAX_EXECUTIONS = 24
+// Monthly cadence + execution count capped for Hive's 730-day end-date limit
+// (see lib/hive/patronRecurrentTransfer.ts). Renew before then, or cancel
+// anytime by sending another recurrent_transfer for 0.
+const RECURRENCE_HOURS = PATRON_RECURRENCE_HOURS
+const MAX_EXECUTIONS = PATRON_MAX_EXECUTIONS
 
 const SUBSCRIPTION_PRESETS: { tier: PatronTier; amount: number }[] = [
   { tier: 'snaperino', amount: 0.5 },

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -21,10 +21,12 @@ const PATRON_MEMO_TAG = 'snapiepatron'
 const PATRON_ACCOUNT = 'snapie'
 
 // Monthly cadence: recurrence is in hours, executions is how many times it
-// repeats. 64 is the max Hive allows — effectively "until cancelled" (~5
-// years); cancel anytime by sending another recurrent_transfer for 0.
+// repeats. Hive rejects recurrent transfers whose final trigger is more than
+// HIVE_MAX_RECURRENT_TRANSFER_END_DATE (730 days) out — so at ~30-day
+// recurrence the safe max is 24 executions (~720 days). Renew before then,
+// or cancel anytime by sending another recurrent_transfer for 0.
 const RECURRENCE_HOURS = 24 * 30
-const MAX_EXECUTIONS = 64
+const MAX_EXECUTIONS = 24
 
 const SUBSCRIPTION_PRESETS: { tier: PatronTier; amount: number }[] = [
   { tier: 'snaperino', amount: 0.5 },
@@ -91,7 +93,11 @@ export default function SupportPage() {
       if (err?.code === 'needs_client_signing') {
         toast({ status: 'info', title: 'Connect a Hive wallet', description: err.message })
       } else {
-        toast({ status: 'error', title: 'Could not set up recurring support', description: err?.message })
+        toast({
+          status: 'error',
+          title: 'Could not set up recurring support',
+          description: String(err?.message ?? 'Unknown error').replace(/<br\s*\/?>/gi, '\n'),
+        })
       }
     } finally {
       setIsSubmittingSub(false)

--- a/lib/hive/patronRecurrentTransfer.test.ts
+++ b/lib/hive/patronRecurrentTransfer.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import {
+  HIVE_MAX_RECURRENT_TRANSFER_END_DATE_DAYS,
+  PATRON_MAX_EXECUTIONS,
+  PATRON_RECURRENCE_HOURS,
+  maxRecurrentExecutions,
+  recurrentTransferSpanDays,
+} from './patronRecurrentTransfer'
+
+describe('recurrentTransferSpanDays', () => {
+  it('treats the first execution as immediate (span uses executions - 1)', () => {
+    // Hive docs/tests: 2 executions with recurrence R lasts R hours, not 2R
+    expect(recurrentTransferSpanDays(24, 2)).toBe(1)
+    expect(recurrentTransferSpanDays(PATRON_RECURRENCE_HOURS, 2)).toBe(30)
+  })
+})
+
+describe('maxRecurrentExecutions', () => {
+  it('caps monthly recurrence within the 730-day Hive limit', () => {
+    const max = maxRecurrentExecutions(PATRON_RECURRENCE_HOURS)
+    expect(max).toBe(25)
+    expect(recurrentTransferSpanDays(PATRON_RECURRENCE_HOURS, max)).toBeLessThanOrEqual(
+      HIVE_MAX_RECURRENT_TRANSFER_END_DATE_DAYS,
+    )
+    expect(recurrentTransferSpanDays(PATRON_RECURRENCE_HOURS, max + 1)).toBeGreaterThan(
+      HIVE_MAX_RECURRENT_TRANSFER_END_DATE_DAYS,
+    )
+  })
+
+  it('matches Hive edge case: recurrence = 730*24/(executions-1) is still valid', () => {
+    // From hive recurrent_transfer date-limit tests
+    const executions = 2
+    const recurrenceHours = HIVE_MAX_RECURRENT_TRANSFER_END_DATE_DAYS * 24 / (executions - 1)
+    expect(recurrentTransferSpanDays(recurrenceHours, executions)).toBe(
+      HIVE_MAX_RECURRENT_TRANSFER_END_DATE_DAYS,
+    )
+    expect(maxRecurrentExecutions(recurrenceHours)).toBeGreaterThanOrEqual(executions)
+  })
+
+  // Regression: previous support page used 64 monthly executions (~1890 days)
+  it('rejects the old MAX_EXECUTIONS=64 monthly span as over the limit', () => {
+    expect(recurrentTransferSpanDays(PATRON_RECURRENCE_HOURS, 64)).toBeGreaterThan(
+      HIVE_MAX_RECURRENT_TRANSFER_END_DATE_DAYS,
+    )
+  })
+})
+
+describe('PATRON_MAX_EXECUTIONS', () => {
+  it('is derived for monthly cadence and stays inside the protocol limit', () => {
+    expect(PATRON_RECURRENCE_HOURS).toBe(720)
+    expect(PATRON_MAX_EXECUTIONS).toBe(25)
+    expect(recurrentTransferSpanDays(PATRON_RECURRENCE_HOURS, PATRON_MAX_EXECUTIONS)).toBe(720)
+  })
+})

--- a/lib/hive/patronRecurrentTransfer.ts
+++ b/lib/hive/patronRecurrentTransfer.ts
@@ -1,0 +1,32 @@
+/** Hive protocol: HIVE_MAX_RECURRENT_TRANSFER_END_DATE */
+export const HIVE_MAX_RECURRENT_TRANSFER_END_DATE_DAYS = 730
+
+/** ~monthly cadence for Snapie patron recurring HBD support. */
+export const PATRON_RECURRENCE_HOURS = 24 * 30
+
+/**
+ * Span from create/edit until the final scheduled trigger, in days.
+ * On a new recurrent_transfer the first execution is immediate, so the
+ * remaining (executions - 1) intervals determine the end date.
+ */
+export function recurrentTransferSpanDays(recurrenceHours: number, executions: number): number {
+  if (recurrenceHours <= 0) throw new Error('recurrenceHours must be > 0')
+  if (executions < 2) throw new Error('executions must be >= 2')
+  return (recurrenceHours * (executions - 1)) / 24
+}
+
+/**
+ * Largest executions count that still fits within Hive's end-date limit
+ * for a given recurrence (hours).
+ */
+export function maxRecurrentExecutions(
+  recurrenceHours: number,
+  maxEndDateDays = HIVE_MAX_RECURRENT_TRANSFER_END_DATE_DAYS,
+): number {
+  if (recurrenceHours <= 0) throw new Error('recurrenceHours must be > 0')
+  // recurrenceHours * (executions - 1) / 24 <= maxEndDateDays
+  return Math.floor((maxEndDateDays * 24) / recurrenceHours) + 1
+}
+
+/** Safe monthly patron subscription length (~720 days with 25 executions). */
+export const PATRON_MAX_EXECUTIONS = maxRecurrentExecutions(PATRON_RECURRENCE_HOURS)


### PR DESCRIPTION
## Summary
- Hive rejects `recurrent_transfer` ops whose final trigger is more than **730 days** out (`HIVE_MAX_RECURRENT_TRANSFER_END_DATE`).
- The support page used monthly recurrence (`720h`) with `MAX_EXECUTIONS = 64` (~1890 days of span), so Subscribe always failed.
- Extracted `lib/hive/patronRecurrentTransfer.ts` using Hive's real span formula (first execution is immediate → span uses `executions - 1`), which yields **25** monthly executions (~720 days).
- Added unit tests + stripped literal `<br/>` from wallet error toasts.

## Test plan
- [ ] `pnpm test -- lib/hive/patronRecurrentTransfer.test.ts`
- [ ] On `/support`, connect Keychain (not Snapie custodial wallet)
- [ ] Subscribe with a small HBD amount (e.g. 0.5)
- [ ] Confirm Keychain prompt shows recurrence ~720h and executions 25
- [ ] Confirm the tx broadcasts successfully (no 730-day rejection)