### PR TITLE
ci: add GitHub Action to run Vitest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 
 concurrency:
   group: test-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yml` to run the Vitest suite on pushes to `main` and all pull requests.
- Uses pnpm 9 + Node 22 with a frozen lockfile install (`pnpm test` → `vitest run`).

## Test plan
- [ ] Confirm this PR’s **Test** workflow appears under Checks
- [ ] Confirm the job installs deps and `pnpm test` exits 0
- [ ] Optional: open a draft PR that breaks a unit test and confirm CI fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated test runs for pushes to the main branch and pull requests.
  * Tests now execute in a consistent environment with dependency caching and a 15-minute timeout.
  * Superseded test runs are automatically canceled when newer changes are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->