### PR TITLE
fix(chat): store read receipts for conversation ids containing a dot

### DIFF
--- a/app/api/chat/channels/[id]/join/route.ts
+++ b/app/api/chat/channels/[id]/join/route.ts
@@ -3,7 +3,7 @@ import { withChatAuth } from '@/lib/chat/auth';
 import { ChatUser } from '@/lib/db/models/ChatUser';
 import { Channel } from '@/lib/db/models/Channel';
 import { subscribeToChannels } from '@/lib/chat/fcm';
-import { conversationSeenPath } from '@/lib/chat/conversations';
+import { conversationSeenAt, conversationSeenPath } from '@/lib/chat/conversations';
 
 export const POST = withChatAuth(async (_req, { username, params }) => {
   const channelId = params?.id;
@@ -26,9 +26,9 @@ export const POST = withChatAuth(async (_req, { username, params }) => {
   // channel's entire backlog counts as unread the moment you enter it, and
   // there is no honest floor to compare against. Only on a genuinely new join —
   // re-opening a channel you are already in must not silently clear it.
-  const alreadySeen = chatUser?.conversationSeen?.get?.(channelId);
+  const alreadySeen = conversationSeenAt(chatUser, channelId);
   const seenPath = conversationSeenPath(channelId);
-  if (!alreadySeen && seenPath) {
+  if (!alreadySeen) {
     await ChatUser.updateOne({ _id: username }, { $set: { [seenPath]: new Date() } });
   }
 

--- a/app/api/chat/channels/route.ts
+++ b/app/api/chat/channels/route.ts
@@ -3,7 +3,7 @@ import { connectDB } from '@/lib/db/mongodb';
 import { Channel } from '@/lib/db/models/Channel';
 import { withChatAuth } from '@/lib/chat/auth';
 import { seedDefaultChannels } from '@/lib/chat/seedChannels';
-import { isSafeConversationKey } from '@/lib/chat/conversations';
+import { isValidChannelId } from '@/lib/chat/conversations';
 
 // force-dynamic is load-bearing: this GET takes no params and calls no
 // dynamic request API, so without it Next statically caches the handler
@@ -23,9 +23,8 @@ export async function GET() {
 export const POST = withChatAuth(async (req, { username }) => {
   const { id, name, description, type } = await req.json();
   if (!id || !name) return NextResponse.json({ error: 'id and name required' }, { status: 400 });
-  // The id doubles as a Mongo Map key for read receipts, and a dot or '$' there
-  // is not storable as a single key — such a channel could never be marked read.
-  if (!isSafeConversationKey(id) || id.startsWith('dm:')) {
+  // The id travels through URL paths and FCM topic names, so it stays plain.
+  if (!isValidChannelId(id) || id.startsWith('dm:')) {
     return NextResponse.json({ error: 'Invalid channel id' }, { status: 400 });
   }
 

--- a/app/api/chat/dm/[id]/memo-fallback/route.ts
+++ b/app/api/chat/dm/[id]/memo-fallback/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withChatAuth } from '@/lib/chat/auth';
 import { ChatUser } from '@/lib/db/models/ChatUser';
-import { getDmPeer, isDmParticipant } from '@/lib/chat/conversations';
+import { conversationKeyPath, getDmPeer, isDmParticipant } from '@/lib/chat/conversations';
 
 const memoMarkRateLimit = new Map<string, number[]>();
 function isMemoMarkRateLimited(username: string): boolean {
@@ -32,7 +32,7 @@ export const POST = withChatAuth(async (req: NextRequest, { username, params }) 
 
   await ChatUser.updateOne(
     { _id: peer },
-    { $set: { [`memoNotifyAt.${id}`]: new Date() } },
+    { $set: { [conversationKeyPath('memoNotifyAt', id)]: new Date() } },
     { upsert: true }
   );
 

--- a/app/api/chat/dm/[id]/messages/route.ts
+++ b/app/api/chat/dm/[id]/messages/route.ts
@@ -2,7 +2,12 @@ import { NextRequest, NextResponse } from 'next/server';
 import { withChatAuth } from '@/lib/chat/auth';
 import { Message } from '@/lib/db/models/Message';
 import { ChatUser } from '@/lib/db/models/ChatUser';
-import { getDmPeer, isDmParticipant } from '@/lib/chat/conversations';
+import {
+  conversationMapValue,
+  conversationSeenAt,
+  getDmPeer,
+  isDmParticipant,
+} from '@/lib/chat/conversations';
 import {
   isRateLimited,
   validateMessageBody,
@@ -70,7 +75,7 @@ export const GET = withChatAuth(async (req: NextRequest, { username, params }) =
 
   if (peer) {
     const peerUser = await ChatUser.findById(peer);
-    const peerSeenAtDate = peerUser?.conversationSeen?.get?.(id) || null;
+    const peerSeenAtDate = conversationSeenAt(peerUser, id);
     const peerLastSeenDate = peerUser?.lastSeen || null;
     const peerLastActiveTs = Math.max(
       peerSeenAtDate ? new Date(peerSeenAtDate).getTime() : 0,
@@ -129,13 +134,9 @@ export const POST = withChatAuth(async (req, { username, params }) => {
 
   const now = Date.now();
   const cooldownMs = 3 * 60 * 1000;
-  const lastMemoAt = peerUser?.memoNotifyAt?.get?.(id)
-    ? new Date(peerUser.memoNotifyAt.get(id) as Date).getTime()
-    : 0;
+  const lastMemoAt = conversationMapValue(peerUser?.memoNotifyAt, id)?.getTime() || 0;
   const hasFcm = !!peerUser?.fcmTokens?.length;
-  const peerConversationSeenAt = peerUser?.conversationSeen?.get?.(id)
-    ? new Date(peerUser.conversationSeen.get(id) as Date).getTime()
-    : 0;
+  const peerConversationSeenAt = conversationSeenAt(peerUser, id)?.getTime() || 0;
   const peerLastSeenAt = peerUser?.lastSeen ? new Date(peerUser.lastSeen).getTime() : 0;
   const peerLastActiveAt = Math.max(peerConversationSeenAt, peerLastSeenAt);
   const activeWindowMs = 10 * 60 * 1000;

--- a/app/api/chat/groups/[id]/members/route.ts
+++ b/app/api/chat/groups/[id]/members/route.ts
@@ -39,12 +39,10 @@ export const POST = withChatAuth(async (req: NextRequest, { username, params }) 
   // Their history in this group starts now — a private group notifies on every
   // message, so without a floor the entire backlog would arrive as unread.
   const seenPath = conversationSeenPath(groupId);
-  if (seenPath) {
-    await ChatUser.updateOne(
-      { _id: normalizedMember, [seenPath]: { $exists: false } },
-      { $set: { [seenPath]: new Date() } }
-    );
-  }
+  await ChatUser.updateOne(
+    { _id: normalizedMember, [seenPath]: { $exists: false } },
+    { $set: { [seenPath]: new Date() } }
+  );
   return NextResponse.json({ group: updated });
 });
 

--- a/app/api/chat/read/route.ts
+++ b/app/api/chat/read/route.ts
@@ -25,7 +25,6 @@ export const POST = withChatAuth(async (req: NextRequest, { username }) => {
   }
 
   const path = conversationSeenPath(conversationId);
-  if (!path) return NextResponse.json({ error: 'Invalid conversationId' }, { status: 400 });
 
   const isDm = conversationId.startsWith('dm:');
   if (isDm && !isDmParticipant(conversationId, username)) {

--- a/app/api/chat/typing/route.ts
+++ b/app/api/chat/typing/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { withChatAuth } from '@/lib/chat/auth';
 import { ChatUser } from '@/lib/db/models/ChatUser';
 import { Channel } from '@/lib/db/models/Channel';
-import { isDmParticipant } from '@/lib/chat/conversations';
+import { conversationKeyPath, encodeConversationKey, isDmParticipant } from '@/lib/chat/conversations';
 
 const TYPING_TTL_MS = 6000;
 const TYPING_CLEANUP_MS = 5 * 60 * 1000;
@@ -37,13 +37,13 @@ export const POST = withChatAuth(async (req: NextRequest, { username }) => {
   if (isTyping) {
     await ChatUser.findOneAndUpdate(
       { _id: username },
-      { $set: { [`typingAt.${convId}`]: new Date() } },
+      { $set: { [conversationKeyPath('typingAt', convId)]: new Date() } },
       { upsert: true, returnDocument: 'after' }
     );
   } else {
     await ChatUser.findOneAndUpdate(
       { _id: username },
-      { $unset: { [`typingAt.${convId}`]: 1 } },
+      { $unset: { [conversationKeyPath('typingAt', convId)]: 1 } },
       { upsert: true, returnDocument: 'after' }
     );
   }
@@ -73,7 +73,7 @@ export const GET = withChatAuth(async (req: NextRequest, { username }) => {
   }
 
   const users = await ChatUser.find(
-    { _id: { $ne: username }, [`typingAt.${convId}`]: { $exists: true } },
+    { _id: { $ne: username }, [conversationKeyPath('typingAt', convId)]: { $exists: true } },
     { _id: 1, typingAt: 1 }
   ).lean();
 
@@ -83,7 +83,7 @@ export const GET = withChatAuth(async (req: NextRequest, { username }) => {
 
   for (const u of users) {
     const rawMap = u.typingAt as unknown as Record<string, string | Date> | undefined;
-    const ts = rawMap?.[convId];
+    const ts = rawMap?.[encodeConversationKey(convId)];
     if (!ts) continue;
     const age = now - new Date(ts).getTime();
     if (age <= TYPING_TTL_MS) typingUsers.push(String(u._id));
@@ -93,7 +93,7 @@ export const GET = withChatAuth(async (req: NextRequest, { username }) => {
   if (staleUsers.length > 0) {
     await ChatUser.updateMany(
       { _id: { $in: staleUsers } },
-      { $unset: { [`typingAt.${convId}`]: 1 } }
+      { $unset: { [conversationKeyPath('typingAt', convId)]: 1 } }
     );
   }
 

--- a/lib/chat/conversations.test.ts
+++ b/lib/chat/conversations.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import {
+  conversationKeyPath,
+  conversationSeenAt,
+  conversationSeenPath,
+  createDmConversationId,
+  encodeConversationKey,
+  isValidChannelId,
+} from '@/lib/chat/conversations';
+
+/** Stand-in for the Mongoose Map on a ChatUser doc. */
+function seenMap(entries: Record<string, Date>) {
+  return { conversationSeen: new Map(Object.entries(entries)) };
+}
+
+describe('encodeConversationKey', () => {
+  it('leaves an ordinary id untouched, so receipts written before this existed still resolve', () => {
+    expect(encodeConversationKey('general')).toBe('general');
+    expect(encodeConversationKey('dm:alice:bob')).toBe('dm:alice:bob');
+  });
+
+  it('escapes the characters a Mongo update path cannot carry', () => {
+    expect(encodeConversationKey('a.b')).toBe('a~2eb');
+    expect(encodeConversationKey('a$b')).toBe('a~24b');
+  });
+
+  it('escapes its own escape character, so the mapping stays injective', () => {
+    // Without this, 'a~2eb' and 'a.b' would both key to 'a~2eb' and two
+    // conversations would share one read receipt.
+    expect(encodeConversationKey('a~2eb')).toBe('a~7e2eb');
+    expect(encodeConversationKey('a~2eb')).not.toBe(encodeConversationKey('a.b'));
+  });
+});
+
+describe('conversationSeenPath', () => {
+  it('gives a dotted DM id a path, which is the whole bug: dots are legal in Hive usernames', () => {
+    const id = createDmConversationId('rashed.ifte', 'tibfox');
+    expect(id).toBe('dm:rashed.ifte:tibfox');
+    expect(conversationSeenPath(id)).toBe('conversationSeen.dm:rashed~2eifte:tibfox');
+  });
+
+  it('addresses exactly one key, never a nested field', () => {
+    const path = conversationSeenPath(createDmConversationId('rashed.ifte', 'some.body'));
+    expect(path.split('.')).toHaveLength(2);
+    expect(path.startsWith('conversationSeen.')).toBe(true);
+  });
+
+  it('does not care which side of the DM holds the dot, because the pair is sorted', () => {
+    expect(conversationSeenPath(createDmConversationId('rashed.ifte', 'tibfox')))
+      .toBe(conversationSeenPath(createDmConversationId('tibfox', 'rashed.ifte')));
+  });
+});
+
+describe('conversationKeyPath', () => {
+  it('escapes for the other conversation-keyed maps too, which had the same raw interpolation', () => {
+    const id = createDmConversationId('rashed.ifte', 'tibfox');
+    expect(conversationKeyPath('typingAt', id)).toBe('typingAt.dm:rashed~2eifte:tibfox');
+    expect(conversationKeyPath('memoNotifyAt', id)).toBe('memoNotifyAt.dm:rashed~2eifte:tibfox');
+    expect(conversationKeyPath('typingAt', id).split('.')).toHaveLength(2);
+  });
+});
+
+describe('conversationSeenAt', () => {
+  it('reads back what the update path wrote', () => {
+    const id = createDmConversationId('rashed.ifte', 'tibfox');
+    const at = new Date('2026-07-30T00:00:00Z');
+    // What Mongo stores for `$set: { [conversationSeenPath(id)]: at }`.
+    const key = conversationSeenPath(id).replace('conversationSeen.', '');
+
+    expect(conversationSeenAt(seenMap({ [key]: at }), id)).toEqual(at);
+  });
+
+  it('is null for a conversation that was never read', () => {
+    expect(conversationSeenAt(seenMap({}), 'general')).toBeNull();
+  });
+
+  it('is null for a missing user or a doc with no map', () => {
+    expect(conversationSeenAt(null, 'general')).toBeNull();
+    expect(conversationSeenAt({}, 'general')).toBeNull();
+  });
+});
+
+describe('isValidChannelId', () => {
+  it('keeps caller-chosen channel ids plain, since they travel in URLs and FCM topics', () => {
+    expect(isValidChannelId('general')).toBe(true);
+    expect(isValidChannelId('a.b')).toBe(false);
+    expect(isValidChannelId('a$b')).toBe(false);
+    expect(isValidChannelId('')).toBe(false);
+  });
+});

--- a/lib/chat/conversations.ts
+++ b/lib/chat/conversations.ts
@@ -24,18 +24,58 @@ export function isDmParticipant(dmId: string, username: string): boolean {
   return parsed[0] === normalized || parsed[1] === normalized;
 }
 
-/** Conversation ids are used as Mongo Map keys (`conversationSeen.<id>`), where
- *  a dot would silently create a nested path instead of one key and a `$` would
- *  be read as an operator — so a read receipt for such an id would never be
- *  stored and its unread count could never clear. Channel ids are caller-chosen
- *  (POST /api/chat/channels), so this is validated at both ends. */
-export function isSafeConversationKey(id: string): boolean {
-  return typeof id === 'string' && id.length > 0 && !id.includes('.') && !id.includes('$');
+/** Read receipts live in a Mongo map keyed by conversation id
+ *  (`conversationSeen.<id>`), and an update path cannot carry a `.`, which
+ *  addresses a nested field rather than one key, or a `$`, which reads as an
+ *  operator. A DM id embeds two Hive usernames and dots are legal in those, so
+ *  `dm:rashed.ifte:tibfox` is an ordinary conversation whose receipt was simply
+ *  unstorable: every write was rejected, so its unread count could never clear,
+ *  and neither could the one for the person on the other side of it. Escaping
+ *  those characters makes every id storable as exactly one key.
+ *
+ *  `~` escapes itself, which keeps the mapping injective. An id containing none
+ *  of the three encodes to itself, so receipts written before this existed
+ *  still resolve and there is nothing to migrate. */
+const SEEN_KEY_ESCAPES: Record<string, string> = { '~': '~7e', '.': '~2e', '$': '~24' };
+
+export function encodeConversationKey(id: string): string {
+  return id.replace(/[~.$]/g, (c) => SEEN_KEY_ESCAPES[c]);
 }
 
-/** Read-receipt path for a conversation, or null when the id can't hold one. */
-export function conversationSeenPath(id: string): string | null {
-  return isSafeConversationKey(id) ? `conversationSeen.${id}` : null;
+/** Update path into one of the ChatUser maps keyed by conversation id
+ *  (`conversationSeen`, `memoNotifyAt`, `typingAt`). Every id has one. */
+export function conversationKeyPath(field: string, id: string): string {
+  return `${field}.${encodeConversationKey(id)}`;
+}
+
+/** Read-receipt update path for a conversation. */
+export function conversationSeenPath(id: string): string {
+  return conversationKeyPath('conversationSeen', id);
+}
+
+type ConversationMap = { get?(key: string): Date | string | null | undefined } | null | undefined;
+
+/** Timestamp held for a conversation in one of those maps, or null. Reads have
+ *  to use the same encoding as the writes above or they miss the key. */
+export function conversationMapValue(map: ConversationMap, id: string): Date | null {
+  const value = map?.get?.(encodeConversationKey(id));
+  return value ? new Date(value) : null;
+}
+
+/** When this user last read a conversation, or null if they never have. */
+export function conversationSeenAt(
+  chatUser: { conversationSeen?: ConversationMap } | null | undefined,
+  id: string
+): Date | null {
+  return conversationMapValue(chatUser?.conversationSeen, id);
+}
+
+/** Channel ids are caller-chosen (POST /api/chat/channels) and travel through
+ *  URL paths and FCM topic names, so they stay restricted to what is safe
+ *  there. DM ids are not caller-chosen: they are built from usernames, and take
+ *  whatever Hive allows in one. */
+export function isValidChannelId(id: string): boolean {
+  return typeof id === 'string' && id.length > 0 && !id.includes('.') && !id.includes('$');
 }
 
 export function getDmPeer(dmId: string, username: string): string | null {

--- a/lib/chat/messages.ts
+++ b/lib/chat/messages.ts
@@ -82,7 +82,6 @@ export async function markConversationRead(
   seenAt: Date
 ): Promise<void> {
   const path = conversationSeenPath(conversationId);
-  if (!path) return;
   await ChatUser.updateOne(
     { _id: username },
     { $setOnInsert: { _id: username }, $set: { [path]: seenAt } },

--- a/lib/chat/unread.test.ts
+++ b/lib/chat/unread.test.ts
@@ -13,6 +13,7 @@ vi.mock('@/lib/db/models/Channel', () => ({
 }));
 
 import { computeUnread } from '@/lib/chat/unread';
+import { encodeConversationKey } from '@/lib/chat/conversations';
 
 /** Minimal stand-in for the Mongoose doc — computeUnread only reads these. */
 function chatUser(overrides: Partial<{
@@ -108,6 +109,22 @@ describe('computeUnread', () => {
     expect(branchFor('general').createdAt).toEqual({ $gt: seenAt });
     // Never read — no floor, so the whole thread is fair game.
     expect(branchFor('dm:alice:me').createdAt).toBeUndefined();
+  });
+
+  it('honours the receipt for a DM whose id contains a dot', async () => {
+    // A dot is legal in a Hive username, so `dm:me:rashed.ifte` is an ordinary
+    // conversation. Its receipt is stored under an escaped key, and reading it
+    // back with the raw id would find nothing: the floor would vanish and the
+    // whole thread would count as unread forever.
+    const seenAt = new Date('2026-07-01T00:00:00Z');
+    const id = 'dm:me:rashed.ifte';
+
+    await computeUnread(chatUser({
+      channels: [id],
+      seen: { [encodeConversationKey(id)]: seenAt },
+    }));
+
+    expect(branchFor(id).createdAt).toEqual({ $gt: seenAt });
   });
 
   it('totals the per-conversation counts', async () => {

--- a/lib/chat/unread.ts
+++ b/lib/chat/unread.ts
@@ -1,6 +1,7 @@
 import type { IChatUser } from '@/lib/db/models/ChatUser';
 import { Message } from '@/lib/db/models/Message';
 import { Channel } from '@/lib/db/models/Channel';
+import { conversationSeenAt } from '@/lib/chat/conversations';
 
 /**
  *  The single definition of "unread" for chat. Both the badge (/api/chat/unread)
@@ -27,11 +28,6 @@ export interface UnreadSummary {
   byConversation: Map<string, number>;
   /** Total unread messages across all conversations. */
   total: number;
-}
-
-function seenAtFor(chatUser: IChatUser, conversationId: string): Date | null {
-  const seen = chatUser.conversationSeen?.get?.(conversationId);
-  return seen ? new Date(seen) : null;
 }
 
 export async function computeUnread(chatUser: IChatUser | null): Promise<UnreadSummary> {
@@ -65,7 +61,7 @@ export async function computeUnread(chatUser: IChatUser | null): Promise<UnreadS
   // addressed to this user.
   const branches: Record<string, unknown>[] = [];
   for (const id of ids) {
-    const seenAt = seenAtFor(chatUser, id);
+    const seenAt = conversationSeenAt(chatUser, id);
     const isDm = id.startsWith('dm:');
     const branch: Record<string, unknown> = {
       target: id,


### PR DESCRIPTION
A dot is legal in a Hive username, so `dm:rashed.ifte:tibfox` is an ordinary DM. Its read receipt was stored at the Mongo update path `conversationSeen.<id>`, where a dot addresses a nested field rather than one key, so `conversationSeenPath` refused to build a path for it and every write was rejected:

  - POST /api/chat/read answered 400 "Invalid conversationId" for ids the server itself had just listed in /api/chat/unread.
  - markConversationRead returned early, so posting a message did not mark the conversation read and your own message came back as its unread message.
  - computeUnread found no floor, so the whole thread counted as unread and no client action could ever clear the badge.

The pair in a DM id is sorted, so a dot on either side breaks the conversation for both participants.

Escape `.` and `$`, and `~` itself so the mapping stays injective, when a conversation id is used as a map key. An id containing none of the three encodes to itself, so receipts written before this still resolve and there is nothing to migrate.

`typingAt.<id>` and `memoNotifyAt.<id>` interpolated the id into a field path with no validation at all, so they carried the same defect: typing indicators and the memo notification cooldown silently missed for the same users. Both now go through the same encoding.

isSafeConversationKey becomes isValidChannelId: it no longer guards storage, only what is safe in a caller-chosen channel id travelling through URL paths and FCM topic names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed read receipts and unread counts for direct messages whose IDs contain special characters, including periods.
  - Improved consistency when tracking message reads, seen status, memo notifications, and typing indicators.
  - Improved channel ID validation while preserving protection against invalid channel names.
  - Ensured newly added group members receive correct initial read-status tracking.

- **Tests**
  - Added coverage for special-character conversation IDs, read receipts, unread counts, and channel validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->